### PR TITLE
Add front end support for panic statements

### DIFF
--- a/ast/corpus_ast_test.go
+++ b/ast/corpus_ast_test.go
@@ -34,7 +34,7 @@ import (
 func TestASTGeneration(t *testing.T) {
 	flag.Parse()
 
-	testPairs := test_util.GetValidTests(t, test_util.AST)
+	testPairs := test_util.GetValidAndPanicTests(t, test_util.AST)
 
 	for _, testPair := range testPairs {
 		t.Run(testPair.Name, func(t *testing.T) {
@@ -112,7 +112,7 @@ func (v *walkTestVisitor) VisitTypeData(typeData *model.TypeData) ast.Visitor {
 func TestWalkTraversal(t *testing.T) {
 	flag.Parse()
 
-	testPairs := test_util.GetValidTests(t, test_util.AST)
+	testPairs := test_util.GetValidAndPanicTests(t, test_util.AST)
 
 	for _, testPair := range testPairs {
 		t.Run(testPair.Name, func(t *testing.T) {

--- a/ast/node_builder.go
+++ b/ast/node_builder.go
@@ -1748,7 +1748,10 @@ func (n *NodeBuilder) TransformWhileStatement(whileStatementNode *tree.WhileStat
 }
 
 func (n *NodeBuilder) TransformPanicStatement(panicStatementNode *tree.PanicStatementNode) BLangNode {
-	panic("TransformPanicStatement unimplemented")
+	bLPanic := &BLangPanic{}
+	bLPanic.pos = getPosition(panicStatementNode)
+	bLPanic.Expr = n.createExpression(panicStatementNode.Expression())
+	return bLPanic
 }
 
 func (n *NodeBuilder) TransformReturnStatement(returnStatementNode *tree.ReturnStatementNode) BLangNode {

--- a/ast/pretty_printer.go
+++ b/ast/pretty_printer.go
@@ -128,6 +128,8 @@ func (p *PrettyPrinter) PrintInner(node BLangNode) {
 		p.printFieldBaseAccess(t)
 	case *BLangErrorConstructorExpr:
 		p.printErrorConstructorExpr(t)
+	case *BLangPanic:
+		p.printPanic(t)
 	default:
 		fmt.Println(p.buffer.String())
 		panic("Unsupported node type: " + reflect.TypeOf(t).String())
@@ -372,6 +374,15 @@ func (p *PrettyPrinter) printReturn(node *BLangReturn) {
 		p.PrintInner(node.Expr.(BLangNode))
 		p.indentLevel--
 	}
+	p.endNode()
+}
+
+func (p *PrettyPrinter) printPanic(node *BLangPanic) {
+	p.startNode()
+	p.printString("panic")
+	p.indentLevel++
+	p.PrintInner(node.Expr.(BLangNode))
+	p.indentLevel--
 	p.endNode()
 }
 

--- a/ast/statements.go
+++ b/ast/statements.go
@@ -29,47 +29,47 @@ const (
 type BLangStatement = model.StatementNode
 
 type (
-	BLangStatementBase struct {
+	bLangStatementBase struct {
 		bLangNodeBase
 	}
 	BLangAssignment struct {
-		BLangStatementBase
+		bLangStatementBase
 		VarRef BLangExpression
 		Expr   BLangExpression
 	}
 	BLangBlockStmt struct {
-		BLangStatementBase
+		bLangStatementBase
 		Stmts            []BLangStatement
 		FailureBreakMode FailureBreakMode
 		IsLetExpr        bool
 	}
 	BLangBreak struct {
-		BLangStatementBase
+		bLangStatementBase
 	}
 
 	BLangCompoundAssignment struct {
-		BLangStatementBase
+		bLangStatementBase
 		VarRef       model.ExpressionNode
 		Expr         BLangExpression
 		OpKind       model.OperatorKind
 		ModifiedExpr BLangExpression
 	}
 	BLangContinue struct {
-		BLangStatementBase
+		bLangStatementBase
 	}
 	BLangDo struct {
-		BLangStatementBase
+		bLangStatementBase
 		Body         BLangBlockStmt
 		OnFailClause BLangOnFailClause
 	}
 
 	BLangExpressionStmt struct {
-		BLangStatementBase
+		bLangStatementBase
 		Expr BLangExpression
 	}
 
 	BLangIf struct {
-		BLangStatementBase
+		bLangStatementBase
 		scope    model.Scope
 		Expr     BLangExpression
 		Body     BLangBlockStmt
@@ -77,7 +77,7 @@ type (
 	}
 
 	BLangWhile struct {
-		BLangStatementBase
+		bLangStatementBase
 		scope        model.Scope
 		Expr         BLangExpression
 		Body         BLangBlockStmt
@@ -85,7 +85,7 @@ type (
 	}
 
 	BLangForeach struct {
-		BLangStatementBase
+		bLangStatementBase
 		scope             model.Scope
 		VariableDef       *BLangSimpleVariableDef
 		Collection        BLangExpression
@@ -95,14 +95,19 @@ type (
 	}
 
 	BLangSimpleVariableDef struct {
-		BLangStatementBase
+		bLangStatementBase
 		Var      *BLangSimpleVariable
 		IsInFork bool
 		IsWorker bool
 	}
 
 	BLangReturn struct {
-		BLangStatementBase
+		bLangStatementBase
+		Expr BLangExpression
+	}
+
+	BLangPanic struct {
+		bLangStatementBase
 		Expr BLangExpression
 	}
 )
@@ -119,6 +124,7 @@ var (
 	_ model.ForeachNode             = &BLangForeach{}
 	_ model.VariableDefinitionNode  = &BLangSimpleVariableDef{}
 	_ model.ReturnNode              = &BLangReturn{}
+	_ model.PanicNode               = &BLangPanic{}
 )
 
 var (
@@ -139,6 +145,8 @@ var (
 	_ BLangNode = &BLangWhile{}
 	_ BLangNode = &BLangForeach{}
 	_ BLangNode = &BLangSimpleVariableDef{}
+	_ BLangNode = &BLangReturn{}
+	_ BLangNode = &BLangPanic{}
 )
 
 func (this *BLangAssignment) GetVariable() model.ExpressionNode {
@@ -502,4 +510,12 @@ func (this *BLangReturn) SetExpression(expression model.ExpressionNode) {
 
 func (this *BLangReturn) GetKind() model.NodeKind {
 	return model.NodeKind_RETURN
+}
+
+func (this *BLangPanic) GetExpression() model.ExpressionNode {
+	return this.Expr
+}
+
+func (this *BLangPanic) GetKind() model.NodeKind {
+	return model.NodeKind_PANIC
 }

--- a/ast/walk.go
+++ b/ast/walk.go
@@ -345,6 +345,11 @@ func Walk(v Visitor, node BLangNode) {
 			Walk(v, node.Expr.(BLangNode))
 		}
 
+	case *BLangPanic:
+		if node.Expr != nil {
+			Walk(v, node.Expr.(BLangNode))
+		}
+
 	case *BLangBreak:
 		// Leaf node
 

--- a/bir/bir_gen.go
+++ b/bir/bir_gen.go
@@ -285,6 +285,8 @@ func handleStatement(ctx *stmtContext, curBB *BIRBasicBlock, stmt ast.BLangState
 		return breakStatement(ctx, curBB, stmt)
 	case *ast.BLangContinue:
 		return continueStatement(ctx, curBB, stmt)
+	case *ast.BLangPanic:
+		return panicStatement(ctx, curBB, stmt)
 	default:
 		panic("unexpected statement type")
 	}
@@ -439,6 +441,13 @@ func returnStatement(ctx *stmtContext, bb *BIRBasicBlock, stmt *ast.BLangReturn)
 		curBB.Instructions = append(curBB.Instructions, mov)
 	}
 	curBB.Terminator = &Return{}
+	return statementEffect{}
+}
+
+func panicStatement(ctx *stmtContext, curBB *BIRBasicBlock, stmt *ast.BLangPanic) statementEffect {
+	errorEffect := handleExpression(ctx, curBB, stmt.Expr)
+	curBB = errorEffect.block
+	curBB.Terminator = &Panic{ErrorOp: errorEffect.result}
 	return statementEffect{}
 }
 

--- a/bir/corpus_bir_test.go
+++ b/bir/corpus_bir_test.go
@@ -55,7 +55,7 @@ func getBIRDiff(expectedText, actualText string) string {
 func TestBIRGeneration(t *testing.T) {
 	flag.Parse()
 
-	testPairs := test_util.GetValidTests(t, test_util.BIR)
+	testPairs := test_util.GetValidAndPanicTests(t, test_util.BIR)
 
 	for _, testPair := range testPairs {
 		t.Run(testPair.Name, func(t *testing.T) {

--- a/bir/pretty_print.go
+++ b/bir/pretty_print.go
@@ -144,6 +144,8 @@ func (p *PrettyPrinter) PrintInstruction(instruction BIRInstruction) string {
 		return p.PrintTypeCast(instruction.(*TypeCast))
 	case *TypeTest:
 		return p.PrintTypeTest(instruction.(*TypeTest))
+	case *Panic:
+		return p.PrintPanic(instruction.(*Panic))
 	default:
 		panic(fmt.Sprintf("unknown instruction type: %T", instruction))
 	}
@@ -214,6 +216,10 @@ func (p *PrettyPrinter) PrintFieldAccess(access *FieldAccess) string {
 
 func (p *PrettyPrinter) PrintReturn(r *Return) string {
 	return "return;"
+}
+
+func (p *PrettyPrinter) PrintPanic(pa *Panic) string {
+	return fmt.Sprintf("panic %s;", p.PrintOperand(*pa.ErrorOp))
 }
 
 func (p *PrettyPrinter) PrintBranch(b *Branch) string {

--- a/bir/terminator.go
+++ b/bir/terminator.go
@@ -57,6 +57,11 @@ type (
 		TrueBB  *BIRBasicBlock
 		FalseBB *BIRBasicBlock
 	}
+
+	Panic struct {
+		BIRTerminatorBase
+		ErrorOp *BIROperand
+	}
 )
 
 var (
@@ -64,6 +69,7 @@ var (
 	_ BIRAssignInstruction = &Call{}
 	_ BIRTerminator        = &Return{}
 	_ BIRTerminator        = &Branch{}
+	_ BIRTerminator        = &Panic{}
 )
 
 func (g *Goto) GetKind() InstructionKind {
@@ -84,4 +90,8 @@ func (r *Return) GetKind() InstructionKind {
 
 func (b *Branch) GetKind() InstructionKind {
 	return INSTRUCTION_KIND_BRANCH
+}
+
+func (p *Panic) GetKind() InstructionKind {
+	return INSTRUCTION_KIND_PANIC
 }

--- a/corpus/ast/subset1/01-int/add10-p.txt
+++ b/corpus/ast/subset1/01-int/add10-p.txt
@@ -1,0 +1,30 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable INT_MIN (type
+          (value-type int)) (expr
+          (binary-expr -
+            (unary-expr -
+              (literal 9223372036854775807))
+            (literal 1)))))
+      (expression-stmt
+        (invocation io println (
+          (invocation add (
+            (simple-var-ref INT_MIN)
+            (unary-expr -
+              (literal 1)))))))))
+  (function add (
+    (variable x (type
+      (value-type int)))
+    (variable y (type
+      (value-type int)))) (
+    (value-type int))
+    (block-function-body
+      (return
+        (binary-expr +
+          (simple-var-ref x)
+          (simple-var-ref y))))))

--- a/corpus/ast/subset1/01-int/add2-p.txt
+++ b/corpus/ast/subset1/01-int/add2-p.txt
@@ -1,0 +1,26 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable INT_MAX (type
+          (value-type int)) (expr
+          (literal 9223372036854775807))))
+      (expression-stmt
+        (invocation io println (
+          (invocation add (
+            (simple-var-ref INT_MAX)
+            (literal 1))))))))
+  (function add (
+    (variable x (type
+      (value-type int)))
+    (variable y (type
+      (value-type int)))) (
+    (value-type int))
+    (block-function-body
+      (return
+        (binary-expr +
+          (simple-var-ref x)
+          (simple-var-ref y))))))

--- a/corpus/ast/subset1/01-int/div1-p.txt
+++ b/corpus/ast/subset1/01-int/div1-p.txt
@@ -1,0 +1,30 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable INT_MIN (type
+          (value-type int)) (expr
+          (binary-expr -
+            (unary-expr -
+              (literal 9223372036854775807))
+            (literal 1)))))
+      (expression-stmt
+        (invocation io println (
+          (invocation div (
+            (simple-var-ref INT_MIN)
+            (unary-expr -
+              (literal 1)))))))))
+  (function div (
+    (variable x (type
+      (value-type int)))
+    (variable y (type
+      (value-type int)))) (
+    (value-type int))
+    (block-function-body
+      (return
+        (binary-expr /
+          (simple-var-ref x)
+          (simple-var-ref y))))))

--- a/corpus/ast/subset1/01-int/div3-p.txt
+++ b/corpus/ast/subset1/01-int/div3-p.txt
@@ -1,0 +1,22 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (expression-stmt
+        (invocation io println (
+          (invocation div (
+            (literal 672)
+            (literal 0))))))))
+  (function div (
+    (variable x (type
+      (value-type int)))
+    (variable y (type
+      (value-type int)))) (
+    (value-type int))
+    (block-function-body
+      (return
+        (binary-expr /
+          (simple-var-ref x)
+          (simple-var-ref y))))))

--- a/corpus/ast/subset1/01-int/mul-p.txt
+++ b/corpus/ast/subset1/01-int/mul-p.txt
@@ -1,0 +1,30 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable INT_MIN (type
+          (value-type int)) (expr
+          (binary-expr -
+            (unary-expr -
+              (literal 9223372036854775807))
+            (literal 1)))))
+      (expression-stmt
+        (invocation io println (
+          (invocation mul (
+            (simple-var-ref INT_MIN)
+            (unary-expr -
+              (literal 1)))))))))
+  (function mul (
+    (variable x (type
+      (value-type int)))
+    (variable y (type
+      (value-type int)))) (
+    (value-type int))
+    (block-function-body
+      (return
+        (binary-expr *
+          (simple-var-ref x)
+          (simple-var-ref y))))))

--- a/corpus/ast/subset1/01-int/rem1-p.txt
+++ b/corpus/ast/subset1/01-int/rem1-p.txt
@@ -1,0 +1,23 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (expression-stmt
+        (invocation io println (
+          (invocation rem (
+            (unary-expr -
+              (literal 10000))
+            (literal 0))))))))
+  (function rem (
+    (variable x (type
+      (value-type int)))
+    (variable y (type
+      (value-type int)))) (
+    (value-type int))
+    (block-function-body
+      (return
+        (binary-expr %
+          (simple-var-ref x)
+          (simple-var-ref y))))))

