### PR TITLE
Add WASM tests to the CI workflow

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -21,6 +21,12 @@ jobs:
       - name: Run tests
         run: go test ./...
 
+      - name: Run WASM tests
+        run: |
+          export GOOS=js
+          export GOARCH=wasm
+          go test ./... -exec="$(go env GOROOT)/lib/wasm/go_js_wasm_exec"
+
       - name: Check gofmt
         run: |
           unformatted=$(gofmt -l -s .)


### PR DESCRIPTION
This pull request adds a new step to the CI workflow to run WebAssembly (WASM) tests for the Go codebase. This ensures that the code is properly tested in a WASM environment in addition to the standard Go environment.

**Testing improvements:**

* Added a new "Run WASM tests" job to `.github/workflows/go-ci.yml`, which sets up the environment for WASM (`GOOS=js`, `GOARCH=wasm`) and runs tests using the WASM exec runner.

Closes #9 