### PR TITLE
Add support for error constructor expressions

### DIFF
--- a/ast/node_builder.go
+++ b/ast/node_builder.go
@@ -2139,7 +2139,11 @@ func (n *NodeBuilder) TransformSpreadField(spreadFieldNode *tree.SpreadFieldNode
 }
 
 func (n *NodeBuilder) TransformNamedArgument(namedArgumentNode *tree.NamedArgumentNode) BLangNode {
-	panic("TransformNamedArgument unimplemented")
+	namedArg := &BLangNamedArgsExpression{}
+	namedArg.pos = getPosition(namedArgumentNode)
+	namedArg.Name = createIdentifierFromToken(getPosition(namedArgumentNode.ArgumentName()), namedArgumentNode.ArgumentName().Name())
+	namedArg.Expr = n.createExpression(namedArgumentNode.Expression())
+	return namedArg
 }
 
 func (n *NodeBuilder) TransformPositionalArgument(positionalArgumentNode *tree.PositionalArgumentNode) BLangNode {
@@ -2500,7 +2504,7 @@ func (n *NodeBuilder) TransformTableTypeDescriptor(tableTypeDescriptorNode *tree
 }
 
 func (n *NodeBuilder) TransformTypeParameter(typeParameterNode *tree.TypeParameterNode) BLangNode {
-	panic("TransformTypeParameter unimplemented")
+	return n.createTypeNode(typeParameterNode.TypeNode()).(BLangNode)
 }
 
 func (n *NodeBuilder) TransformKeyTypeConstraint(keyTypeConstraintNode *tree.KeyTypeConstraintNode) BLangNode {
@@ -2939,6 +2943,9 @@ func (n *NodeBuilder) TransformRequiredExpression(requiredExpressionNode *tree.R
 }
 
 func (n *NodeBuilder) TransformErrorConstructorExpression(errorConstructorExpressionNode *tree.ErrorConstructorExpressionNode) BLangNode {
+	if errorConstructorExpressionNode.HasDiagnostics() {
+		n.cx.SyntaxError("invalid error constructor", getPosition(errorConstructorExpressionNode))
+	}
 	result := &BLangErrorConstructorExpr{}
 	result.pos = getPosition(errorConstructorExpressionNode)
 
@@ -2954,6 +2961,7 @@ func (n *NodeBuilder) TransformErrorConstructorExpression(errorConstructorExpres
 
 	arguments := errorConstructorExpressionNode.Arguments()
 	positionalArgs := make([]BLangExpression, 0)
+	namedArgs := make([]*BLangNamedArgsExpression, 0)
 
 	for arg := range arguments.Iterator() {
 		switch arg.Kind() {
@@ -2963,7 +2971,9 @@ func (n *NodeBuilder) TransformErrorConstructorExpression(errorConstructorExpres
 			positionalArgs = append(positionalArgs, expr)
 
 		case common.NAMED_ARG:
-			n.cx.InternalError("named arguments not yet supported in error constructor", getPosition(arg))
+			namedArgNode := arg.(*tree.NamedArgumentNode)
+			namedArg := n.TransformNamedArgument(namedArgNode).(*BLangNamedArgsExpression)
+			namedArgs = append(namedArgs, namedArg)
 		case common.REST_ARG:
 			n.cx.InternalError("rest arguments not supported in error constructor", getPosition(arg))
 		default:
@@ -2972,6 +2982,7 @@ func (n *NodeBuilder) TransformErrorConstructorExpression(errorConstructorExpres
 	}
 
 	result.PositionalArgs = positionalArgs
+	result.NamedArgs = namedArgs
 
 	return result
 }
@@ -2990,7 +3001,7 @@ func (n *NodeBuilder) transformErrorTypeDescriptor(errorTypeDescriptorNode *tree
 	// Handle optional type parameter
 	typeParamNode := errorTypeDescriptorNode.TypeParamNode()
 	if typeParamNode != nil {
-		errorType.detailType = model.TypeData{
+		errorType.DetailType = model.TypeData{
 			TypeDescriptor: n.createTypeNode(typeParamNode),
 		}
 	}

--- a/ast/pretty_printer.go
+++ b/ast/pretty_printer.go
@@ -126,6 +126,8 @@ func (p *PrettyPrinter) PrintInner(node BLangNode) {
 		p.printRecordType(t)
 	case *BLangFieldBaseAccess:
 		p.printFieldBaseAccess(t)
+	case *BLangErrorConstructorExpr:
+		p.printErrorConstructorExpr(t)
 	default:
 		fmt.Println(p.buffer.String())
 		panic("Unsupported node type: " + reflect.TypeOf(t).String())
@@ -739,7 +741,7 @@ func (p *PrettyPrinter) printErrorTypeNode(node *BLangErrorTypeNode) {
 	p.printString("error-type")
 	if !node.IsTop() {
 		p.indentLevel++
-		p.PrintInner(node.detailType.TypeDescriptor.(BLangNode))
+		p.PrintInner(node.DetailType.TypeDescriptor.(BLangNode))
 		p.indentLevel--
 	}
 	p.endNode()
@@ -833,6 +835,42 @@ func (p *PrettyPrinter) printFieldBaseAccess(node *BLangFieldBaseAccess) {
 	p.indentLevel++
 	p.PrintInner(node.Expr.(BLangNode))
 	p.indentLevel--
+	p.endNode()
+}
+
+// Error constructor expression printer
+func (p *PrettyPrinter) printErrorConstructorExpr(node *BLangErrorConstructorExpr) {
+	p.startNode()
+	p.printString("error-constructor-expr")
+	if node.ErrorTypeRef != nil {
+		p.indentLevel++
+		p.PrintInner(node.ErrorTypeRef)
+		p.indentLevel--
+	}
+	p.printString("(")
+	if len(node.PositionalArgs) > 0 {
+		p.indentLevel++
+		for _, arg := range node.PositionalArgs {
+			p.PrintInner(arg.(BLangNode))
+		}
+		p.indentLevel--
+	}
+	p.printSticky(")")
+	if len(node.NamedArgs) > 0 {
+		p.printString("(")
+		p.indentLevel++
+		for _, namedArg := range node.NamedArgs {
+			p.startNode()
+			p.printString("named-arg")
+			p.printString(namedArg.Name.Value)
+			p.indentLevel++
+			p.PrintInner(namedArg.Expr.(BLangNode))
+			p.indentLevel--
+			p.endNode()
+		}
+		p.indentLevel--
+		p.printSticky(")")
+	}
 	p.endNode()
 }
 

--- a/ast/types.go
+++ b/ast/types.go
@@ -132,7 +132,7 @@ type (
 
 	BLangErrorTypeNode struct {
 		bLangTypeBase
-		detailType model.TypeData
+		DetailType model.TypeData
 	}
 
 	BLangConstrainedType struct {
@@ -503,11 +503,11 @@ func (this *BLangUnionTypeNode) SetRhs(typeData model.TypeData) {
 }
 
 func (this *BLangErrorTypeNode) GetDetailType() model.TypeData {
-	return this.detailType
+	return this.DetailType
 }
 
 func (this *BLangErrorTypeNode) IsTop() bool {
-	return this.detailType.TypeDescriptor == nil
+	return this.DetailType.TypeDescriptor == nil
 }
 
 func (this *BLangErrorTypeNode) GetKind() model.NodeKind {

--- a/ast/walk.go
+++ b/ast/walk.go
@@ -431,6 +431,9 @@ func Walk(v Visitor, node BLangNode) {
 		for _, arg := range node.PositionalArgs {
 			Walk(v, arg.(BLangNode))
 		}
+		for _, arg := range node.NamedArgs {
+			Walk(v, arg)
+		}
 
 	case *BLangInvocation:
 		if node.PkgAlias != nil {
@@ -567,7 +570,7 @@ func Walk(v Visitor, node BLangNode) {
 		WalkTypeData(v, &node.rhs)
 
 	case *BLangErrorTypeNode:
-		WalkTypeData(v, &node.detailType)
+		WalkTypeData(v, &node.DetailType)
 
 	case *BLangConstrainedType:
 		WalkTypeData(v, &node.Type)
@@ -725,6 +728,10 @@ func Walk(v Visitor, node BLangNode) {
 
 	case *BLangMarkdownReferenceDocumentation:
 		// Leaf node
+
+	case *BLangNamedArgsExpression:
+		Walk(v, &node.Name)
+		Walk(v, node.Expr.(BLangNode))
 
 	default:
 		panic(fmt.Sprintf("unexpected node type %T", node))

--- a/bir/bir_gen.go
+++ b/bir/bir_gen.go
@@ -534,34 +534,104 @@ func handleExpression(ctx *stmtContext, curBB *BIRBasicBlock, expr ast.BLangExpr
 		return typeTestExpression(ctx, curBB, expr)
 	case *ast.BLangMappingConstructorExpr:
 		return mappingConstructorExpression(ctx, curBB, expr)
+	case *ast.BLangErrorConstructorExpr:
+		return errorConstructorExpression(ctx, curBB, expr)
 	default:
 		panic("unexpected expression type")
 	}
 }
 
+type mappingField struct {
+	key   string
+	value ast.BLangExpression
+}
+
 func mappingConstructorExpression(ctx *stmtContext, curBB *BIRBasicBlock, expr *ast.BLangMappingConstructorExpr) expressionEffect {
-	var values []MappingConstructorEntry
+	var fields []mappingField
 	for _, field := range expr.Fields {
 		switch f := field.(type) {
 		case *ast.BLangMappingKeyValueField:
-			keyEffect := handleExpression(ctx, curBB, f.Key.Expr)
-			curBB = keyEffect.block
-			valueEffect := handleExpression(ctx, curBB, f.ValueExpr)
-			curBB = valueEffect.block
-			values = append(values, &MappingConstructorKeyValueEntry{
-				keyOp:   keyEffect.result,
-				valueOp: valueEffect.result,
-			})
+			keyName := mappingKeyName(f.Key)
+			fields = append(fields, mappingField{key: keyName, value: f.ValueExpr})
 		default:
 			ctx.birCx.CompilerContext.Unimplemented("non-key-value record field not implemented", expr.GetPosition())
 		}
 	}
-	resultOperand := ctx.addTempVar(expr.GetDeterminedType())
+	return mappingConstructorExpressionInner(ctx, curBB, expr.GetDeterminedType(), fields)
+}
+
+func mappingKeyName(key *ast.BLangMappingKey) string {
+	switch expr := key.Expr.(type) {
+	case *ast.BLangLiteral:
+		return expr.Value.(string)
+	case *ast.BLangSimpleVarRef:
+		return expr.VariableName.Value
+	default:
+		panic(fmt.Sprintf("unexpected mapping key expression type: %T", key.Expr))
+	}
+}
+
+func mappingConstructorExpressionInner(ctx *stmtContext, curBB *BIRBasicBlock, mapType semtypes.SemType, fields []mappingField) expressionEffect {
+	var entries []MappingConstructorEntry
+	for _, field := range fields {
+		keyOperand := ctx.addTempVar(&semtypes.STRING)
+		keyLoad := &ConstantLoad{}
+		keyLoad.Value = field.key
+		keyLoad.LhsOp = keyOperand
+		curBB.Instructions = append(curBB.Instructions, keyLoad)
+
+		valueEffect := handleExpression(ctx, curBB, field.value)
+		curBB = valueEffect.block
+		entries = append(entries, &MappingConstructorKeyValueEntry{
+			keyOp:   keyOperand,
+			valueOp: valueEffect.result,
+		})
+	}
+	resultOperand := ctx.addTempVar(mapType)
 	newMap := &NewMap{}
-	newMap.Type = expr.GetDeterminedType()
-	newMap.Values = values
+	newMap.Type = mapType
+	newMap.Values = entries
 	newMap.LhsOp = resultOperand
 	curBB.Instructions = append(curBB.Instructions, newMap)
+	return expressionEffect{
+		result: resultOperand,
+		block:  curBB,
+	}
+}
+
+func errorConstructorExpression(ctx *stmtContext, curBB *BIRBasicBlock, expr *ast.BLangErrorConstructorExpr) expressionEffect {
+	// Message is the first positional arg
+	msgEffect := handleExpression(ctx, curBB, expr.PositionalArgs[0])
+	curBB = msgEffect.block
+
+	// Cause is the optional second positional arg
+	var causeOp *BIROperand
+	if len(expr.PositionalArgs) > 1 {
+		causeEffect := handleExpression(ctx, curBB, expr.PositionalArgs[1])
+		curBB = causeEffect.block
+		causeOp = causeEffect.result
+	}
+
+	// Detail from named args
+	var detailOp *BIROperand
+	if len(expr.NamedArgs) > 0 {
+		var fields []mappingField
+		for _, namedArg := range expr.NamedArgs {
+			fields = append(fields, mappingField{key: namedArg.Name.Value, value: namedArg.Expr})
+		}
+		detailEffect := mappingConstructorExpressionInner(ctx, curBB, &semtypes.MAPPING, fields)
+		curBB = detailEffect.block
+		detailOp = detailEffect.result
+	}
+
+	resultOperand := ctx.addTempVar(expr.GetDeterminedType())
+	newError := &NewError{}
+	newError.Type = expr.GetDeterminedType()
+	newError.MessageOp = msgEffect.result
+	newError.CauseOp = causeOp
+	newError.DetailOp = detailOp
+	newError.LhsOp = resultOperand
+	curBB.Instructions = append(curBB.Instructions, newError)
 	return expressionEffect{
 		result: resultOperand,
 		block:  curBB,

--- a/bir/non_terminator.go
+++ b/bir/non_terminator.go
@@ -82,6 +82,14 @@ type (
 		Values []MappingConstructorEntry
 	}
 
+	NewError struct {
+		BIRInstructionBase
+		Type      semtypes.SemType
+		MessageOp *BIROperand
+		CauseOp   *BIROperand
+		DetailOp  *BIROperand
+	}
+
 	TypeCast struct {
 		BIRInstructionBase
 		RhsOp *BIROperand
@@ -115,6 +123,7 @@ var (
 	_ BIRInstruction          = &TypeCast{}
 	_ BIRAssignInstruction    = &TypeTest{}
 	_ BIRInstruction          = &NewMap{}
+	_ BIRAssignInstruction    = &NewError{}
 	_ MappingConstructorEntry = &MappingConstructorKeyValueEntry{}
 )
 
@@ -224,6 +233,14 @@ func (t *TypeTest) GetKind() InstructionKind {
 
 func (n *NewMap) GetKind() InstructionKind {
 	return INSTRUCTION_KIND_NEW_STRUCTURE
+}
+
+func (n *NewError) GetKind() InstructionKind {
+	return INSTRUCTION_KIND_NEW_ERROR
+}
+
+func (n *NewError) GetLhsOperand() *BIROperand {
+	return n.LhsOp
 }
 
 func (n *NewMap) GetLhsOperand() *BIROperand {

--- a/bir/pretty_print.go
+++ b/bir/pretty_print.go
@@ -139,6 +139,8 @@ func (p *PrettyPrinter) PrintInstruction(instruction BIRInstruction) string {
 		return p.PrintNewArray(instruction.(*NewArray))
 	case *NewMap:
 		return p.PrintNewMap(instruction.(*NewMap))
+	case *NewError:
+		return p.PrintNewError(instruction.(*NewError))
 	case *TypeCast:
 		return p.PrintTypeCast(instruction.(*TypeCast))
 	case *TypeTest:
@@ -187,6 +189,17 @@ func (p *PrettyPrinter) PrintNewMap(m *NewMap) string {
 		}
 	}
 	return fmt.Sprintf("%s = newMap %s{%s}", p.PrintOperand(*m.LhsOp), p.PrintSemType(m.Type), values.String())
+}
+
+func (p *PrettyPrinter) PrintNewError(e *NewError) string {
+	args := p.PrintOperand(*e.MessageOp)
+	if e.CauseOp != nil {
+		args += ", " + p.PrintOperand(*e.CauseOp)
+	}
+	if e.DetailOp != nil {
+		args += ", " + p.PrintOperand(*e.DetailOp)
+	}
+	return fmt.Sprintf("%s = newError %s(%s)", p.PrintOperand(*e.LhsOp), p.PrintSemType(e.Type), args)
 }
 
 func (p *PrettyPrinter) PrintFieldAccess(access *FieldAccess) string {

--- a/corpus/ast/subset5/05-error/simple-v.txt
+++ b/corpus/ast/subset5/05-error/simple-v.txt
@@ -1,0 +1,58 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (type-definition Detail
+    (record-type
+      (field message
+        (value-type string))
+      (field id
+        (value-type int))))
+  (type-definition ErrorWithDetail
+    (error-type
+      (user-defined-type Detail)))
+  (function foo () (
+    (union-type
+      (value-type int)
+      (error-type)))
+    (block-function-body
+      (return
+        (error-constructor-expr (
+          (literal foo)) (
+          (named-arg ff
+            (literal foo)))))))
+  (function bar () (
+    (union-type
+      (value-type int)
+      (error-type)))
+    (block-function-body
+      (return
+        (error-constructor-expr
+          (user-defined-type ErrorWithDetail) (
+          (literal bar)) (
+          (named-arg message
+            (literal message))
+          (named-arg id
+            (literal 1)))))))
+  (function baz () (
+    (union-type
+      (value-type int)
+      (error-type)))
+    (block-function-body
+      (var-def
+        (variable e (type
+          (error-type)) (expr
+          (error-constructor-expr
+            (user-defined-type ErrorWithDetail) (
+            (literal bar)) (
+            (named-arg message
+              (literal message))
+            (named-arg id
+              (literal 1)))))))
+      (return
+        (error-constructor-expr
+          (user-defined-type ErrorWithDetail) (
+          (literal bar)
+          (simple-var-ref e)) (
+          (named-arg message
+            (literal message))
+          (named-arg id
+            (literal 1))))))))

--- a/corpus/bal/subset5/05-error/constructor-1-e.bal
+++ b/corpus/bal/subset5/05-error/constructor-1-e.bal
@@ -1,0 +1,26 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type Detail record {|
+    string message;
+    int id;
+|};
+
+type ErrorWithDetail error<Detail>;
+
+function bar() returns int|error {
+    return error ErrorWithDetail(message = "message", id = 1) // @error
+}

--- a/corpus/bal/subset5/05-error/constructor-2-e.bal
+++ b/corpus/bal/subset5/05-error/constructor-2-e.bal
@@ -1,0 +1,26 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type Detail record {|
+    string message;
+    int id;
+|};
+
+type ErrorWithDetail error<Detail>;
+
+function bar() returns int|error {
+    return error ErrorWithDetail("bar", id = 1) // @error
+}

--- a/corpus/bal/subset5/05-error/simple-v.bal
+++ b/corpus/bal/subset5/05-error/simple-v.bal
@@ -1,0 +1,35 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type Detail record {|
+    string message;
+    int id;
+|};
+
+type ErrorWithDetail error<Detail>;
+
+function foo() returns int|error {
+    return error("foo", ff = "foo");
+}
+
+function bar() returns int|error {
+    return error ErrorWithDetail("bar", message = "message", id = 1);
+}
+
+function baz() returns int|error {
+    error e = error ErrorWithDetail("bar", message = "message", id = 1);
+    return error ErrorWithDetail("bar", e, message = "message", id = 1);
+}

--- a/corpus/bir/subset5/05-error/simple-v.txt
+++ b/corpus/bir/subset5/05-error/simple-v.txt
@@ -1,0 +1,46 @@
+module $anon.. v 0.0.0;
+foo<NIL>{
+  bb0 {
+    %1 = ConstantLoad foo
+    %2 = ConstantLoad ff
+    %3 = ConstantLoad foo
+    %4 = newMap ((MAPPING), ()){%2=%3}
+    %5 = newError ((ERROR), ())(%1, %4)
+    %0 = %5;
+    return;
+  }
+}
+bar<NIL>{
+  bb0 {
+    %1 = ConstantLoad bar
+    %2 = ConstantLoad message
+    %3 = ConstantLoad message
+    %4 = ConstantLoad id
+    %5 = ConstantLoad 1
+    %6 = newMap ((MAPPING), ()){%2=%3, %4=%5}
+    %7 = newError ((), (ERROR))(%1, %6)
+    %0 = %7;
+    return;
+  }
+}
+baz<NIL>{
+  bb0 {
+    %1 = ConstantLoad bar
+    %2 = ConstantLoad message
+    %3 = ConstantLoad message
+    %4 = ConstantLoad id
+    %5 = ConstantLoad 1
+    %6 = newMap ((MAPPING), ()){%2=%3, %4=%5}
+    %7 = newError ((), (ERROR))(%1, %6)
+    e = %7;
+    %9 = ConstantLoad bar
+    %10 = ConstantLoad message
+    %11 = ConstantLoad message
+    %12 = ConstantLoad id
+    %13 = ConstantLoad 1
+    %14 = newMap ((MAPPING), ()){%10=%11, %12=%13}
+    %15 = newError ((), (ERROR))(%9, e, %14)
+    %0 = %15;
+    return;
+  }
+}

--- a/corpus/cfg/subset5/05-error/simple-v.txt
+++ b/corpus/cfg/subset5/05-error/simple-v.txt
@@ -1,0 +1,44 @@
+(bar
+  (bb0 () ()
+    (return
+      (error-constructor-expr
+        (user-defined-type ErrorWithDetail) (
+        (literal bar)) (
+        (named-arg message
+          (literal message))
+        (named-arg id
+          (literal 1)))))
+  )
+)
+(baz
+  (bb0 () ()
+    (var-def
+      (variable e (type
+        (error-type)) (expr
+        (error-constructor-expr
+          (user-defined-type ErrorWithDetail) (
+          (literal bar)) (
+          (named-arg message
+            (literal message))
+          (named-arg id
+            (literal 1)))))))
+    (return
+      (error-constructor-expr
+        (user-defined-type ErrorWithDetail) (
+        (literal bar)
+        (simple-var-ref e)) (
+        (named-arg message
+          (literal message))
+        (named-arg id
+          (literal 1)))))
+  )
+)
+(foo
+  (bb0 () ()
+    (return
+      (error-constructor-expr (
+        (literal foo)) (
+        (named-arg ff
+          (literal foo)))))
+  )
+)

--- a/corpus/desugared/subset5/05-error/simple-v.txt
+++ b/corpus/desugared/subset5/05-error/simple-v.txt
@@ -1,0 +1,57 @@
+(package
+  (type-definition Detail
+    (record-type
+      (field message
+        (value-type string))
+      (field id
+        (value-type int))))
+  (type-definition ErrorWithDetail
+    (error-type
+      (user-defined-type Detail)))
+  (function foo () (
+    (union-type
+      (value-type int)
+      (error-type)))
+    (block-function-body
+      (return
+        (error-constructor-expr (
+          (literal foo)) (
+          (named-arg ff
+            (literal foo)))))))
+  (function bar () (
+    (union-type
+      (value-type int)
+      (error-type)))
+    (block-function-body
+      (return
+        (error-constructor-expr
+          (user-defined-type ErrorWithDetail) (
+          (literal bar)) (
+          (named-arg message
+            (literal message))
+          (named-arg id
+            (literal 1)))))))
+  (function baz () (
+    (union-type
+      (value-type int)
+      (error-type)))
+    (block-function-body
+      (var-def
+        (variable e (type
+          (error-type)) (expr
+          (error-constructor-expr
+            (user-defined-type ErrorWithDetail) (
+            (literal bar)) (
+            (named-arg message
+              (literal message))
+            (named-arg id
+              (literal 1)))))))
+      (return
+        (error-constructor-expr
+          (user-defined-type ErrorWithDetail) (
+          (literal bar)
+          (simple-var-ref e)) (
+          (named-arg message
+            (literal message))
+          (named-arg id
+            (literal 1))))))))

--- a/corpus/integration/subset2/02-error-constructor/error-constructor-no-args-e.txtar
+++ b/corpus/integration/subset2/02-error-constructor/error-constructor-no-args-e.txtar
@@ -1,7 +1,7 @@
 -- stdout --
 
 -- stderr --
-error[SEMANTIC_ERROR]: error constructor must have at least 1 and at most 2 positional arguments
+error[SYNTAX_ERROR]: invalid error constructor
   --> error-constructor-no-args-e.bal:18:17
    |
 18 |     error err = error();  // @error

--- a/corpus/integration/subset2/02-error-constructor/error-constructor-too-many-args-e.txtar
+++ b/corpus/integration/subset2/02-error-constructor/error-constructor-too-many-args-e.txtar
@@ -1,5 +1,15 @@
 -- stdout --
-panic: unexpected expression type
 
 -- stderr --
+error[SYNTAX_ERROR]: invalid error constructor
+  --> error-constructor-too-many-args-e.bal:18:17
+   |
+18 |     error err = error("msg", error("cause"), "extra");  // @error
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[SYNTAX_ERROR]: invalid error constructor
+  --> error-constructor-too-many-args-e.bal:18:30
+   |
+18 |     error err = error("msg", error("cause"), "extra");  // @error
+   |                              ^^^^^^^^^^^^^^
 

--- a/corpus/integration/subset5/05-error/constructor-1-e.txtar
+++ b/corpus/integration/subset5/05-error/constructor-1-e.txtar
@@ -1,0 +1,9 @@
+-- stdout --
+
+-- stderr --
+error[SYNTAX_ERROR]: invalid error constructor
+  --> constructor-1-e.bal:25:12
+   |
+25 |     return error ErrorWithDetail(message = "message", id = 1) // @error
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+

--- a/corpus/integration/subset5/05-error/constructor-2-e.txtar
+++ b/corpus/integration/subset5/05-error/constructor-2-e.txtar
@@ -1,0 +1,9 @@
+-- stdout --
+
+-- stderr --
+error[SEMANTIC_ERROR]: missing required field 'message' in error constructor
+  --> constructor-2-e.bal:25:12
+   |
+25 |     return error ErrorWithDetail("bar", id = 1) // @error
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+

--- a/corpus/integration_test.go
+++ b/corpus/integration_test.go
@@ -57,7 +57,9 @@ var (
 	update = flag.Bool("update", false, "update corpus integration test outputs")
 
 	// Skip tests that cause unrecoverable Go runtime errors
-	skipTestsMap = makeSkipTestsMap([]string{})
+	skipTestsMap = makeSkipTestsMap([]string{
+		"subset5/05-error/simple-v.bal",
+	})
 )
 
 type failedTest struct {

--- a/desugar/expression.go
+++ b/desugar/expression.go
@@ -253,6 +253,12 @@ func walkErrorConstructorExpr(cx *FunctionContext, expr *ast.BLangErrorConstruct
 		expr.PositionalArgs[i] = result.replacementNode.(ast.BLangExpression)
 	}
 
+	for i := range expr.NamedArgs {
+		result := walkExpression(cx, expr.NamedArgs[i].Expr)
+		initStmts = append(initStmts, result.initStmts...)
+		expr.NamedArgs[i].Expr = result.replacementNode.(ast.BLangExpression)
+	}
+
 	return desugaredNode[model.ExpressionNode]{
 		initStmts:       initStmts,
 		replacementNode: expr,

--- a/semantics/semantic_analyzer.go
+++ b/semantics/semantic_analyzer.go
@@ -17,16 +17,15 @@
 package semantics
 
 import (
-	"fmt"
-	"math/big"
-	"reflect"
-	"sort"
-
 	"ballerina-lang-go/ast"
 	"ballerina-lang-go/context"
 	"ballerina-lang-go/model"
 	"ballerina-lang-go/semtypes"
 	"ballerina-lang-go/tools/diagnostics"
+	"fmt"
+	"math/big"
+	"reflect"
+	"sort"
 )
 
 type analyzer interface {
@@ -575,7 +574,8 @@ func analyzeExpression[A analyzer](a A, expr ast.BLangExpression, expectedType s
 
 	case *ast.BLangTypeTestExpr:
 		return validateResolvedType(a, expr, expectedType)
-
+	case *ast.BLangNamedArgsExpression:
+		return analyzeExpression(a, expr.Expr, expectedType)
 	default:
 		a.internalErr("unexpected expression type: "+reflect.TypeOf(expr).String(), expr.GetPosition())
 		return false
@@ -848,6 +848,38 @@ func analyzeErrorConstructorExpr[A analyzer](a A, expr *ast.BLangErrorConstructo
 	msgArg := expr.PositionalArgs[0]
 	if !analyzeExpression(a, msgArg, &semtypes.STRING) {
 		return false
+	}
+	tyCtx := a.tyCtx()
+	mat, ok := semtypes.ErrorDetailAtomicType(tyCtx, expr.DeterminedType)
+	if !ok {
+		a.unimplementedErr("non-atomic detail types not supported", expr.GetPosition())
+		return false
+	}
+	seen := make(map[string]bool, len(expr.NamedArgs))
+	clonableTy := semtypes.CreateCloneable(tyCtx)
+	for _, namedArg := range expr.NamedArgs {
+		name := namedArg.Name.GetValue()
+		if seen[name] {
+			a.semanticErr(fmt.Sprintf("duplicate named argument '%s' in error constructor", name), namedArg.GetPosition())
+			return false
+		}
+		seen[name] = true
+		fieldType := mat.FieldInnerVal(name)
+		if !analyzeExpression(a, namedArg.Expr, fieldType) {
+			return false
+		}
+		if !semtypes.IsSubtype(tyCtx, namedArg.Expr.GetDeterminedType(), clonableTy) {
+			a.semanticErr("named arguments must be subtypes of cloneable", namedArg.GetPosition())
+			return false
+		}
+	}
+
+	// Every field in the atom must be provided
+	for _, name := range mat.Names {
+		if !seen[name] {
+			a.semanticErr(fmt.Sprintf("missing required field '%s' in error constructor", name), expr.GetPosition())
+			return false
+		}
 	}
 
 	if argCount == 2 {

--- a/semantics/type_resolver.go
+++ b/semantics/type_resolver.go
@@ -550,6 +550,13 @@ func (t *TypeResolver) resolveExpression(expr ast.BLangExpression) (semtypes.Sem
 		return t.resolveTypeConversionExpr(e)
 	case *ast.BLangTypeTestExpr:
 		return t.resolveTypeTestExpr(e)
+	case *ast.BLangNamedArgsExpression:
+		ty, ok := t.resolveExpression(e.Expr)
+		if !ok {
+			return nil, false
+		}
+		setExpectedType(e, ty)
+		return ty, true
 	default:
 		t.ctx.InternalError(fmt.Sprintf("unsupported expression type: %T", expr), expr.GetPosition())
 		return nil, false
@@ -1303,11 +1310,12 @@ func (tr *TypeResolver) resolveBTypeInner(btype ast.BType, depth int) (semtypes.
 		if ty.IsTop() {
 			return &semtypes.ERROR, true
 		} else {
-			detailTy, ok := tr.resolveBType(ty.GetDetailType().TypeDescriptor.(ast.BType), depth+1)
+			detailTy, ok := tr.resolveBType(ty.DetailType.TypeDescriptor.(ast.BType), depth+1)
 			if !ok {
 				return nil, false
 			}
-			return semtypes.ErrorDetail(detailTy), true
+			ty.DetailType.Type = detailTy
+			return semtypes.ErrorWithDetail(detailTy), true
 		}
 	case *ast.BLangUserDefinedType:
 		ast.Walk(tr, &ty.TypeName)

--- a/semtypes/all_or_nothing_subtype.go
+++ b/semtypes/all_or_nothing_subtype.go
@@ -23,6 +23,7 @@ type AllOrNothingSubtype struct {
 var AllOrNothingSubtypeAll = newAllOrNothingSubtypeFromBool(true)
 var AllOrNothingSubtypeNothing = newAllOrNothingSubtypeFromBool(false)
 var _ SubtypeData = &AllOrNothingSubtype{}
+var _ Bdd = &AllOrNothingSubtype{}
 
 func newAllOrNothingSubtypeFromBool(isAll bool) AllOrNothingSubtype {
 	this := AllOrNothingSubtype{}

--- a/semtypes/bdd_node.go
+++ b/semtypes/bdd_node.go
@@ -33,15 +33,22 @@ func BddNodeCreate(atom Atom, left Bdd, middle Bdd, right Bdd) BddNode {
 }
 
 func IsSimpleNode(left Bdd, middle Bdd, right Bdd) bool {
-	var leftIsAll, middleIsNothing, rightIsNothing bool
-	if leftNode, ok := left.(BddAllOrNothing); ok {
-		leftIsAll = leftNode.IsAll()
-	}
-	if middleNode, ok := middle.(BddAllOrNothing); ok {
-		middleIsNothing = middleNode.IsNothing()
-	}
-	if rightNode, ok := right.(BddAllOrNothing); ok {
-		rightIsNothing = rightNode.IsNothing()
-	}
+	leftIsAll := isAll(left)
+	middleIsNothing := isNothing(middle)
+	rightIsNothing := isNothing(right)
 	return leftIsAll && middleIsNothing && rightIsNothing
+}
+
+func isAll(bdd Bdd) bool {
+	if allOrNothig, ok := bdd.(BddAllOrNothing); ok {
+		return allOrNothig.isAll
+	}
+	return false
+}
+
+func isNothing(bdd Bdd) bool {
+	if allOrNothig, ok := bdd.(BddAllOrNothing); ok {
+		return !allOrNothig.isAll
+	}
+	return false
 }

--- a/semtypes/error.go
+++ b/semtypes/error.go
@@ -18,10 +18,39 @@ package semtypes
 
 import "ballerina-lang-go/common"
 
-type Error struct {
+func ErrorDetailAtomicType(ctx Context, errorType SemType) (MappingAtomicType, bool) {
+	errorType = Intersect(errorType, &ERROR)
+	if IsNever(errorType) || !IsSubtype(ctx, errorType, &ERROR) {
+		return MappingAtomicType{}, false
+	}
+
+	if IsSameType(ctx, errorType, &ERROR) {
+		return MappingAtomicTypeFrom(nil, nil, CellContaining(ctx.Env(), CreateCloneable(ctx))), true
+	}
+	mappingSd := subtypeData(errorType, BT_ERROR)
+	if bddNode, ok := mappingSd.(BddNode); ok {
+		if bddNode.Atom().Index() != 0 {
+			// Not readonly. Not sure if this can happen (due to ErroWithDetail) but just in case
+			return MappingAtomicType{}, false
+		}
+		if !isNothing(bddNode.Middle()) || !isNothing(bddNode.Right()) {
+			// Not atomic
+			return MappingAtomicType{}, false
+		}
+		if leftNode, ok := bddNode.Left().(BddNode); ok {
+			if !IsSimpleNode(leftNode.Left(), leftNode.Middle(), leftNode.Right()) {
+				// Also not atomic
+				return MappingAtomicType{}, false
+			}
+			return *ctx.mappingAtomType(leftNode.Atom()), true
+		} else {
+			return MappingAtomicType{}, false
+		}
+	}
+	return MappingAtomicType{}, false
 }
 
-func ErrorDetail(detail SemType) SemType {
+func ErrorWithDetail(detail SemType) SemType {
 	// migrated from Error.java:39:5
 	mappingSd := subtypeData(detail, BT_MAPPING)
 	if allOrNothingSubtype, ok := mappingSd.(AllOrNothingSubtype); ok {

--- a/semtypes/field_pair.go
+++ b/semtypes/field_pair.go
@@ -163,6 +163,8 @@ func NewFieldPairs(m1 *MappingAtomicType, m2 *MappingAtomicType) iter.Seq[FieldP
 		types2:          m2.Types,
 		len1:            len(m1.Names),
 		len2:            len(m2.Names),
+		rest1:           m1.Rest,
+		rest2:           m2.Rest,
 		shouldCalculate: true,
 	}
 	return i.toIterator()


### PR DESCRIPTION
## Purpose
Resolves #185
Depends on #183




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Named arguments supported in error constructors, allowing labeled detail fields when creating errors.
  * Error constructors now preserve and print typed detail information.

* **Bug Fixes**
  * Improved diagnostics for invalid error constructors (clearer syntax vs semantic reporting).
  * Validation for duplicate or incompatible named fields; required-detail fields are enforced.

* **Tests**
  * Added/updated test cases and examples covering named and positional error-constructor usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->