--- a/corpus/ast/subset1/01-int/sub-p.txt
+++ b/corpus/ast/subset1/01-int/sub-p.txt
@@ -1,0 +1,29 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable INT_MIN (type
+          (value-type int)) (expr
+          (binary-expr -
+            (unary-expr -
+              (literal 9223372036854775807))
+            (literal 1)))))
+      (expression-stmt
+        (invocation io println (
+          (invocation sub (
+            (simple-var-ref INT_MIN)
+            (literal 1))))))))
+  (function sub (
+    (variable x (type
+      (value-type int)))
+    (variable y (type
+      (value-type int)))) (
+    (value-type int))
+    (block-function-body
+      (return
+        (binary-expr -
+          (simple-var-ref x)
+          (simple-var-ref y))))))

--- a/corpus/ast/subset1/01-int/sub2-p.txt
+++ b/corpus/ast/subset1/01-int/sub2-p.txt
@@ -1,0 +1,27 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable INT_MAX (type
+          (value-type int)) (expr
+          (literal 9223372036854775807))))
+      (expression-stmt
+        (invocation io println (
+          (invocation sub (
+            (simple-var-ref INT_MAX)
+            (unary-expr -
+              (literal 1)))))))))
+  (function sub (
+    (variable x (type
+      (value-type int)))
+    (variable y (type
+      (value-type int)))) (
+    (value-type int))
+    (block-function-body
+      (return
+        (binary-expr -
+          (simple-var-ref x)
+          (simple-var-ref y))))))

--- a/corpus/ast/subset2/02-misc/stackoverflow-p.txt
+++ b/corpus/ast/subset2/02-misc/stackoverflow-p.txt
@@ -1,0 +1,12 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (expression-stmt
+        (invocation f ()))))
+  (function f () (
+    (value-type null))
+    (block-function-body
+      (expression-stmt
+        (invocation f ())))))

--- a/corpus/ast/subset2/02-typecast/2-p.txt
+++ b/corpus/ast/subset2/02-typecast/2-p.txt
@@ -1,0 +1,35 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable n (type
+          (value-type int)) (expr
+          (type-conversion-expr
+            (invocation ifElse (
+              (literal true)
+              (literal true)
+              (literal 17)))
+            (value-type int)))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref n))))))
+  (function ifElse (
+    (variable t (type
+      (value-type boolean)))
+    (variable b (type
+      (value-type boolean)))
+    (variable n (type
+      (value-type int)))) (
+    (value-type any))
+    (block-function-body
+      (if
+        (simple-var-ref t)
+        (block-stmt
+          (return
+            (simple-var-ref b))) (
+        (block-stmt
+          (return
+            (simple-var-ref n))))))))

--- a/corpus/ast/subset3/03-float/div1-p.txt
+++ b/corpus/ast/subset3/03-float/div1-p.txt
@@ -1,0 +1,30 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable x (type
+          (value-type float)) (expr
+          (literal 1.0))))
+      (var-def
+        (variable y (type
+          (value-type float)) (expr
+          (literal 0.0))))
+      (expression-stmt
+        (invocation io println (
+          (invocation div (
+            (simple-var-ref x)
+            (simple-var-ref y))))))))
+  (function div (
+    (variable x (type
+      (value-type float)))
+    (variable y (type
+      (value-type float)))) (
+    (value-type float))
+    (block-function-body
+      (return
+        (binary-expr /
+          (simple-var-ref x)
+          (simple-var-ref y))))))

--- a/corpus/ast/subset3/03-float/mod1-p.txt
+++ b/corpus/ast/subset3/03-float/mod1-p.txt
@@ -1,0 +1,30 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable x (type
+          (value-type float)) (expr
+          (literal 1.0))))
+      (var-def
+        (variable y (type
+          (value-type float)) (expr
+          (literal 0.0))))
+      (expression-stmt
+        (invocation io println (
+          (invocation mod (
+            (simple-var-ref x)
+            (simple-var-ref y))))))))
+  (function mod (
+    (variable x (type
+      (value-type float)))
+    (variable y (type
+      (value-type float)))) (
+    (value-type float))
+    (block-function-body
+      (return
+        (binary-expr %
+          (simple-var-ref x)
+          (simple-var-ref y))))))

--- a/corpus/ast/subset3/03-int/neg-p.txt
+++ b/corpus/ast/subset3/03-int/neg-p.txt
@@ -1,0 +1,25 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable INT_MIN (type
+          (value-type int)) (expr
+          (binary-expr -
+            (unary-expr -
+              (literal 9223372036854775807))
+            (literal 1)))))
+      (expression-stmt
+        (invocation io println (
+          (invocation neg (
+            (simple-var-ref INT_MIN))))))))
+  (function neg (
+    (variable x (type
+      (value-type int)))) (
+    (value-type int))
+    (block-function-body
+      (return
+        (unary-expr -
+          (simple-var-ref x))))))

--- a/corpus/ast/subset3/03-list/02-p.txt
+++ b/corpus/ast/subset3/03-list/02-p.txt
@@ -1,0 +1,24 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable v (type
+          (array-type
+            (value-type any) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 17)
+            (literal 42)
+            (unary-expr -
+              (literal 11))))))
+      (var-def
+        (variable i (type
+          (value-type int)) (expr
+          (literal 3))))
+      (expression-stmt
+        (invocation io println (
+          (index-based-access
+            (simple-var-ref v)
+            (simple-var-ref i))))))))

--- a/corpus/ast/subset3/03-list/05-p.txt
+++ b/corpus/ast/subset3/03-list/05-p.txt
@@ -1,0 +1,25 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable v (type
+          (array-type
+            (value-type any) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 17)
+            (literal 42)
+            (unary-expr -
+              (literal 11))))))
+      (var-def
+        (variable i (type
+          (value-type int)) (expr
+          (unary-expr -
+            (literal 1)))))
+      (expression-stmt
+        (invocation io println (
+          (index-based-access
+            (simple-var-ref v)
+            (simple-var-ref i))))))))

--- a/corpus/ast/subset3/03-list/08-p.txt
+++ b/corpus/ast/subset3/03-list/08-p.txt
@@ -1,0 +1,20 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable v (type
+          (array-type
+            (value-type any) dimensions: 1 ([]))) (expr
+          (list-constructor-expr))))
+      (var-def
+        (variable i (type
+          (value-type int)) (expr
+          (literal 0))))
+      (expression-stmt
+        (invocation io println (
+          (index-based-access
+            (simple-var-ref v)
+            (simple-var-ref i))))))))

--- a/corpus/ast/subset3/03-list/11-p.txt
+++ b/corpus/ast/subset3/03-list/11-p.txt
@@ -1,0 +1,44 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable v (type
+          (array-type
+            (value-type any) dimensions: 1 ([]))) (expr
+          (list-constructor-expr))))
+      (var-def
+        (variable val (type
+          (value-type int)) (expr
+          (literal 1))))
+      (var-def
+        (variable i (type
+          (value-type int)) (expr
+          (literal 0))))
+      (while
+        (binary-expr <
+          (simple-var-ref i)
+          (literal 62))
+        (block-stmt
+          (assignment
+            (simple-var-ref val)
+            (binary-expr *
+              (simple-var-ref val)
+              (literal 2)))
+          (assignment
+            (simple-var-ref i)
+            (binary-expr +
+              (simple-var-ref i)
+              (literal 1)))))
+      (assignment
+        (index-based-access
+          (simple-var-ref v)
+          (simple-var-ref val))
+        (literal 0))
+      (expression-stmt
+        (invocation io println (
+          (index-based-access
+            (simple-var-ref v)
+            (simple-var-ref val))))))))

