### PR TITLE
Add subset 5 docs

### DIFF
--- a/doc/subset5.md
+++ b/doc/subset5.md
@@ -1,0 +1,87 @@
+# Supported language features (subset 5)
+
+## Module level declarations
+
+- [Import declarations](https://ballerina.io/spec/lang/master/#import-decl)
+- [Function definition](https://ballerina.io/spec/lang/master/#function-defn)
+  - Currently only support [`block-function-body`](https://ballerina.io/spec/lang/master/#block-function-body)
+  - Currently only support [`required-params`](https://ballerina.io/spec/lang/master/#required-params) in the signature
+- [Constant declarations](https://ballerina.io/spec/lang/master/#module-const-decl)
+  - Currently only support literals as constant expressions
+  - Currently don't support type declarations in constant declarations
+
+## Statements
+
+- [Assignment](https://ballerina.io/spec/lang/master/#assignment-stmt)
+  - See supported [`lvexpr`](#expressions)
+- [Destructuring assignment statement](https://ballerina.io/spec/lang/master/#destructuring-assignment-stmt)
+  - Only support [`wildcard-binding-pattern`](https://ballerina.io/spec/lang/master/#wildcard-binding-pattern)
+- [Compound Assignment](https://ballerina.io/spec/lang/master/#compound-assignment-stmt)
+  - See supported [binary operators](#operators)
+  - Currently don't fully support [nil lifting](https://ballerina.io/spec/lang/master/#nil_lifting)
+- [Break](https://ballerina.io/spec/lang/master/#break-stmt)
+- [Continue](https://ballerina.io/spec/lang/master/#continue-stmt)
+- [Call](https://ballerina.io/spec/lang/master/#call-stmt)
+- [While](https://ballerina.io/spec/lang/master/#while-stmt)
+- [Local variable declarations](https://ballerina.io/spec/lang/master/#local-var-decl-stmt)
+  - Currently don't support `final`
+- [Return](https://ballerina.io/spec/lang/master/#return-stmt)
+
+## Expressions
+
+- [Literal](https://ballerina.io/spec/lang/master/#literal)
+  - Currently support `nil-literal`, `boolean-literal`, `numeric-literal` and `string-literal` only
+- [lvexpr](https://ballerina.io/spec/lang/master/#section_7.14.1)
+  - Currently only support [variable-reference-lvexpr](https://ballerina.io/spec/lang/master/#variable-reference-lvexpr)
+- [`Call`](https://ballerina.io/spec/lang/master/#call-expr)
+- [List constructor](https://ballerina.io/spec/lang/master/#list-constructor-expr)
+  - Currently [spread-list-member](https://ballerina.io/spec/lang/master/#spread-list-member) not supported
+- [Variable reference](https://ballerina.io/spec/lang/master/#variable-reference-expr)
+  - Currently `xml-qualified-names` not supported
+- [Unary logical expression](https://ballerina.io/spec/lang/master/#unary-logical-expr)
+- [Nil lifted expression](https://ballerina.io/spec/lang/master/#nil-lifted-expr)
+  - Currently nil lifting is not fully supported
+- [Relational expression](https://ballerina.io/spec/lang/master/#relational-expr)
+- [Equality expression](https://ballerina.io/spec/lang/master/#equality-expr)
+- Nested expressions (`(expression)`)
+- [Shift expression](https://ballerina.io/spec/lang/master/#section_6.25)
+- [Type test expression](https://ballerina.io/spec/lang/master/#section_6.28)
+- [Field access expression](https://ballerina.io/spec/lang/master/#section_6.10)
+
+## Operators
+
+- Binary operators
+  - Equality ops `==`, `!=`, `===`, `!==`
+  - Multiplicative ops `*`, `%`, `/`
+  - Bitwise ops `&`, `|`, `^`
+  - Relational ops `<`, `<=`, `>`, `>=`,
+  - Additive ops `+`, `-`
+  - Shift ops `<<`, `>>`, `>>>`
+- Unary operators
+  - logical `!`
+  - numeric ops `+`, `-`
+
+# Subset restrictions
+
+## Import declarations
+
+- Only following libraries with given methods are supported
+  - `ballerina/io`
+    - `println`
+  - `ballerina/lang.array`
+    - `length`
+    - `push`
+  - `ballerina/lang.int`
+    - `Signed8`
+    - `Signed16`
+    - `Signed32`
+    - `Unsigned8`
+    - `Unsigned16`
+    - `Unsigned32`
+    - `toHexString`
+
+## Method call
+
+- Method call syntax can be used for calling the following langlib functions:
+  - `array:length`
+  - `array:push`


### PR DESCRIPTION
## Purpose
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added detailed documentation for language subset 5, providing a complete reference of supported language features including module declarations, statement types, expression forms, operators, and available standard library methods. This comprehensive guide clarifies all capabilities and limitations of the subset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->