### PR TITLE
Add Codecov for coverage reporting

### DIFF
--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -18,8 +18,15 @@ jobs:
         with:
           go-version: '1.24'
 
-      - name: Run tests
-        run: go test -skip 'TestParseCorpusFiles|TestJBalUnitTests|TestJBalUnitBIRTests' ./...
+      - name: Run tests with coverage
+        run: go test -skip 'TestParseCorpusFiles|TestJBalUnitTests|TestJBalUnitBIRTests' -coverprofile=coverage.out -covermode=atomic ./...
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.out
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Check gofmt
         run: |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ballerina-lang-go
 
+[![codecov](https://codecov.io/gh/ballerina-platform/ballerina-lang-go/graph/badge.svg)](https://codecov.io/gh/ballerina-platform/ballerina-lang-go)
+
 ## Goals
 
 The primary goal of this effort is to come up with a native Ballerina compiler frontend that is fast, memory-efficient and has a fast startup. Eventually it could replace the current [jBallerina](https://github.com/ballerina-platform/ballerina-lang) compiler frontend.


### PR DESCRIPTION
## Purpose

Fixes https://github.com/ballerina-platform/ballerina-lang-go/issues/160

Added with minimum codecov settings and use default configs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * CI now collects test coverage during runs and uploads coverage reports, enabling visibility into test completeness.

* **Documentation**
  * Added a code coverage badge to the README to display current coverage status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->