--- a/corpus/ast/subset3/03-list/13-p.txt
+++ b/corpus/ast/subset3/03-list/13-p.txt
@@ -1,0 +1,25 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable v (type
+          (array-type
+            (value-type any) dimensions: 1 ([]))) (expr
+          (list-constructor-expr))))
+      (var-def
+        (variable i (type
+          (value-type int)) (expr
+          (unary-expr -
+            (literal 1)))))
+      (assignment
+        (index-based-access
+          (simple-var-ref v)
+          (simple-var-ref i))
+        (literal 0))
+      (expression-stmt
+        (invocation io println (
+          (invocation length expr:
+            (simple-var-ref v) ())))))))

--- a/corpus/ast/subset4/04-int/shift3-p.txt
+++ b/corpus/ast/subset4/04-int/shift3-p.txt
@@ -1,0 +1,26 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable amount (type
+          (value-type int)) (expr
+          (literal 64))))
+      (expression-stmt
+        (invocation io println (
+          (invocation shift (
+            (literal 1)
+            (simple-var-ref amount))))))))
+  (function shift (
+    (variable x (type
+      (value-type int)))
+    (variable amount (type
+      (value-type int)))) (
+    (value-type int))
+    (block-function-body
+      (return
+        (binary-expr <<
+          (simple-var-ref x)
+          (simple-var-ref amount))))))

--- a/corpus/ast/subset5/05-error/panic1-p.txt
+++ b/corpus/ast/subset5/05-error/panic1-p.txt
@@ -1,0 +1,8 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (panic
+        (error-constructor-expr (
+          (literal whoops)))))))

--- a/corpus/ast/subset5/05-error/panic2-p.txt
+++ b/corpus/ast/subset5/05-error/panic2-p.txt
@@ -1,0 +1,16 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (expression-stmt
+        (invocation p (
+          (literal help))))))
+  (function p (
+    (variable s (type
+      (value-type string)))) (
+    (value-type null))
+    (block-function-body
+      (panic
+        (error-constructor-expr (
+          (simple-var-ref s)))))))

--- a/corpus/ast/subset5/05-error/panic3-p.txt
+++ b/corpus/ast/subset5/05-error/panic3-p.txt
@@ -1,0 +1,16 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (expression-stmt
+        (invocation p (
+          (error-constructor-expr (
+            (literal help))))))))
+  (function p (
+    (variable e (type
+      (error-type)))) (
+    (value-type null))
+    (block-function-body
+      (panic
+        (simple-var-ref e)))))

--- a/corpus/ast/subset5/05-error/panic4-p.txt
+++ b/corpus/ast/subset5/05-error/panic4-p.txt
@@ -1,0 +1,26 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (foreach
+        (var-def
+          (variable i (type
+            (value-type int))))
+        (binary-expr ..<
+          (literal 0)
+          (literal 3))
+        (block-stmt
+          (if
+            (binary-expr ==
+              (simple-var-ref i)
+              (literal 1))
+            (block-stmt
+              (panic
+                (error-constructor-expr (
+                  (literal range panic))))) ())
+          (block-stmt
+            (expression-stmt
+              (invocation io println (
+                (simple-var-ref i))))))))))

--- a/corpus/ast/subset5/05-error/panic5-p.txt
+++ b/corpus/ast/subset5/05-error/panic5-p.txt
@@ -1,0 +1,32 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable arr (type
+          (array-type
+            (value-type int) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 1)
+            (literal 2)
+            (literal 3)))))
+      (foreach
+        (var-def
+          (variable val (type
+            (value-type int))))
+        (simple-var-ref arr)
+        (block-stmt
+          (if
+            (binary-expr ==
+              (simple-var-ref val)
+              (literal 2))
+            (block-stmt
+              (panic
+                (error-constructor-expr (
+                  (literal list panic))))) ())
+          (block-stmt
+            (expression-stmt
+              (invocation io println (
+                (simple-var-ref val))))))))))

--- a/corpus/bal/subset5/05-error/panic-unreachable-e.bal
+++ b/corpus/bal/subset5/05-error/panic-unreachable-e.bal
@@ -1,0 +1,23 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// @productions panic-stmt error-constructor-expr string-literal
+import ballerina/io;
+
+public function main() {
+    panic error("whoops");
+    io:println("foo"); // @error
+}

--- a/corpus/bal/subset5/05-error/panic1-p.bal
+++ b/corpus/bal/subset5/05-error/panic1-p.bal
@@ -1,0 +1,20 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// @productions panic-stmt error-constructor-expr string-literal
+public function main() {
+    panic error("whoops"); // @panic whoops
+}

--- a/corpus/bal/subset5/05-error/panic2-p.bal
+++ b/corpus/bal/subset5/05-error/panic2-p.bal
@@ -1,0 +1,24 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// @productions panic-stmt error-constructor-expr string string-literal function-call-expr
+public function main() {
+    p("help");
+}
+
+function p(string s) {
+    panic error(s); // @panic help
+}

--- a/corpus/bal/subset5/05-error/panic3-p.bal
+++ b/corpus/bal/subset5/05-error/panic3-p.bal
@@ -1,0 +1,24 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// @productions panic-stmt error-constructor-expr string-literal function-call-expr
+public function main() {
+    p(error("help")); // @panic help
+}
+
+function p(error e) {
+    panic e;
+}

--- a/corpus/bal/subset5/05-error/panic4-p.bal
+++ b/corpus/bal/subset5/05-error/panic4-p.bal
@@ -1,0 +1,27 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// @productions panic-stmt error-constructor-expr string-literal foreach-stmt range-expr if-stmt
+import ballerina/io;
+
+public function main() {
+    foreach int i in 0 ..< 3 {
+        if i == 1 {
+            panic error("range panic"); // @panic range panic
+        }
+        io:println(i); // @output 0
+    }
+}

--- a/corpus/bal/subset5/05-error/panic5-p.bal
+++ b/corpus/bal/subset5/05-error/panic5-p.bal
@@ -1,0 +1,28 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// @productions panic-stmt error-constructor-expr string-literal foreach-stmt list-constructor-expr int-literal if-stmt
+import ballerina/io;
+
+public function main() {
+    int[] arr = [1, 2, 3];
+    foreach int val in arr {
+        if val == 2 {
+            panic error("list panic"); // @panic list panic
+        }
+        io:println(val); // @output 1
+    }
+}

