### PR TITLE
Skip self-field-shadow test in integration

### DIFF
--- a/corpus/integration_test.go
+++ b/corpus/integration_test.go
@@ -84,6 +84,7 @@ var (
 		"subset6/06-object/inclusion-transitive-2-v.bal",
 		"subset6/06-object/init-error-return-v.bal",
 		"subset6/06-object/init-error-check-v.bal",
+		"subset6/06-object/self-field-shadow-e.bal",
 		// cast #139
 		"subset6/06-map/length2-v.bal",
 	}


### PR DESCRIPTION
## Purpose
Temporarily skip integration test for self-field-shadow due to syntax reporting bug. Related issue: #293.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**No user-facing changes.** This release includes internal test infrastructure updates.

* **Chores**
  * Updated test configuration to manage test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->