### PR TITLE
Make type resolution of local nodes concurrent

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -20,10 +20,12 @@ import (
 	"ballerina-lang-go/model"
 	"ballerina-lang-go/semtypes"
 	"ballerina-lang-go/tools/diagnostics"
+	"sync"
 )
 
 type CompilerContext struct {
 	env         *CompilerEnvironment
+	mu          sync.Mutex
 	diagnostics []diagnostics.Diagnostic
 }
 
@@ -107,7 +109,9 @@ func (this *CompilerContext) SemanticError(message string, pos diagnostics.Locat
 
 func (this *CompilerContext) addDiagnostic(code string, severity diagnostics.DiagnosticSeverity, message string, pos diagnostics.Location) {
 	diagnostic := diagnostics.CreateDiagnostic(diagnostics.NewDiagnosticInfo(&code, message, severity), pos)
+	this.mu.Lock()
 	this.diagnostics = append(this.diagnostics, diagnostic)
+	this.mu.Unlock()
 }
 
 func (this *CompilerContext) HasDiagnostics() bool {

--- a/context/env.go
+++ b/context/env.go
@@ -58,7 +58,7 @@ func (this *CompilerEnvironment) NewBlockScope(parent model.Scope, pkg model.Pac
 
 func (this *CompilerEnvironment) GetSymbol(symbol model.SymbolRef) model.Symbol {
 	symbolSpace := this.symbolSpaces[symbol.SpaceIndex]
-	return symbolSpace.Symbols[symbol.Index]
+	return symbolSpace.SymbolAt(symbol.Index)
 }
 
 // CreateNarrowedSymbol create a narrowed symbol for the given baseRef symbol. IMPORTANT: baseRef must be the actual symbol

--- a/model/symbol.go
+++ b/model/symbol.go
@@ -176,12 +176,16 @@ func (space *SymbolSpace) AddSymbol(name string, symbol Symbol) {
 	if _, ok := symbol.(*SymbolRef); ok {
 		panic("SymbolRef cannot be added to a SymbolSpace")
 	}
+	space.mu.Lock()
 	space.lookupTable[name] = len(space.Symbols)
 	space.Symbols = append(space.Symbols, symbol)
+	space.mu.Unlock()
 }
 
 func (space *SymbolSpace) GetSymbol(name string) (SymbolRef, bool) {
+	space.mu.RLock()
 	index, ok := space.lookupTable[name]
+	space.mu.RUnlock()
 	if !ok {
 		return SymbolRef{}, false
 	}

--- a/semantics/type_resolver.go
+++ b/semantics/type_resolver.go
@@ -27,20 +27,19 @@ import (
 	"math/bits"
 	"strconv"
 	"strings"
+	"sync"
 
 	array "ballerina-lang-go/lib/array/compile"
 	bInt "ballerina-lang-go/lib/int/compile"
 )
 
-type (
-	TypeResolver struct {
-		ctx             *context.CompilerContext
-		tyCtx           semtypes.Context
-		importedSymbols map[string]model.ExportedSymbolSpace
-		pkg             *ast.BLangPackage
-		implicitImports map[string]bool
-	}
-)
+type TypeResolver struct {
+	ctx             *context.CompilerContext
+	tyCtx           semtypes.Context
+	importedSymbols map[string]model.ExportedSymbolSpace
+	pkg             *ast.BLangPackage
+	implicitImports map[string]ast.BLangImportPackage
+}
 
 var _ ast.Visitor = &TypeResolver{}
 
@@ -49,8 +48,8 @@ func newTypeResolver(ctx *context.CompilerContext, pkg *ast.BLangPackage, import
 		ctx:             ctx,
 		tyCtx:           semtypes.ContextFrom(ctx.GetTypeEnv()),
 		importedSymbols: importedSymbols,
-		implicitImports: make(map[string]bool),
 		pkg:             pkg,
+		implicitImports: make(map[string]ast.BLangImportPackage),
 	}
 }
 
@@ -64,8 +63,38 @@ func ResolveTopLevelNodes(ctx *context.CompilerContext, pkg *ast.BLangPackage, i
 
 // ResolveLocalNodes resolves the types of function bodies and remaining inner nodes.
 func ResolveLocalNodes(ctx *context.CompilerContext, pkg *ast.BLangPackage, importedSymbols map[string]model.ExportedSymbolSpace) {
+	resolvers := make([]*TypeResolver, len(pkg.Functions))
+	var wg sync.WaitGroup
+	for i := range pkg.Functions {
+		fn := &pkg.Functions[i]
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			resolvers[idx] = resolveFunctionBody(ctx, pkg, fn, importedSymbols)
+		}(i)
+	}
+	wg.Wait()
+
+	seen := make(map[string]bool, len(resolvers))
+	for _, t := range resolvers {
+		for name, importNode := range t.implicitImports {
+			if !seen[name] {
+				seen[name] = true
+				pkg.Imports = append(pkg.Imports, importNode)
+			}
+		}
+	}
+}
+
+func resolveFunctionBody(ctx *context.CompilerContext, pkg *ast.BLangPackage, fn *ast.BLangFunction, importedSymbols map[string]model.ExportedSymbolSpace) *TypeResolver {
 	t := newTypeResolver(ctx, pkg, importedSymbols)
-	t.resolveInnerNodeTypes(pkg)
+	if body, ok := fn.Body.(*ast.BLangBlockFunctionBody); ok {
+		t.resolveBlockStatements(nil, body.Stmts)
+		body.SetDeterminedType(&semtypes.NEVER)
+	} else {
+		ctx.Unimplemented("unsupported function body kind", fn.Body.GetPosition())
+	}
+	return t
 }
 
 func (t *TypeResolver) resolveTopLevelTypes(ctx *context.CompilerContext, pkg *ast.BLangPackage) {
@@ -109,16 +138,6 @@ func (t *TypeResolver) resolveTopLevelTypes(ctx *context.CompilerContext, pkg *a
 	for _, defn := range pkg.TypeDefinitions {
 		if semtypes.IsEmpty(tctx, defn.DeterminedType) {
 			t.ctx.SemanticError(fmt.Sprintf("type definition %s is empty", defn.Name.GetValue()), defn.GetPosition())
-		}
-	}
-}
-
-func (t *TypeResolver) resolveInnerNodeTypes(pkg *ast.BLangPackage) {
-	for i := range pkg.Functions {
-		fn := &pkg.Functions[i]
-		if body, ok := fn.Body.(*ast.BLangBlockFunctionBody); ok {
-			t.resolveBlockStatements(nil, body.Stmts)
-			body.SetDeterminedType(&semtypes.NEVER)
 		}
 	}
 }
@@ -412,7 +431,6 @@ func (t *TypeResolver) resolveLiteral(n *ast.BLangLiteral) bool {
 		case int64:
 			ty = semtypes.IntConst(v)
 		case float64:
-			bType.BTypeSetTag(model.TypeTags_FLOAT)
 			ty = semtypes.FloatConst(v)
 		default:
 			t.ctx.InternalError(fmt.Sprintf("unexpected int literal value type: %T", n.GetValue()), n.GetPosition())
@@ -1509,15 +1527,14 @@ func (t *TypeResolver) resolveMethodCall(chain *binding, expr *ast.BLangInvocati
 		}
 		symbolSpace = space
 		pkgAlias = ast.BLangIdentifier{Value: pkgName}
-		if !t.implicitImports[pkgName] {
-			t.implicitImports[pkgName] = true
+		if _, exists := t.implicitImports[pkgName]; !exists {
 			importNode := ast.BLangImportPackage{
 				OrgName:      &ast.BLangIdentifier{Value: "ballerina"},
 				PkgNameComps: []ast.BLangIdentifier{{Value: "lang"}, {Value: "array"}},
 				Alias:        &pkgAlias,
 			}
 			ast.Walk(t, &importNode)
-			t.pkg.Imports = append(t.pkg.Imports, importNode)
+			t.implicitImports[pkgName] = importNode
 		}
 	} else if semtypes.IsSubtypeSimple(recieverTy, semtypes.INT) {
 		pkgName := bInt.PackageName
@@ -1528,15 +1545,14 @@ func (t *TypeResolver) resolveMethodCall(chain *binding, expr *ast.BLangInvocati
 		}
 		symbolSpace = space
 		pkgAlias = ast.BLangIdentifier{Value: pkgName}
-		if !t.implicitImports[pkgName] {
-			t.implicitImports[pkgName] = true
+		if _, exists := t.implicitImports[pkgName]; !exists {
 			importNode := ast.BLangImportPackage{
 				OrgName:      &ast.BLangIdentifier{Value: "ballerina"},
 				PkgNameComps: []ast.BLangIdentifier{{Value: "lang"}, {Value: "int"}},
 				Alias:        &pkgAlias,
 			}
 			ast.Walk(t, &importNode)
-			t.pkg.Imports = append(t.pkg.Imports, importNode)
+			t.implicitImports[pkgName] = importNode
 		}
 	} else {
 		t.ctx.Unimplemented("lang.value not implemented", expr.GetPosition())


### PR DESCRIPTION
## Purpose
$subject
Depends on #221




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrency safety in symbol handling and diagnostic recording to prevent race conditions.

* **Performance**
  * Parallelized per-function type resolution for faster overall compilation.

* **Refactor**
  * Consolidated import collection to avoid duplicates and simplified type-resolution flow for clearer, more reliable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->