--- a/corpus/bir/subset1/01-int/add10-p.txt
+++ b/corpus/bir/subset1/01-int/add10-p.txt
@@ -1,0 +1,27 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> ((NIL), ()){
+  bb0 {
+    %2 = ConstantLoad 9223372036854775807
+    %3 = unknown %2;
+    %4 = ConstantLoad 1
+    %1 = - %3 %4;
+    INT_MIN = %1;
+    %6 = ConstantLoad 1
+    %7 = unknown %6;
+    %8 = add(INT_MIN,%7) -> bb1;
+  }
+  bb1 {
+    %9 = println(%8) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}
+add(((INT), ()),((INT), ())) -> ((INT), ()){
+  bb0 {
+    %3 = + x y;
+    %0 = %3;
+    return;
+  }
+}

--- a/corpus/bir/subset1/01-int/add2-p.txt
+++ b/corpus/bir/subset1/01-int/add2-p.txt
@@ -1,0 +1,23 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> ((NIL), ()){
+  bb0 {
+    %1 = ConstantLoad 9223372036854775807
+    INT_MAX = %1;
+    %3 = ConstantLoad 1
+    %4 = add(INT_MAX,%3) -> bb1;
+  }
+  bb1 {
+    %5 = println(%4) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}
+add(((INT), ()),((INT), ())) -> ((INT), ()){
+  bb0 {
+    %3 = + x y;
+    %0 = %3;
+    return;
+  }
+}

--- a/corpus/bir/subset1/01-int/div1-p.txt
+++ b/corpus/bir/subset1/01-int/div1-p.txt
@@ -1,0 +1,27 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> ((NIL), ()){
+  bb0 {
+    %2 = ConstantLoad 9223372036854775807
+    %3 = unknown %2;
+    %4 = ConstantLoad 1
+    %1 = - %3 %4;
+    INT_MIN = %1;
+    %6 = ConstantLoad 1
+    %7 = unknown %6;
+    %8 = div(INT_MIN,%7) -> bb1;
+  }
+  bb1 {
+    %9 = println(%8) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}
+div(((INT), ()),((INT), ())) -> ((INT), ()){
+  bb0 {
+    %3 = / x y;
+    %0 = %3;
+    return;
+  }
+}

--- a/corpus/bir/subset1/01-int/div3-p.txt
+++ b/corpus/bir/subset1/01-int/div3-p.txt
@@ -1,0 +1,22 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> ((NIL), ()){
+  bb0 {
+    %1 = ConstantLoad 672
+    %2 = ConstantLoad 0
+    %3 = div(%1,%2) -> bb1;
+  }
+  bb1 {
+    %4 = println(%3) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}
+div(((INT), ()),((INT), ())) -> ((INT), ()){
+  bb0 {
+    %3 = / x y;
+    %0 = %3;
+    return;
+  }
+}

--- a/corpus/bir/subset1/01-int/mul-p.txt
+++ b/corpus/bir/subset1/01-int/mul-p.txt
@@ -1,0 +1,27 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> ((NIL), ()){
+  bb0 {
+    %2 = ConstantLoad 9223372036854775807
+    %3 = unknown %2;
+    %4 = ConstantLoad 1
+    %1 = - %3 %4;
+    INT_MIN = %1;
+    %6 = ConstantLoad 1
+    %7 = unknown %6;
+    %8 = mul(INT_MIN,%7) -> bb1;
+  }
+  bb1 {
+    %9 = println(%8) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}
+mul(((INT), ()),((INT), ())) -> ((INT), ()){
+  bb0 {
+    %3 = * x y;
+    %0 = %3;
+    return;
+  }
+}

--- a/corpus/bir/subset1/01-int/rem1-p.txt
+++ b/corpus/bir/subset1/01-int/rem1-p.txt
@@ -1,0 +1,23 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> ((NIL), ()){
+  bb0 {
+    %1 = ConstantLoad 10000
+    %2 = unknown %1;
+    %3 = ConstantLoad 0
+    %4 = rem(%2,%3) -> bb1;
+  }
+  bb1 {
+    %5 = println(%4) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}
+rem(((INT), ()),((INT), ())) -> ((INT), ()){
+  bb0 {
+    %3 = % x y;
+    %0 = %3;
+    return;
+  }
+}

--- a/corpus/bir/subset1/01-int/sub-p.txt
+++ b/corpus/bir/subset1/01-int/sub-p.txt
@@ -1,0 +1,26 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> ((NIL), ()){
+  bb0 {
+    %2 = ConstantLoad 9223372036854775807
+    %3 = unknown %2;
+    %4 = ConstantLoad 1
+    %1 = - %3 %4;
+    INT_MIN = %1;
+    %6 = ConstantLoad 1
+    %7 = sub(INT_MIN,%6) -> bb1;
+  }
+  bb1 {
+    %8 = println(%7) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}
+sub(((INT), ()),((INT), ())) -> ((INT), ()){
+  bb0 {
+    %3 = - x y;
+    %0 = %3;
+    return;
+  }
+}

--- a/corpus/bir/subset1/01-int/sub2-p.txt
+++ b/corpus/bir/subset1/01-int/sub2-p.txt
@@ -1,0 +1,24 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> ((NIL), ()){
+  bb0 {
+    %1 = ConstantLoad 9223372036854775807
+    INT_MAX = %1;
+    %3 = ConstantLoad 1
+    %4 = unknown %3;
+    %5 = sub(INT_MAX,%4) -> bb1;
+  }
+  bb1 {
+    %6 = println(%5) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}
+sub(((INT), ()),((INT), ())) -> ((INT), ()){
+  bb0 {
+    %3 = - x y;
+    %0 = %3;
+    return;
+  }
+}

--- a/corpus/bir/subset2/02-misc/stackoverflow-p.txt
+++ b/corpus/bir/subset2/02-misc/stackoverflow-p.txt
@@ -1,0 +1,17 @@
+module $anon.. v 0.0.0;
+main() -> ((NIL), ()){
+  bb0 {
+    %1 = f() -> bb1;
+  }
+  bb1 {
+    return;
+  }
+}
+f() -> ((NIL), ()){
+  bb0 {
+    %1 = f() -> bb1;
+  }
+  bb1 {
+    return;
+  }
+}

--- a/corpus/bir/subset2/02-typecast/2-p.txt
+++ b/corpus/bir/subset2/02-typecast/2-p.txt
@@ -1,0 +1,34 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> ((NIL), ()){
+  bb0 {
+    %1 = ConstantLoad true
+    %2 = ConstantLoad true
+    %3 = ConstantLoad 17
+    %4 = ifElse(%1,%2,%3) -> bb1;
+  }
+  bb1 {
+    %5 = <((INT), ())>(%4)
+    n = %5;
+    %7 = println(n) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}
+ifElse(((BOOLEAN), ()),((BOOLEAN), ()),((INT), ())) -> ((NIL, BOOLEAN, INT, FLOAT, DECIMAL, STRING, TYPEDESC, HANDLE, FUNCTION, REGEXP, FUTURE, STREAM, LIST, MAPPING, TABLE, XML, OBJECT), ()){
+  bb0 {
+    t ? bb1 : bb2;
+  }
+  bb1 {
+    %0 = b;
+    return;
+  }
+  bb2 {
+    %0 = n;
+    return;
+  }
+  bb3 {
+    return;
+  }
+}

--- a/corpus/bir/subset3/03-float/div1-p.txt
+++ b/corpus/bir/subset3/03-float/div1-p.txt
@@ -1,0 +1,24 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> ((NIL), ()){
+  bb0 {
+    %1 = ConstantLoad 1
+    x = %1;
+    %3 = ConstantLoad 0
+    y = %3;
+    %5 = div(x,y) -> bb1;
+  }
+  bb1 {
+    %6 = println(%5) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}
+div(((FLOAT), ()),((FLOAT), ())) -> ((FLOAT), ()){
+  bb0 {
+    %3 = / x y;
+    %0 = %3;
+    return;
+  }
+}

--- a/corpus/bir/subset3/03-float/mod1-p.txt
+++ b/corpus/bir/subset3/03-float/mod1-p.txt
@@ -1,0 +1,24 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> ((NIL), ()){
+  bb0 {
+    %1 = ConstantLoad 1
+    x = %1;
+    %3 = ConstantLoad 0
+    y = %3;
+    %5 = mod(x,y) -> bb1;
+  }
+  bb1 {
+    %6 = println(%5) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}
+mod(((FLOAT), ()),((FLOAT), ())) -> ((FLOAT), ()){
+  bb0 {
+    %3 = % x y;
+    %0 = %3;
+    return;
+  }
+}

--- a/corpus/bir/subset3/03-int/neg-p.txt
+++ b/corpus/bir/subset3/03-int/neg-p.txt
@@ -1,0 +1,25 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> ((NIL), ()){
+  bb0 {
+    %2 = ConstantLoad 9223372036854775807
+    %3 = unknown %2;
+    %4 = ConstantLoad 1
+    %1 = - %3 %4;
+    INT_MIN = %1;
+    %6 = neg(INT_MIN) -> bb1;
+  }
+  bb1 {
+    %7 = println(%6) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}
+neg(((INT), ())) -> ((INT), ()){
+  bb0 {
+    %2 = unknown x;
+    %0 = %2;
+    return;
+  }
+}

--- a/corpus/bir/subset3/03-list/02-p.txt
+++ b/corpus/bir/subset3/03-list/02-p.txt
@@ -1,0 +1,20 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> ((NIL), ()){
+  bb0 {
+    %1 = ConstantLoad 17
+    %2 = ConstantLoad 42
+    %3 = ConstantLoad 11
+    %4 = unknown %3;
+    %5 = ConstantLoad 3
+    %6 = newArray ((), (LIST))[%5]{%1, %2, %4}
+    v = %6;
+    %8 = ConstantLoad 3
+    i = %8;
+    %10 = v[i];
+    %11 = println(%10) -> bb1;
+  }
+  bb1 {
+    return;
+  }
+}

--- a/corpus/bir/subset3/03-list/05-p.txt
+++ b/corpus/bir/subset3/03-list/05-p.txt
@@ -1,0 +1,21 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> ((NIL), ()){
+  bb0 {
+    %1 = ConstantLoad 17
+    %2 = ConstantLoad 42
+    %3 = ConstantLoad 11
+    %4 = unknown %3;
+    %5 = ConstantLoad 3
+    %6 = newArray ((), (LIST))[%5]{%1, %2, %4}
+    v = %6;
+    %8 = ConstantLoad 1
+    %9 = unknown %8;
+    i = %9;
+    %11 = v[i];
+    %12 = println(%11) -> bb1;
+  }
+  bb1 {
+    return;
+  }
+}

--- a/corpus/bir/subset3/03-list/08-p.txt
+++ b/corpus/bir/subset3/03-list/08-p.txt
@@ -1,0 +1,16 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> ((NIL), ()){
+  bb0 {
+    %1 = ConstantLoad 0
+    %2 = newArray ((), (LIST))[%1]{}
+    v = %2;
+    %4 = ConstantLoad 0
+    i = %4;
+    %6 = v[i];
+    %7 = println(%6) -> bb1;
+  }
+  bb1 {
+    return;
+  }
+}

--- a/corpus/bir/subset3/03-list/11-p.txt
+++ b/corpus/bir/subset3/03-list/11-p.txt
@@ -1,0 +1,37 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> ((NIL), ()){
+  bb0 {
+    %1 = ConstantLoad 0
+    %2 = newArray ((), (LIST))[%1]{}
+    v = %2;
+    %4 = ConstantLoad 1
+    val = %4;
+    %6 = ConstantLoad 0
+    i = %6;
+    GOTO bb1;
+  }
+  bb1 {
+    %9 = ConstantLoad 62
+    %8 = < i %9;
+    %8 ? bb2 : bb3;
+  }
+  bb2 {
+    %11 = ConstantLoad 2
+    %10 = * val %11;
+    val = %10;
+    %13 = ConstantLoad 1
+    %12 = + i %13;
+    i = %12;
+    GOTO bb1;
+  }
+  bb3 {
+    %14 = ConstantLoad 0
+    v[val] = %14;
+    %15 = v[val];
+    %16 = println(%15) -> bb4;
+  }
+  bb4 {
+    return;
+  }
+}

--- a/corpus/bir/subset3/03-list/13-p.txt
+++ b/corpus/bir/subset3/03-list/13-p.txt
@@ -1,0 +1,22 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> ((NIL), ()){
+  bb0 {
+    %1 = ConstantLoad 0
+    %2 = newArray ((), (LIST))[%1]{}
+    v = %2;
+    %4 = ConstantLoad 1
+    %5 = unknown %4;
+    i = %5;
+    %7 = ConstantLoad 0
+    v[i] = %7;
+    %8 = length(v) -> bb1;
+  }
+  bb1 {
+    %9 = println(%8) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}

--- a/corpus/bir/subset4/04-int/shift3-p.txt
+++ b/corpus/bir/subset4/04-int/shift3-p.txt
@@ -1,0 +1,23 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> ((NIL), ()){
+  bb0 {
+    %1 = ConstantLoad 64
+    amount = %1;
+    %3 = ConstantLoad 1
+    %4 = shift(%3,amount) -> bb1;
+  }
+  bb1 {
+    %5 = println(%4) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}
+shift(((INT), ()),((INT), ())) -> ((INT), ()){
+  bb0 {
+    %3 = unknown x amount;
+    %0 = %3;
+    return;
+  }
+}

--- a/corpus/bir/subset5/05-error/panic1-p.txt
+++ b/corpus/bir/subset5/05-error/panic1-p.txt
@@ -1,0 +1,8 @@
+module $anon.. v 0.0.0;
+main() -> ((NIL), ()){
+  bb0 {
+    %1 = ConstantLoad whoops
+    %2 = newError ((ERROR), ())(%1)
+    panic %2;
+  }
+}

--- a/corpus/bir/subset5/05-error/panic2-p.txt
+++ b/corpus/bir/subset5/05-error/panic2-p.txt
@@ -1,0 +1,16 @@
+module $anon.. v 0.0.0;
+main() -> ((NIL), ()){
+  bb0 {
+    %1 = ConstantLoad help
+    %2 = p(%1) -> bb1;
+  }
+  bb1 {
+    return;
+  }
+}
+p(((STRING), ())) -> ((NIL), ()){
+  bb0 {
+    %2 = newError ((ERROR), ())(s)
+    panic %2;
+  }
+}

--- a/corpus/bir/subset5/05-error/panic3-p.txt
+++ b/corpus/bir/subset5/05-error/panic3-p.txt
@@ -1,0 +1,16 @@
+module $anon.. v 0.0.0;
+main() -> ((NIL), ()){
+  bb0 {
+    %1 = ConstantLoad help
+    %2 = newError ((ERROR), ())(%1)
+    %3 = p(%2) -> bb1;
+  }
+  bb1 {
+    return;
+  }
+}
+p(((ERROR), ())) -> ((NIL), ()){
+  bb0 {
+    panic e;
+  }
+}

--- a/corpus/bir/subset5/05-error/panic4-p.txt
+++ b/corpus/bir/subset5/05-error/panic4-p.txt
@@ -1,0 +1,37 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> ((NIL), ()){
+  bb0 {
+    %1 = ConstantLoad 0
+    i = %1;
+    %3 = ConstantLoad 3
+    $desugar$0 = %3;
+    GOTO bb1;
+  }
+  bb1 {
+    %5 = < i $desugar$0;
+    %5 ? bb2 : bb3;
+  }
+  bb2 {
+    %7 = ConstantLoad 1
+    %6 = == i %7;
+    %6 ? bb4 : bb5;
+  }
+  bb3 {
+    return;
+  }
+  bb4 {
+    %8 = ConstantLoad range panic
+    %9 = newError ((ERROR), ())(%8)
+    panic %9;
+  }
+  bb5 {
+    %10 = println(i) -> bb6;
+  }
+  bb6 {
+    %12 = ConstantLoad 1
+    %11 = + i %12;
+    i = %11;
+    GOTO bb1;
+  }
+}

--- a/corpus/bir/subset5/05-error/panic5-p.txt
+++ b/corpus/bir/subset5/05-error/panic5-p.txt
@@ -1,0 +1,49 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> ((NIL), ()){
+  bb0 {
+    %1 = ConstantLoad 1
+    %2 = ConstantLoad 2
+    %3 = ConstantLoad 3
+    %4 = ConstantLoad 3
+    %5 = newArray ((), (LIST))[%4]{%1, %2, %3}
+    arr = %5;
+    $desugar$0 = arr;
+    %8 = ConstantLoad 0
+    $desugar$1 = %8;
+    %10 = length($desugar$0) -> bb1;
+  }
+  bb1 {
+    $desugar$2 = %10;
+    GOTO bb2;
+  }
+  bb2 {
+    %12 = < $desugar$1 $desugar$2;
+    %12 ? bb3 : bb4;
+  }
+  bb3 {
+    %13 = $desugar$0[$desugar$1];
+    val = %13;
+    %16 = ConstantLoad 2
+    %15 = == val %16;
+    %15 ? bb5 : bb6;
+  }
+  bb4 {
+    return;
+  }
+  bb5 {
+    %17 = ConstantLoad list panic
+    %18 = newError ((ERROR), ())(%17)
+    panic %18;
+  }
+  bb6 {
+    %19 = println(val) -> bb7;
+  }
+  bb7 {
+    %21 = ConstantLoad 1
+    %20 = + $desugar$1 %21;
+    $desugar$1 = %20;
+    GOTO bb2;
+  }
+}

--- a/corpus/cfg/subset1/01-int/add10-p.txt
+++ b/corpus/cfg/subset1/01-int/add10-p.txt
@@ -1,0 +1,25 @@
+(add
+  (bb0 () ()
+    (return
+      (binary-expr +
+        (simple-var-ref x)
+        (simple-var-ref y)))
+  )
+)
+(main
+  (bb0 () ()
+    (var-def
+      (variable INT_MIN (type
+        (value-type int)) (expr
+        (binary-expr -
+          (unary-expr -
+            (literal 9223372036854775807))
+          (literal 1)))))
+    (expression-stmt
+      (invocation io println (
+        (invocation add (
+          (simple-var-ref INT_MIN)
+          (unary-expr -
+            (literal 1)))))))
+  )
+)

--- a/corpus/cfg/subset1/01-int/add2-p.txt
+++ b/corpus/cfg/subset1/01-int/add2-p.txt
@@ -1,0 +1,21 @@
+(add
+  (bb0 () ()
+    (return
+      (binary-expr +
+        (simple-var-ref x)
+        (simple-var-ref y)))
+  )
+)
+(main
+  (bb0 () ()
+    (var-def
+      (variable INT_MAX (type
+        (value-type int)) (expr
+        (literal 9223372036854775807))))
+    (expression-stmt
+      (invocation io println (
+        (invocation add (
+          (simple-var-ref INT_MAX)
+          (literal 1))))))
+  )
+)

--- a/corpus/cfg/subset1/01-int/div1-p.txt
+++ b/corpus/cfg/subset1/01-int/div1-p.txt
@@ -1,0 +1,25 @@
+(div
+  (bb0 () ()
+    (return
+      (binary-expr /
+        (simple-var-ref x)
+        (simple-var-ref y)))
+  )
+)
+(main
+  (bb0 () ()
+    (var-def
+      (variable INT_MIN (type
+        (value-type int)) (expr
+        (binary-expr -
+          (unary-expr -
+            (literal 9223372036854775807))
+          (literal 1)))))
+    (expression-stmt
+      (invocation io println (
+        (invocation div (
+          (simple-var-ref INT_MIN)
+          (unary-expr -
+            (literal 1)))))))
+  )
+)

--- a/corpus/cfg/subset1/01-int/div3-p.txt
+++ b/corpus/cfg/subset1/01-int/div3-p.txt
@@ -1,0 +1,17 @@
+(div
+  (bb0 () ()
+    (return
+      (binary-expr /
+        (simple-var-ref x)
+        (simple-var-ref y)))
+  )
+)
+(main
+  (bb0 () ()
+    (expression-stmt
+      (invocation io println (
+        (invocation div (
+          (literal 672)
+          (literal 0))))))
+  )
+)

--- a/corpus/cfg/subset1/01-int/mul-p.txt
+++ b/corpus/cfg/subset1/01-int/mul-p.txt
@@ -1,0 +1,25 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable INT_MIN (type
+        (value-type int)) (expr
+        (binary-expr -
+          (unary-expr -
+            (literal 9223372036854775807))
+          (literal 1)))))
+    (expression-stmt
+      (invocation io println (
+        (invocation mul (
+          (simple-var-ref INT_MIN)
+          (unary-expr -
+            (literal 1)))))))
+  )
+)
+(mul
+  (bb0 () ()
+    (return
+      (binary-expr *
+        (simple-var-ref x)
+        (simple-var-ref y)))
+  )
+)

--- a/corpus/cfg/subset1/01-int/rem1-p.txt
+++ b/corpus/cfg/subset1/01-int/rem1-p.txt
@@ -1,0 +1,18 @@
+(main
+  (bb0 () ()
+    (expression-stmt
+      (invocation io println (
+        (invocation rem (
+          (unary-expr -
+            (literal 10000))
+          (literal 0))))))
+  )
+)
+(rem
+  (bb0 () ()
+    (return
+      (binary-expr %
+        (simple-var-ref x)
+        (simple-var-ref y)))
+  )
+)

--- a/corpus/cfg/subset1/01-int/sub-p.txt
+++ b/corpus/cfg/subset1/01-int/sub-p.txt
@@ -1,0 +1,24 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable INT_MIN (type
+        (value-type int)) (expr
+        (binary-expr -
+          (unary-expr -
+            (literal 9223372036854775807))
+          (literal 1)))))
+    (expression-stmt
+      (invocation io println (
+        (invocation sub (
+          (simple-var-ref INT_MIN)
+          (literal 1))))))
+  )
+)
+(sub
+  (bb0 () ()
+    (return
+      (binary-expr -
+        (simple-var-ref x)
+        (simple-var-ref y)))
+  )
+)

--- a/corpus/cfg/subset1/01-int/sub2-p.txt
+++ b/corpus/cfg/subset1/01-int/sub2-p.txt
@@ -1,0 +1,22 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable INT_MAX (type
+        (value-type int)) (expr
+        (literal 9223372036854775807))))
+    (expression-stmt
+      (invocation io println (
+        (invocation sub (
+          (simple-var-ref INT_MAX)
+          (unary-expr -
+            (literal 1)))))))
+  )
+)
+(sub
+  (bb0 () ()
+    (return
+      (binary-expr -
+        (simple-var-ref x)
+        (simple-var-ref y)))
+  )
+)

--- a/corpus/cfg/subset2/02-misc/stackoverflow-p.txt
+++ b/corpus/cfg/subset2/02-misc/stackoverflow-p.txt
@@ -1,0 +1,12 @@
+(f
+  (bb0 () ()
+    (expression-stmt
+      (invocation f ()))
+  )
+)
+(main
+  (bb0 () ()
+    (expression-stmt
+      (invocation f ()))
+  )
+)

--- a/corpus/cfg/subset2/02-typecast/2-p.txt
+++ b/corpus/cfg/subset2/02-typecast/2-p.txt
@@ -1,0 +1,29 @@
+(ifElse
+  (bb0 () (bb1 bb2)
+    (simple-var-ref t)
+  )
+  (bb1 (bb0) ()
+    (return
+      (simple-var-ref b))
+  )
+  (bb2 (bb0) ()
+    (return
+      (simple-var-ref n))
+  )
+)
+(main
+  (bb0 () ()
+    (var-def
+      (variable n (type
+        (value-type int)) (expr
+        (type-conversion-expr
+          (invocation ifElse (
+            (literal true)
+            (literal true)
+            (literal 17)))
+          (value-type int)))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref n))))
+  )
+)

--- a/corpus/cfg/subset3/03-float/div1-p.txt
+++ b/corpus/cfg/subset3/03-float/div1-p.txt
@@ -1,0 +1,25 @@
+(div
+  (bb0 () ()
+    (return
+      (binary-expr /
+        (simple-var-ref x)
+        (simple-var-ref y)))
+  )
+)
+(main
+  (bb0 () ()
+    (var-def
+      (variable x (type
+        (value-type float)) (expr
+        (literal 1))))
+    (var-def
+      (variable y (type
+        (value-type float)) (expr
+        (literal 0))))
+    (expression-stmt
+      (invocation io println (
+        (invocation div (
+          (simple-var-ref x)
+          (simple-var-ref y))))))
+  )
+)

--- a/corpus/cfg/subset3/03-float/mod1-p.txt
+++ b/corpus/cfg/subset3/03-float/mod1-p.txt
@@ -1,0 +1,25 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable x (type
+        (value-type float)) (expr
+        (literal 1))))
+    (var-def
+      (variable y (type
+        (value-type float)) (expr
+        (literal 0))))
+    (expression-stmt
+      (invocation io println (
+        (invocation mod (
+          (simple-var-ref x)
+          (simple-var-ref y))))))
+  )
+)
+(mod
+  (bb0 () ()
+    (return
+      (binary-expr %
+        (simple-var-ref x)
+        (simple-var-ref y)))
+  )
+)

--- a/corpus/cfg/subset3/03-int/neg-p.txt
+++ b/corpus/cfg/subset3/03-int/neg-p.txt
@@ -1,0 +1,22 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable INT_MIN (type
+        (value-type int)) (expr
+        (binary-expr -
+          (unary-expr -
+            (literal 9223372036854775807))
+          (literal 1)))))
+    (expression-stmt
+      (invocation io println (
+        (invocation neg (
+          (simple-var-ref INT_MIN))))))
+  )
+)
+(neg
+  (bb0 () ()
+    (return
+      (unary-expr -
+        (simple-var-ref x)))
+  )
+)

--- a/corpus/cfg/subset3/03-list/02-p.txt
+++ b/corpus/cfg/subset3/03-list/02-p.txt
@@ -1,0 +1,22 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable v (type
+        (array-type
+          (value-type any) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal 17)
+          (literal 42)
+          (unary-expr -
+            (literal 11))))))
+    (var-def
+      (variable i (type
+        (value-type int)) (expr
+        (literal 3))))
+    (expression-stmt
+      (invocation io println (
+        (index-based-access
+          (simple-var-ref v)
+          (simple-var-ref i)))))
+  )
+)

--- a/corpus/cfg/subset3/03-list/05-p.txt
+++ b/corpus/cfg/subset3/03-list/05-p.txt
@@ -1,0 +1,23 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable v (type
+        (array-type
+          (value-type any) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal 17)
+          (literal 42)
+          (unary-expr -
+            (literal 11))))))
+    (var-def
+      (variable i (type
+        (value-type int)) (expr
+        (unary-expr -
+          (literal 1)))))
+    (expression-stmt
+      (invocation io println (
+        (index-based-access
+          (simple-var-ref v)
+          (simple-var-ref i)))))
+  )
+)

--- a/corpus/cfg/subset3/03-list/08-p.txt
+++ b/corpus/cfg/subset3/03-list/08-p.txt
@@ -1,0 +1,18 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable v (type
+        (array-type
+          (value-type any) dimensions: 1 ([]))) (expr
+        (list-constructor-expr))))
+    (var-def
+      (variable i (type
+        (value-type int)) (expr
+        (literal 0))))
+    (expression-stmt
+      (invocation io println (
+        (index-based-access
+          (simple-var-ref v)
+          (simple-var-ref i)))))
+  )
+)

--- a/corpus/cfg/subset3/03-list/11-p.txt
+++ b/corpus/cfg/subset3/03-list/11-p.txt
@@ -1,0 +1,46 @@
+(main
+  (bb0 () (bb1)
+    (var-def
+      (variable v (type
+        (array-type
+          (value-type any) dimensions: 1 ([]))) (expr
+        (list-constructor-expr))))
+    (var-def
+      (variable val (type
+        (value-type int)) (expr
+        (literal 1))))
+    (var-def
+      (variable i (type
+        (value-type int)) (expr
+        (literal 0))))
+  )
+  (bb1 (bb0 bb2) (bb2 bb3)
+    (binary-expr <
+      (simple-var-ref i)
+      (literal 62))
+  )
+  (bb2 (bb1) (bb1)
+    (assignment
+      (simple-var-ref val)
+      (binary-expr *
+        (simple-var-ref val)
+        (literal 2)))
+    (assignment
+      (simple-var-ref i)
+      (binary-expr +
+        (simple-var-ref i)
+        (literal 1)))
+  )
+  (bb3 (bb1) ()
+    (assignment
+      (index-based-access
+        (simple-var-ref v)
+        (simple-var-ref val))
+      (literal 0))
+    (expression-stmt
+      (invocation io println (
+        (index-based-access
+          (simple-var-ref v)
+          (simple-var-ref val)))))
+  )
+)

--- a/corpus/cfg/subset3/03-list/13-p.txt
+++ b/corpus/cfg/subset3/03-list/13-p.txt
@@ -1,0 +1,23 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable v (type
+        (array-type
+          (value-type any) dimensions: 1 ([]))) (expr
+        (list-constructor-expr))))
+    (var-def
+      (variable i (type
+        (value-type int)) (expr
+        (unary-expr -
+          (literal 1)))))
+    (assignment
+      (index-based-access
+        (simple-var-ref v)
+        (simple-var-ref i))
+      (literal 0))
+    (expression-stmt
+      (invocation io println (
+        (invocation lang.array length (
+          (simple-var-ref v))))))
+  )
+)

--- a/corpus/cfg/subset4/04-int/shift3-p.txt
+++ b/corpus/cfg/subset4/04-int/shift3-p.txt
@@ -1,0 +1,21 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable amount (type
+        (value-type int)) (expr
+        (literal 64))))
+    (expression-stmt
+      (invocation io println (
+        (invocation shift (
+          (literal 1)
+          (simple-var-ref amount))))))
+  )
+)
+(shift
+  (bb0 () ()
+    (return
+      (binary-expr <<
+        (simple-var-ref x)
+        (simple-var-ref amount)))
+  )
+)

--- a/corpus/cfg/subset5/05-error/panic1-p.txt
+++ b/corpus/cfg/subset5/05-error/panic1-p.txt
@@ -1,0 +1,7 @@
+(main
+  (bb0 () ()
+    (panic
+      (error-constructor-expr (
+        (literal whoops))))
+  )
+)

--- a/corpus/cfg/subset5/05-error/panic2-p.txt
+++ b/corpus/cfg/subset5/05-error/panic2-p.txt
@@ -1,0 +1,14 @@
+(main
+  (bb0 () ()
+    (expression-stmt
+      (invocation p (
+        (literal help))))
+  )
+)
+(p
+  (bb0 () ()
+    (panic
+      (error-constructor-expr (
+        (simple-var-ref s))))
+  )
+)

--- a/corpus/cfg/subset5/05-error/panic3-p.txt
+++ b/corpus/cfg/subset5/05-error/panic3-p.txt
@@ -1,0 +1,14 @@
+(main
+  (bb0 () ()
+    (expression-stmt
+      (invocation p (
+        (error-constructor-expr (
+          (literal help))))))
+  )
+)
+(p
+  (bb0 () ()
+    (panic
+      (simple-var-ref e))
+  )
+)

--- a/corpus/cfg/subset5/05-error/panic4-p.txt
+++ b/corpus/cfg/subset5/05-error/panic4-p.txt
@@ -1,0 +1,27 @@
+(main
+  (bb0 () (bb1))
+  (bb1 (bb0 bb5) (bb2 bb3)
+    (binary-expr ..<
+      (literal 0)
+      (literal 3))
+    (var-def
+      (variable i (type
+        (value-type int))))
+  )
+  (bb2 (bb1) (bb4 bb5)
+    (binary-expr ==
+      (simple-var-ref i)
+      (literal 1))
+  )
+  (bb3 (bb1) ())
+  (bb4 (bb2) ()
+    (panic
+      (error-constructor-expr (
+        (literal range panic))))
+  )
+  (bb5 (bb2) (bb1)
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref i))))
+  )
+)

--- a/corpus/cfg/subset5/05-error/panic5-p.txt
+++ b/corpus/cfg/subset5/05-error/panic5-p.txt
@@ -1,0 +1,34 @@
+(main
+  (bb0 () (bb1)
+    (var-def
+      (variable arr (type
+        (array-type
+          (value-type int) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal 1)
+          (literal 2)
+          (literal 3)))))
+  )
+  (bb1 (bb0 bb5) (bb2 bb3)
+    (simple-var-ref arr)
+    (var-def
+      (variable val (type
+        (value-type int))))
+  )
+  (bb2 (bb1) (bb4 bb5)
+    (binary-expr ==
+      (simple-var-ref val)
+      (literal 2))
+  )
+  (bb3 (bb1) ())
+  (bb4 (bb2) ()
+    (panic
+      (error-constructor-expr (
+        (literal list panic))))
+  )
+  (bb5 (bb2) (bb1)
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref val))))
+  )
+)

--- a/corpus/desugared/subset1/01-int/add10-p.txt
+++ b/corpus/desugared/subset1/01-int/add10-p.txt
@@ -1,0 +1,29 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable INT_MIN (type
+          (value-type int)) (expr
+          (binary-expr -
+            (unary-expr -
+              (literal 9223372036854775807))
+            (literal 1)))))
+      (expression-stmt
+        (invocation io println (
+          (invocation add (
+            (simple-var-ref INT_MIN)
+            (unary-expr -
+              (literal 1)))))))))
+  (function add (
+    (variable x (type
+      (value-type int)))
+    (variable y (type
+      (value-type int)))) (
+    (value-type int))
+    (block-function-body
+      (return
+        (binary-expr +
+          (simple-var-ref x)
+          (simple-var-ref y))))))

--- a/corpus/desugared/subset1/01-int/add2-p.txt
+++ b/corpus/desugared/subset1/01-int/add2-p.txt
@@ -1,0 +1,25 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable INT_MAX (type
+          (value-type int)) (expr
+          (literal 9223372036854775807))))
+      (expression-stmt
+        (invocation io println (
+          (invocation add (
+            (simple-var-ref INT_MAX)
+            (literal 1))))))))
+  (function add (
+    (variable x (type
+      (value-type int)))
+    (variable y (type
+      (value-type int)))) (
+    (value-type int))
+    (block-function-body
+      (return
+        (binary-expr +
+          (simple-var-ref x)
+          (simple-var-ref y))))))

--- a/corpus/desugared/subset1/01-int/div1-p.txt
+++ b/corpus/desugared/subset1/01-int/div1-p.txt
@@ -1,0 +1,29 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable INT_MIN (type
+          (value-type int)) (expr
+          (binary-expr -
+            (unary-expr -
+              (literal 9223372036854775807))
+            (literal 1)))))
+      (expression-stmt
+        (invocation io println (
+          (invocation div (
+            (simple-var-ref INT_MIN)
+            (unary-expr -
+              (literal 1)))))))))
+  (function div (
+    (variable x (type
+      (value-type int)))
+    (variable y (type
+      (value-type int)))) (
+    (value-type int))
+    (block-function-body
+      (return
+        (binary-expr /
+          (simple-var-ref x)
+          (simple-var-ref y))))))

--- a/corpus/desugared/subset1/01-int/div3-p.txt
+++ b/corpus/desugared/subset1/01-int/div3-p.txt
@@ -1,0 +1,21 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (expression-stmt
+        (invocation io println (
+          (invocation div (
+            (literal 672)
+            (literal 0))))))))
+  (function div (
+    (variable x (type
+      (value-type int)))
+    (variable y (type
+      (value-type int)))) (
+    (value-type int))
+    (block-function-body
+      (return
+        (binary-expr /
+          (simple-var-ref x)
+          (simple-var-ref y))))))

--- a/corpus/desugared/subset1/01-int/mul-p.txt
+++ b/corpus/desugared/subset1/01-int/mul-p.txt
@@ -1,0 +1,29 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable INT_MIN (type
+          (value-type int)) (expr
+          (binary-expr -
+            (unary-expr -
+              (literal 9223372036854775807))
+            (literal 1)))))
+      (expression-stmt
+        (invocation io println (
+          (invocation mul (
+            (simple-var-ref INT_MIN)
+            (unary-expr -
+              (literal 1)))))))))
+  (function mul (
+    (variable x (type
+      (value-type int)))
+    (variable y (type
+      (value-type int)))) (
+    (value-type int))
+    (block-function-body
+      (return
+        (binary-expr *
+          (simple-var-ref x)
+          (simple-var-ref y))))))

--- a/corpus/desugared/subset1/01-int/rem1-p.txt
+++ b/corpus/desugared/subset1/01-int/rem1-p.txt
@@ -1,0 +1,22 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (expression-stmt
+        (invocation io println (
+          (invocation rem (
+            (unary-expr -
+              (literal 10000))
+            (literal 0))))))))
+  (function rem (
+    (variable x (type
+      (value-type int)))
+    (variable y (type
+      (value-type int)))) (
+    (value-type int))
+    (block-function-body
+      (return
+        (binary-expr %
+          (simple-var-ref x)
+          (simple-var-ref y))))))

--- a/corpus/desugared/subset1/01-int/sub-p.txt
+++ b/corpus/desugared/subset1/01-int/sub-p.txt
@@ -1,0 +1,28 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable INT_MIN (type
+          (value-type int)) (expr
+          (binary-expr -
+            (unary-expr -
+              (literal 9223372036854775807))
+            (literal 1)))))
+      (expression-stmt
+        (invocation io println (
+          (invocation sub (
+            (simple-var-ref INT_MIN)
+            (literal 1))))))))
+  (function sub (
+    (variable x (type
+      (value-type int)))
+    (variable y (type
+      (value-type int)))) (
+    (value-type int))
+    (block-function-body
+      (return
+        (binary-expr -
+          (simple-var-ref x)
+          (simple-var-ref y))))))

--- a/corpus/desugared/subset1/01-int/sub2-p.txt
+++ b/corpus/desugared/subset1/01-int/sub2-p.txt
@@ -1,0 +1,26 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable INT_MAX (type
+          (value-type int)) (expr
+          (literal 9223372036854775807))))
+      (expression-stmt
+        (invocation io println (
+          (invocation sub (
+            (simple-var-ref INT_MAX)
+            (unary-expr -
+              (literal 1)))))))))
+  (function sub (
+    (variable x (type
+      (value-type int)))
+    (variable y (type
+      (value-type int)))) (
+    (value-type int))
+    (block-function-body
+      (return
+        (binary-expr -
+          (simple-var-ref x)
+          (simple-var-ref y))))))

--- a/corpus/desugared/subset2/02-misc/stackoverflow-p.txt
+++ b/corpus/desugared/subset2/02-misc/stackoverflow-p.txt
@@ -1,0 +1,11 @@
+(package
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (expression-stmt
+        (invocation f ()))))
+  (function f () (
+    (value-type null))
+    (block-function-body
+      (expression-stmt
+        (invocation f ())))))

--- a/corpus/desugared/subset2/02-typecast/2-p.txt
+++ b/corpus/desugared/subset2/02-typecast/2-p.txt
@@ -1,0 +1,34 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable n (type
+          (value-type int)) (expr
+          (type-conversion-expr
+            (invocation ifElse (
+              (literal true)
+              (literal true)
+              (literal 17)))
+            (value-type int)))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref n))))))
+  (function ifElse (
+    (variable t (type
+      (value-type boolean)))
+    (variable b (type
+      (value-type boolean)))
+    (variable n (type
+      (value-type int)))) (
+    (value-type any))
+    (block-function-body
+      (if
+        (simple-var-ref t)
+        (block-stmt
+          (return
+            (simple-var-ref b))) (
+        (block-stmt
+          (return
+            (simple-var-ref n))))))))

--- a/corpus/desugared/subset3/03-float/div1-p.txt
+++ b/corpus/desugared/subset3/03-float/div1-p.txt
@@ -1,0 +1,29 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable x (type
+          (value-type float)) (expr
+          (literal 1))))
+      (var-def
+        (variable y (type
+          (value-type float)) (expr
+          (literal 0))))
+      (expression-stmt
+        (invocation io println (
+          (invocation div (
+            (simple-var-ref x)
+            (simple-var-ref y))))))))
+  (function div (
+    (variable x (type
+      (value-type float)))
+    (variable y (type
+      (value-type float)))) (
+    (value-type float))
+    (block-function-body
+      (return
+        (binary-expr /
+          (simple-var-ref x)
+          (simple-var-ref y))))))

--- a/corpus/desugared/subset3/03-float/mod1-p.txt
+++ b/corpus/desugared/subset3/03-float/mod1-p.txt
@@ -1,0 +1,29 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable x (type
+          (value-type float)) (expr
+          (literal 1))))
+      (var-def
+        (variable y (type
+          (value-type float)) (expr
+          (literal 0))))
+      (expression-stmt
+        (invocation io println (
+          (invocation mod (
+            (simple-var-ref x)
+            (simple-var-ref y))))))))
+  (function mod (
+    (variable x (type
+      (value-type float)))
+    (variable y (type
+      (value-type float)))) (
+    (value-type float))
+    (block-function-body
+      (return
+        (binary-expr %
+          (simple-var-ref x)
+          (simple-var-ref y))))))

--- a/corpus/desugared/subset3/03-int/neg-p.txt
+++ b/corpus/desugared/subset3/03-int/neg-p.txt
@@ -1,0 +1,24 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable INT_MIN (type
+          (value-type int)) (expr
+          (binary-expr -
+            (unary-expr -
+              (literal 9223372036854775807))
+            (literal 1)))))
+      (expression-stmt
+        (invocation io println (
+          (invocation neg (
+            (simple-var-ref INT_MIN))))))))
+  (function neg (
+    (variable x (type
+      (value-type int)))) (
+    (value-type int))
+    (block-function-body
+      (return
+        (unary-expr -
+          (simple-var-ref x))))))

--- a/corpus/desugared/subset3/03-list/02-p.txt
+++ b/corpus/desugared/subset3/03-list/02-p.txt
@@ -1,0 +1,23 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable v (type
+          (array-type
+            (value-type any) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 17)
+            (literal 42)
+            (unary-expr -
+              (literal 11))))))
+      (var-def
+        (variable i (type
+          (value-type int)) (expr
+          (literal 3))))
+      (expression-stmt
+        (invocation io println (
+          (index-based-access
+            (simple-var-ref v)
+            (simple-var-ref i))))))))

--- a/corpus/desugared/subset3/03-list/05-p.txt
+++ b/corpus/desugared/subset3/03-list/05-p.txt
@@ -1,0 +1,24 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable v (type
+          (array-type
+            (value-type any) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 17)
+            (literal 42)
+            (unary-expr -
+              (literal 11))))))
+      (var-def
+        (variable i (type
+          (value-type int)) (expr
+          (unary-expr -
+            (literal 1)))))
+      (expression-stmt
+        (invocation io println (
+          (index-based-access
+            (simple-var-ref v)
+            (simple-var-ref i))))))))

--- a/corpus/desugared/subset3/03-list/08-p.txt
+++ b/corpus/desugared/subset3/03-list/08-p.txt
@@ -1,0 +1,19 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable v (type
+          (array-type
+            (value-type any) dimensions: 1 ([]))) (expr
+          (list-constructor-expr))))
+      (var-def
+        (variable i (type
+          (value-type int)) (expr
+          (literal 0))))
+      (expression-stmt
+        (invocation io println (
+          (index-based-access
+            (simple-var-ref v)
+            (simple-var-ref i))))))))

--- a/corpus/desugared/subset3/03-list/11-p.txt
+++ b/corpus/desugared/subset3/03-list/11-p.txt
@@ -1,0 +1,43 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable v (type
+          (array-type
+            (value-type any) dimensions: 1 ([]))) (expr
+          (list-constructor-expr))))
+      (var-def
+        (variable val (type
+          (value-type int)) (expr
+          (literal 1))))
+      (var-def
+        (variable i (type
+          (value-type int)) (expr
+          (literal 0))))
+      (while
+        (binary-expr <
+          (simple-var-ref i)
+          (literal 62))
+        (block-stmt
+          (assignment
+            (simple-var-ref val)
+            (binary-expr *
+              (simple-var-ref val)
+              (literal 2)))
+          (assignment
+            (simple-var-ref i)
+            (binary-expr +
+              (simple-var-ref i)
+              (literal 1)))))
+      (assignment
+        (index-based-access
+          (simple-var-ref v)
+          (simple-var-ref val))
+        (literal 0))
+      (expression-stmt
+        (invocation io println (
+          (index-based-access
+            (simple-var-ref v)
+            (simple-var-ref val))))))))

--- a/corpus/desugared/subset3/03-list/13-p.txt
+++ b/corpus/desugared/subset3/03-list/13-p.txt
@@ -1,0 +1,25 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang array (as lang.array))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable v (type
+          (array-type
+            (value-type any) dimensions: 1 ([]))) (expr
+          (list-constructor-expr))))
+      (var-def
+        (variable i (type
+          (value-type int)) (expr
+          (unary-expr -
+            (literal 1)))))
+      (assignment
+        (index-based-access
+          (simple-var-ref v)
+          (simple-var-ref i))
+        (literal 0))
+      (expression-stmt
+        (invocation io println (
+          (invocation lang.array length (
+            (simple-var-ref v)))))))))

--- a/corpus/desugared/subset4/04-int/shift3-p.txt
+++ b/corpus/desugared/subset4/04-int/shift3-p.txt
@@ -1,0 +1,25 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable amount (type
+          (value-type int)) (expr
+          (literal 64))))
+      (expression-stmt
+        (invocation io println (
+          (invocation shift (
+            (literal 1)
+            (simple-var-ref amount))))))))
+  (function shift (
+    (variable x (type
+      (value-type int)))
+    (variable amount (type
+      (value-type int)))) (
+    (value-type int))
+    (block-function-body
+      (return
+        (binary-expr <<
+          (simple-var-ref x)
+          (simple-var-ref amount))))))

--- a/corpus/desugared/subset5/05-error/panic1-p.txt
+++ b/corpus/desugared/subset5/05-error/panic1-p.txt
@@ -1,0 +1,7 @@
+(package
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (panic
+        (error-constructor-expr (
+          (literal whoops)))))))

--- a/corpus/desugared/subset5/05-error/panic2-p.txt
+++ b/corpus/desugared/subset5/05-error/panic2-p.txt
@@ -1,0 +1,15 @@
+(package
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (expression-stmt
+        (invocation p (
+          (literal help))))))
+  (function p (
+    (variable s (type
+      (value-type string)))) (
+    (value-type null))
+    (block-function-body
+      (panic
+        (error-constructor-expr (
+          (simple-var-ref s)))))))

--- a/corpus/desugared/subset5/05-error/panic3-p.txt
+++ b/corpus/desugared/subset5/05-error/panic3-p.txt
@@ -1,0 +1,15 @@
+(package
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (expression-stmt
+        (invocation p (
+          (error-constructor-expr (
+            (literal help))))))))
+  (function p (
+    (variable e (type
+      (error-type)))) (
+    (value-type null))
+    (block-function-body
+      (panic
+        (simple-var-ref e)))))

--- a/corpus/desugared/subset5/05-error/panic4-p.txt
+++ b/corpus/desugared/subset5/05-error/panic4-p.txt
@@ -1,0 +1,34 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable i (type
+          (value-type int)) (expr
+          (literal 0))))
+      (var-def
+        (variable $desugar$0 (expr
+          (literal 3))))
+      (while
+        (binary-expr <
+          (simple-var-ref i)
+          (simple-var-ref $desugar$0))
+        (block-stmt
+          (if
+            (binary-expr ==
+              (simple-var-ref i)
+              (literal 1))
+            (block-stmt
+              (panic
+                (error-constructor-expr (
+                  (literal range panic))))) ())
+          (block-stmt
+            (expression-stmt
+              (invocation io println (
+                (simple-var-ref i)))))
+          (assignment
+            (simple-var-ref i)
+            (binary-expr +
+              (simple-var-ref i)
+              (numeric-literal 1))))))))

--- a/corpus/desugared/subset5/05-error/panic5-p.txt
+++ b/corpus/desugared/subset5/05-error/panic5-p.txt
@@ -1,0 +1,52 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang array (as lang.array))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable arr (type
+          (array-type
+            (value-type int) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 1)
+            (literal 2)
+            (literal 3)))))
+      (var-def
+        (variable $desugar$0 (expr
+          (simple-var-ref arr))))
+      (var-def
+        (variable $desugar$1 (expr
+          (numeric-literal 0))))
+      (var-def
+        (variable $desugar$2 (expr
+          (invocation lang.array length (
+            (simple-var-ref $desugar$0))))))
+      (while
+        (binary-expr <
+          (simple-var-ref $desugar$1)
+          (simple-var-ref $desugar$2))
+        (block-stmt
+          (var-def
+            (variable val (type
+              (value-type int)) (expr
+              (index-based-access
+                (simple-var-ref $desugar$0)
+                (simple-var-ref $desugar$1)))))
+          (if
+            (binary-expr ==
+              (simple-var-ref val)
+              (literal 2))
+            (block-stmt
+              (panic
+                (error-constructor-expr (
+                  (literal list panic))))) ())
+          (block-stmt
+            (expression-stmt
+              (invocation io println (
+                (simple-var-ref val)))))
+          (assignment
+            (simple-var-ref $desugar$1)
+            (binary-expr +
+              (simple-var-ref $desugar$1)
+              (numeric-literal 1))))))))

--- a/corpus/integration/subset5/05-error/panic-unreachable-e.txtar
+++ b/corpus/integration/subset5/05-error/panic-unreachable-e.txtar
@@ -1,0 +1,8 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: Unreachable code
+  --> panic-unreachable-e.bal:22:5
+   |
+22 |     io:println("foo"); // @error
+   |     ^^^^^^^^^^^^^^^^^^
+

--- a/corpus/integration_test.go
+++ b/corpus/integration_test.go
@@ -52,6 +52,11 @@ var (
 	skipIntegrationTests = []string{
 		"subset5/05-error/simple-v.bal",
 		"subset5/05-error/context-type-v.bal",
+		"subset5/05-error/panic1-p.bal",
+		"subset5/05-error/panic2-p.bal",
+		"subset5/05-error/panic3-p.bal",
+		"subset5/05-error/panic4-p.bal",
+		"subset5/05-error/panic5-p.bal",
 	}
 )
 

--- a/desugar/corpus_desugar_test.go
+++ b/desugar/corpus_desugar_test.go
@@ -34,7 +34,7 @@ var update = flag.Bool("update", false, "update expected desugared AST files")
 func TestDesugar(t *testing.T) {
 	flag.Parse()
 
-	testPairs := test_util.GetValidTests(t, test_util.Desugar)
+	testPairs := test_util.GetValidAndPanicTests(t, test_util.Desugar)
 
 	for _, testPair := range testPairs {
 		t.Run(testPair.Name, func(t *testing.T) {

--- a/desugar/statement.go
+++ b/desugar/statement.go
@@ -46,6 +46,8 @@ func walkStatement(cx *FunctionContext, node model.StatementNode) desugaredNode[
 		return walkSimpleVariableDef(cx, stmt)
 	case *ast.BLangReturn:
 		return walkReturn(cx, stmt)
+	case *ast.BLangPanic:
+		return walkPanic(cx, stmt)
 	case *ast.BLangBreak:
 		return desugaredNode[model.StatementNode]{replacementNode: stmt}
 	case *ast.BLangContinue:
@@ -241,6 +243,21 @@ func walkSimpleVariableDef(cx *FunctionContext, stmt *ast.BLangSimpleVariableDef
 	}
 }
 
+func walkPanic(cx *FunctionContext, stmt *ast.BLangPanic) desugaredNode[model.StatementNode] {
+	var initStmts []model.StatementNode
+
+	if stmt.Expr != nil {
+		result := walkExpression(cx, stmt.Expr)
+		initStmts = append(initStmts, result.initStmts...)
+		stmt.Expr = result.replacementNode.(ast.BLangExpression)
+	}
+
+	return desugaredNode[model.StatementNode]{
+		initStmts:       initStmts,
+		replacementNode: stmt,
+	}
+}
+
 func walkReturn(cx *FunctionContext, stmt *ast.BLangReturn) desugaredNode[model.StatementNode] {
 	var initStmts []model.StatementNode
 
@@ -401,7 +418,7 @@ func desugarForEachOnList(cx *FunctionContext, collection ast.BLangExpression, l
 	newBodyStmts = append(newBodyStmts, loopVarDef)
 	newBodyStmts = append(newBodyStmts, body.Stmts...)
 	if len(newBodyStmts) > 0 {
-		if isAppentReachable(newBodyStmts[len(newBodyStmts)-1]) {
+		if isAppendReachable(newBodyStmts[len(newBodyStmts)-1]) {
 			newBodyStmts = append(newBodyStmts, incrementStmt)
 		}
 	}
@@ -511,7 +528,7 @@ func desugarForEachOnRange(cx *FunctionContext, rangeExpr *ast.BLangBinaryExpr, 
 	newBodyStmts := make([]model.StatementNode, len(body.Stmts))
 	copy(newBodyStmts, body.Stmts)
 	if len(newBodyStmts) > 0 {
-		if isAppentReachable(newBodyStmts[len(newBodyStmts)-1]) {
+		if isAppendReachable(newBodyStmts[len(newBodyStmts)-1]) {
 			newBodyStmts = append(newBodyStmts, incrementStmt)
 		}
 	} else {
@@ -544,16 +561,16 @@ func desugarForEachOnRange(cx *FunctionContext, rangeExpr *ast.BLangBinaryExpr, 
 // TODO: do we need to think about if-else here as well?
 // If the last statement in a block is something like panic, return, continue or break, then we shouldn't append
 // nodes after that. I would make that node unreacheable. We need to make sure desugared AST is still valid.
-func isAppentReachable(stmt ast.BLangStatement) bool {
+func isAppendReachable(stmt ast.BLangStatement) bool {
 	switch stmt := stmt.(type) {
-	case *ast.BLangReturn, *ast.BLangContinue, *ast.BLangBreak:
+	case *ast.BLangReturn, *ast.BLangContinue, *ast.BLangBreak, *ast.BLangPanic:
 		return false
 	case *ast.BLangBlockStmt:
 		if len(stmt.Stmts) == 0 {
 			return true
 		}
 		lastChild := stmt.Stmts[len(stmt.Stmts)-1]
-		return isAppentReachable(lastChild)
+		return isAppendReachable(lastChild)
 	default:
 		return true
 	}

--- a/model/tree.go
+++ b/model/tree.go
@@ -1047,6 +1047,11 @@ type ReturnNode interface {
 	SetExpression(expression ExpressionNode)
 }
 
+type PanicNode interface {
+	StatementNode
+	GetExpression() ExpressionNode
+}
+
 type DoNode interface {
 	StatementNode
 	GetBody() BlockStatementNode

--- a/semantics/control_flow_analyzer.go
+++ b/semantics/control_flow_analyzer.go
@@ -231,6 +231,8 @@ func (analyzer *functionControlFlowAnalyzer) analyzeStatement(curBB bbRef, stmt 
 	switch s := stmt.(type) {
 	case *ast.BLangReturn:
 		return analyzer.analyzeReturn(curBB, s)
+	case *ast.BLangPanic:
+		return analyzer.analyzePanic(curBB, s)
 	case *ast.BLangIf:
 		return analyzer.analyzeIf(curBB, s)
 	case *ast.BLangBlockStmt:
@@ -299,6 +301,11 @@ func (c *ternaryExpressionChecker) VisitTypeData(typeData *model.TypeData) ast.V
 func (analyzer *functionControlFlowAnalyzer) analyzeReturn(curBB bbRef, stmt *ast.BLangReturn) stmtEffect {
 	analyzer.addNode(curBB, stmt)
 	// Return terminates execution - current block has no children
+	return terminatedEffect()
+}
+
+func (analyzer *functionControlFlowAnalyzer) analyzePanic(curBB bbRef, stmt *ast.BLangPanic) stmtEffect {
+	analyzer.addNode(curBB, stmt)
 	return terminatedEffect()
 }
 

--- a/semantics/corpus_cfg_test.go
+++ b/semantics/corpus_cfg_test.go
@@ -35,7 +35,7 @@ var updateCFG = flag.Bool("update", false, "update expected CFG text files")
 func TestCFGGeneration(t *testing.T) {
 	flag.Parse()
 
-	testPairs := test_util.GetValidTests(t, test_util.CFG)
+	testPairs := test_util.GetValidAndPanicTests(t, test_util.CFG)
 
 	for _, testPair := range testPairs {
 		t.Run(testPair.Name, func(t *testing.T) {

--- a/semantics/corpus_semantic_analysis_test.go
+++ b/semantics/corpus_semantic_analysis_test.go
@@ -31,7 +31,7 @@ import (
 func TestSemanticAnalysis(t *testing.T) {
 	flag.Parse()
 
-	testPairs := test_util.GetValidTests(t, test_util.AST)
+	testPairs := test_util.GetValidAndPanicTests(t, test_util.AST)
 
 	for _, testPair := range testPairs {
 		t.Run(testPair.Name, func(t *testing.T) {

--- a/semantics/corpus_symbol_resolver_test.go
+++ b/semantics/corpus_symbol_resolver_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestSymbolResolver(t *testing.T) {
 	flag.Parse()
-	testPairs := test_util.GetValidTests(t, test_util.AST)
+	testPairs := test_util.GetValidAndPanicTests(t, test_util.AST)
 
 	for _, testPair := range testPairs {
 		t.Run(testPair.Name, func(t *testing.T) {

--- a/semantics/corpus_type_resolver_test.go
+++ b/semantics/corpus_type_resolver_test.go
@@ -31,7 +31,7 @@ import (
 func TestTypeResolver(t *testing.T) {
 	flag.Parse()
 
-	testPairs := test_util.GetValidTests(t, test_util.AST)
+	testPairs := test_util.GetValidAndPanicTests(t, test_util.AST)
 
 	for _, testPair := range testPairs {
 		t.Run(testPair.Name, func(t *testing.T) {

--- a/semantics/semantic_analyzer.go
+++ b/semantics/semantic_analyzer.go
@@ -1141,6 +1141,9 @@ func visitInner[A analyzer](a A, node ast.BLangNode) ast.Visitor {
 			return nil
 		}
 		return nil
+	case *ast.BLangPanic:
+		analyzeExpression(a, n.Expr, &semtypes.ERROR)
+		return nil
 	default:
 		return a
 	}

--- a/semantics/type_resolver.go
+++ b/semantics/type_resolver.go
@@ -251,6 +251,11 @@ func (t *TypeResolver) resolveStatementInner(chain *binding, stmt ast.BLangState
 			t.resolveOnFailClause(chain, s.OnFailClause)
 		}
 		return defaultStmtEffect(chain), ok
+	case *ast.BLangPanic:
+		if _, _, ok := t.resolveExpression(chain, s.Expr); !ok {
+			return defaultStmtEffect(chain), false
+		}
+		return statementEffect{nil, true}, true
 	case *ast.BLangBreak, *ast.BLangContinue:
 		return defaultStmtEffect(chain), true
 	default:

--- a/test_util/test_util.go
+++ b/test_util/test_util.go
@@ -58,6 +58,13 @@ func GetErrorTests(t *testing.T, kind TestKind) []TestCase {
 	})
 }
 
+// GetValidAndPanicTests returns all valid and panic test pairs for the given test kind
+func GetValidAndPanicTests(t *testing.T, kind TestKind) []TestCase {
+	return GetTests(t, kind, func(path string) bool {
+		return strings.HasSuffix(path, "-v.bal") || strings.HasSuffix(path, "-p.bal")
+	})
+}
+
 // GetTests returns test pairs for the given test kind, filtered by the provided function
 func GetTests(t *testing.T, kind TestKind, filterFunc func(string) bool) []TestCase {
 	inputBaseDirAlt := "bal"


### PR DESCRIPTION
## Purpose
Resolves #187
Depends on #191



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added first-class support for panic statements across parsing, printing, analysis, desugaring, and code generation; panic expressions are validated and treated as terminating control flow.

* **Tests**
  * Expanded corpus and unit/integration tests to include panic scenarios; added utilities to select panic-capable test cases and skipped certain panic integration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->