### PR TITLE
Fix multiline diagnostic snippet

### DIFF
--- a/cli/cmd/utils.go
+++ b/cli/cmd/utils.go
@@ -171,7 +171,7 @@ func printSourceSnippet(w io.Writer, s outputStyle, loc diagnosticLocation, fsys
 	}
 
 	for line := loc.startLine; line <= loc.endLine && line < len(lines); line++ {
-		lineContent := lines[line]
+		lineContent := strings.TrimSuffix(lines[line], "\r")
 		lineNumStr := fmt.Sprintf("%d", line+1)
 
 		startCol := 0
@@ -192,20 +192,16 @@ func printSourceSnippet(w io.Writer, s outputStyle, loc diagnosticLocation, fsys
 			endCol = len(lineContent)
 		}
 
-		var ok bool
 		var highlightLen int
-		startCol, _, highlightLen, ok = computeTrimmedCaretSpan(lineContent, startCol, endCol)
-		if !ok {
-			continue
-		}
+		startCol, _, highlightLen = computeTrimmedCaretSpan(lineContent, startCol, endCol)
 
-		_, _ = fmt.Fprintf(w, "%s%s |%s %s\n", s.cyan, lineNumStr, s.reset, lineContent)
+		_, _ = fmt.Fprintf(w, "%s%*s%s | %s\n", s.cyan, loc.numWidth, lineNumStr, s.reset, lineContent)
 		pointer := buildPointer(lineContent, startCol, highlightLen)
 		_, _ = fmt.Fprintf(w, "%*s %s| %s%s%s\n", loc.numWidth, "", s.cyan, severityColor, pointer, s.reset)
 	}
 }
 
-func computeTrimmedCaretSpan(lineContent string, startCol, endCol int) (trimStartCol, trimEndCol, highlightLen int, ok bool) {
+func computeTrimmedCaretSpan(lineContent string, startCol, endCol int) (trimStartCol, trimEndCol, highlightLen int) {
 	firstNonWS := -1
 	for i := 0; i < len(lineContent); i++ {
 		if lineContent[i] != ' ' && lineContent[i] != '\t' {
@@ -235,47 +231,30 @@ func computeTrimmedCaretSpan(lineContent string, startCol, endCol int) (trimStar
 	}
 
 	if !hasNonWS {
-		return startCol, startCol, 0, true
+		return startCol, startCol, 0
 	}
 
-	if hasNonWS {
-		if startCol < firstNonWS {
-			startCol = firstNonWS
-		}
-		if endCol > lastNonWS {
-			endCol = lastNonWS
-		}
-		if endCol < startCol {
-			endCol = startCol
-		}
+	if startCol < firstNonWS {
+		startCol = firstNonWS
+	}
+	if endCol > lastNonWS {
+		endCol = lastNonWS
+	}
+	if endCol < startCol {
+		endCol = startCol
 	}
 
 	highlightLen = endCol - startCol
 	maxHighlightLen := len(lineContent) - startCol
-	if maxHighlightLen < 1 {
-		if hasNonWS {
-			startCol = firstNonWS
-			endCol = firstNonWS + 1
-			highlightLen = 1
-			return startCol, endCol, highlightLen, true
-		}
-		return 0, 0, 0, false
-	}
-
-	if highlightLen < 1 {
-		if hasNonWS {
-			startCol = firstNonWS
-			endCol = firstNonWS + 1
-			highlightLen = 1
-			return startCol, endCol, highlightLen, true
-		}
-		return 0, 0, 0, false
+	if highlightLen < 1 || maxHighlightLen < 1 {
+		caretCol := startCol
+		return caretCol, caretCol + 1, 1
 	}
 
 	if highlightLen > maxHighlightLen {
 		highlightLen = maxHighlightLen
 	}
-	return startCol, endCol, highlightLen, true
+	return startCol, endCol, highlightLen
 }
 
 func buildPointer(lineContent string, startCol, highlightLen int) string {

--- a/cli/cmd/utils.go
+++ b/cli/cmd/utils.go
@@ -216,44 +216,13 @@ func computeTrimmedCaretSpan(lineContent string, startCol, endCol int) (trimStar
 			lastNonWS--
 		}
 	}
-
-	if startCol < 0 {
-		startCol = 0
-	}
-	if endCol < 0 {
-		endCol = 0
-	}
-	if startCol > len(lineContent) {
-		startCol = len(lineContent)
-	}
-	if endCol > len(lineContent) {
-		endCol = len(lineContent)
-	}
-
 	if !hasNonWS {
 		return startCol, startCol, 0
 	}
-
 	if startCol < firstNonWS {
 		startCol = firstNonWS
 	}
-	if endCol > lastNonWS {
-		endCol = lastNonWS
-	}
-	if endCol < startCol {
-		endCol = startCol
-	}
-
 	highlightLen = endCol - startCol
-	maxHighlightLen := len(lineContent) - startCol
-	if highlightLen < 1 || maxHighlightLen < 1 {
-		caretCol := startCol
-		return caretCol, caretCol + 1, 1
-	}
-
-	if highlightLen > maxHighlightLen {
-		highlightLen = maxHighlightLen
-	}
 	return startCol, endCol, highlightLen
 }
 

--- a/cli/cmd/utils.go
+++ b/cli/cmd/utils.go
@@ -92,20 +92,23 @@ type diagnosticLocation struct {
 	filePath            string
 	startLine, startCol int
 	endLine, endCol     int
-	lineNumStr          string
 	numWidth            int
 }
 
 func buildDiagnosticLocation(filePath string, startLine, startCol, endLine, endCol int) diagnosticLocation {
-	lineNumStr := fmt.Sprintf("%d", startLine+1)
+	startLineNumStr := fmt.Sprintf("%d", startLine+1)
+	endLineNumStr := fmt.Sprintf("%d", endLine+1)
+	numWidth := len(startLineNumStr)
+	if w := len(endLineNumStr); w > numWidth {
+		numWidth = w
+	}
 	return diagnosticLocation{
-		filePath:   filePath,
-		startLine:  startLine,
-		startCol:   startCol,
-		endLine:    endLine,
-		endCol:     endCol,
-		lineNumStr: lineNumStr,
-		numWidth:   len(lineNumStr),
+		filePath:  filePath,
+		startLine: startLine,
+		startCol:  startCol,
+		endLine:   endLine,
+		endCol:    endCol,
+		numWidth:  numWidth,
 	}
 }
 
@@ -166,17 +169,113 @@ func printSourceSnippet(w io.Writer, s outputStyle, loc diagnosticLocation, fsys
 	if loc.startLine >= len(lines) {
 		return
 	}
-	lineContent := lines[loc.startLine]
-	_, _ = fmt.Fprintf(w, "%s%s |%s %s\n", s.cyan, loc.lineNumStr, s.reset, lineContent)
-	highlightLen := loc.endCol - loc.startCol
-	if loc.startLine != loc.endLine {
-		highlightLen = len(lineContent) - loc.startCol
+
+	for line := loc.startLine; line <= loc.endLine && line < len(lines); line++ {
+		lineContent := lines[line]
+		lineNumStr := fmt.Sprintf("%d", line+1)
+
+		startCol := 0
+		var endCol int
+
+		switch {
+		case loc.startLine == loc.endLine:
+			startCol = loc.startCol
+			endCol = loc.endCol
+		case line == loc.startLine:
+			startCol = loc.startCol
+			endCol = len(lineContent)
+		case line == loc.endLine:
+			startCol = 0
+			endCol = loc.endCol
+		default:
+			startCol = 0
+			endCol = len(lineContent)
+		}
+
+		var ok bool
+		var highlightLen int
+		startCol, _, highlightLen, ok = computeTrimmedCaretSpan(lineContent, startCol, endCol)
+		if !ok {
+			continue
+		}
+
+		_, _ = fmt.Fprintf(w, "%s%s |%s %s\n", s.cyan, lineNumStr, s.reset, lineContent)
+		pointer := buildPointer(lineContent, startCol, highlightLen)
+		_, _ = fmt.Fprintf(w, "%*s %s| %s%s%s\n", loc.numWidth, "", s.cyan, severityColor, pointer, s.reset)
 	}
+}
+
+func computeTrimmedCaretSpan(lineContent string, startCol, endCol int) (trimStartCol, trimEndCol, highlightLen int, ok bool) {
+	firstNonWS := -1
+	for i := 0; i < len(lineContent); i++ {
+		if lineContent[i] != ' ' && lineContent[i] != '\t' {
+			firstNonWS = i
+			break
+		}
+	}
+	lastNonWS := len(lineContent)
+	hasNonWS := firstNonWS != -1
+	if hasNonWS {
+		for lastNonWS > firstNonWS && (lineContent[lastNonWS-1] == ' ' || lineContent[lastNonWS-1] == '\t') {
+			lastNonWS--
+		}
+	}
+
+	if startCol < 0 {
+		startCol = 0
+	}
+	if endCol < 0 {
+		endCol = 0
+	}
+	if startCol > len(lineContent) {
+		startCol = len(lineContent)
+	}
+	if endCol > len(lineContent) {
+		endCol = len(lineContent)
+	}
+
+	if !hasNonWS {
+		return startCol, startCol, 0, true
+	}
+
+	if hasNonWS {
+		if startCol < firstNonWS {
+			startCol = firstNonWS
+		}
+		if endCol > lastNonWS {
+			endCol = lastNonWS
+		}
+		if endCol < startCol {
+			endCol = startCol
+		}
+	}
+
+	highlightLen = endCol - startCol
+	maxHighlightLen := len(lineContent) - startCol
+	if maxHighlightLen < 1 {
+		if hasNonWS {
+			startCol = firstNonWS
+			endCol = firstNonWS + 1
+			highlightLen = 1
+			return startCol, endCol, highlightLen, true
+		}
+		return 0, 0, 0, false
+	}
+
 	if highlightLen < 1 {
-		highlightLen = 1
+		if hasNonWS {
+			startCol = firstNonWS
+			endCol = firstNonWS + 1
+			highlightLen = 1
+			return startCol, endCol, highlightLen, true
+		}
+		return 0, 0, 0, false
 	}
-	pointer := buildPointer(lineContent, loc.startCol, highlightLen)
-	_, _ = fmt.Fprintf(w, "%*s %s| %s%s%s\n", loc.numWidth, "", s.cyan, severityColor, pointer, s.reset)
+
+	if highlightLen > maxHighlightLen {
+		highlightLen = maxHighlightLen
+	}
+	return startCol, endCol, highlightLen, true
 }
 
 func buildPointer(lineContent string, startCol, highlightLen int) string {

--- a/corpus/diagnostic_printer.go
+++ b/corpus/diagnostic_printer.go
@@ -30,20 +30,23 @@ type diagnosticLocation struct {
 	filePath            string
 	startLine, startCol int
 	endLine, endCol     int
-	lineNumStr          string
 	numWidth            int
 }
 
 func buildDiagnosticLocation(filePath string, startLine, startCol, endLine, endCol int) diagnosticLocation {
-	lineNumStr := fmt.Sprintf("%d", startLine+1)
+	startLineNumStr := fmt.Sprintf("%d", startLine+1)
+	endLineNumStr := fmt.Sprintf("%d", endLine+1)
+	numWidth := len(startLineNumStr)
+	if w := len(endLineNumStr); w > numWidth {
+		numWidth = w
+	}
 	return diagnosticLocation{
-		filePath:   filePath,
-		startLine:  startLine,
-		startCol:   startCol,
-		endLine:    endLine,
-		endCol:     endCol,
-		lineNumStr: lineNumStr,
-		numWidth:   len(lineNumStr),
+		filePath:  filePath,
+		startLine: startLine,
+		startCol:  startCol,
+		endLine:   endLine,
+		endCol:    endCol,
+		numWidth:  numWidth,
 	}
 }
 
@@ -102,17 +105,113 @@ func printSourceSnippet(w io.Writer, loc diagnosticLocation, fsys fs.FS) {
 	if loc.startLine >= len(lines) {
 		return
 	}
-	lineContent := lines[loc.startLine]
-	_, _ = fmt.Fprintf(w, "%s | %s\n", loc.lineNumStr, lineContent)
-	highlightLen := loc.endCol - loc.startCol
-	if loc.startLine != loc.endLine {
-		highlightLen = len(lineContent) - loc.startCol
+
+	for line := loc.startLine; line <= loc.endLine && line < len(lines); line++ {
+		lineContent := lines[line]
+		lineNumStr := fmt.Sprintf("%d", line+1)
+
+		startCol := 0
+		var endCol int
+
+		switch {
+		case loc.startLine == loc.endLine:
+			startCol = loc.startCol
+			endCol = loc.endCol
+		case line == loc.startLine:
+			startCol = loc.startCol
+			endCol = len(lineContent)
+		case line == loc.endLine:
+			startCol = 0
+			endCol = loc.endCol
+		default:
+			startCol = 0
+			endCol = len(lineContent)
+		}
+
+		var ok bool
+		var highlightLen int
+		startCol, _, highlightLen, ok = computeTrimmedCaretSpan(lineContent, startCol, endCol)
+		if !ok {
+			continue
+		}
+
+		_, _ = fmt.Fprintf(w, "%s | %s\n", lineNumStr, lineContent)
+		pointer := buildPointer(lineContent, startCol, highlightLen)
+		_, _ = fmt.Fprintf(w, "%*s | %s\n", loc.numWidth, "", pointer)
 	}
+}
+
+func computeTrimmedCaretSpan(lineContent string, startCol, endCol int) (trimStartCol, trimEndCol, highlightLen int, ok bool) {
+	firstNonWS := -1
+	for i := 0; i < len(lineContent); i++ {
+		if lineContent[i] != ' ' && lineContent[i] != '\t' {
+			firstNonWS = i
+			break
+		}
+	}
+	lastNonWS := len(lineContent)
+	hasNonWS := firstNonWS != -1
+	if hasNonWS {
+		for lastNonWS > firstNonWS && (lineContent[lastNonWS-1] == ' ' || lineContent[lastNonWS-1] == '\t') {
+			lastNonWS--
+		}
+	}
+
+	if startCol < 0 {
+		startCol = 0
+	}
+	if endCol < 0 {
+		endCol = 0
+	}
+	if startCol > len(lineContent) {
+		startCol = len(lineContent)
+	}
+	if endCol > len(lineContent) {
+		endCol = len(lineContent)
+	}
+
+	if !hasNonWS {
+		return startCol, startCol, 0, true
+	}
+
+	if hasNonWS {
+		if startCol < firstNonWS {
+			startCol = firstNonWS
+		}
+		if endCol > lastNonWS {
+			endCol = lastNonWS
+		}
+		if endCol < startCol {
+			endCol = startCol
+		}
+	}
+
+	highlightLen = endCol - startCol
+	maxHighlightLen := len(lineContent) - startCol
+	if maxHighlightLen < 1 {
+		if hasNonWS {
+			startCol = firstNonWS
+			endCol = firstNonWS + 1
+			highlightLen = 1
+			return startCol, endCol, highlightLen, true
+		}
+		return 0, 0, 0, false
+	}
+
 	if highlightLen < 1 {
-		highlightLen = 1
+		if hasNonWS {
+			startCol = firstNonWS
+			endCol = firstNonWS + 1
+			highlightLen = 1
+			return startCol, endCol, highlightLen, true
+		}
+		return 0, 0, 0, false
 	}
-	pointer := buildPointer(lineContent, loc.startCol, highlightLen)
-	_, _ = fmt.Fprintf(w, "%*s | %s\n", loc.numWidth, "", pointer)
+
+	if highlightLen > maxHighlightLen {
+		highlightLen = maxHighlightLen
+	}
+	return startCol, endCol, highlightLen, true
 }
 
 func buildPointer(lineContent string, startCol, highlightLen int) string {

--- a/corpus/diagnostic_printer.go
+++ b/corpus/diagnostic_printer.go
@@ -152,44 +152,13 @@ func computeTrimmedCaretSpan(lineContent string, startCol, endCol int) (trimStar
 			lastNonWS--
 		}
 	}
-
-	if startCol < 0 {
-		startCol = 0
-	}
-	if endCol < 0 {
-		endCol = 0
-	}
-	if startCol > len(lineContent) {
-		startCol = len(lineContent)
-	}
-	if endCol > len(lineContent) {
-		endCol = len(lineContent)
-	}
-
 	if !hasNonWS {
 		return startCol, startCol, 0
 	}
-
 	if startCol < firstNonWS {
 		startCol = firstNonWS
 	}
-	if endCol > lastNonWS {
-		endCol = lastNonWS
-	}
-	if endCol < startCol {
-		endCol = startCol
-	}
-
 	highlightLen = endCol - startCol
-	maxHighlightLen := len(lineContent) - startCol
-	if highlightLen < 1 || maxHighlightLen < 1 {
-		caretCol := startCol
-		return caretCol, caretCol + 1, 1
-	}
-
-	if highlightLen > maxHighlightLen {
-		highlightLen = maxHighlightLen
-	}
 	return startCol, endCol, highlightLen
 }
 

--- a/corpus/diagnostic_printer.go
+++ b/corpus/diagnostic_printer.go
@@ -107,7 +107,7 @@ func printSourceSnippet(w io.Writer, loc diagnosticLocation, fsys fs.FS) {
 	}
 
 	for line := loc.startLine; line <= loc.endLine && line < len(lines); line++ {
-		lineContent := lines[line]
+		lineContent := strings.TrimSuffix(lines[line], "\r")
 		lineNumStr := fmt.Sprintf("%d", line+1)
 
 		startCol := 0
@@ -128,20 +128,16 @@ func printSourceSnippet(w io.Writer, loc diagnosticLocation, fsys fs.FS) {
 			endCol = len(lineContent)
 		}
 
-		var ok bool
 		var highlightLen int
-		startCol, _, highlightLen, ok = computeTrimmedCaretSpan(lineContent, startCol, endCol)
-		if !ok {
-			continue
-		}
+		startCol, _, highlightLen = computeTrimmedCaretSpan(lineContent, startCol, endCol)
 
-		_, _ = fmt.Fprintf(w, "%s | %s\n", lineNumStr, lineContent)
+		_, _ = fmt.Fprintf(w, "%*s | %s\n", loc.numWidth, lineNumStr, lineContent)
 		pointer := buildPointer(lineContent, startCol, highlightLen)
 		_, _ = fmt.Fprintf(w, "%*s | %s\n", loc.numWidth, "", pointer)
 	}
 }
 
-func computeTrimmedCaretSpan(lineContent string, startCol, endCol int) (trimStartCol, trimEndCol, highlightLen int, ok bool) {
+func computeTrimmedCaretSpan(lineContent string, startCol, endCol int) (trimStartCol, trimEndCol, highlightLen int) {
 	firstNonWS := -1
 	for i := 0; i < len(lineContent); i++ {
 		if lineContent[i] != ' ' && lineContent[i] != '\t' {
@@ -171,47 +167,30 @@ func computeTrimmedCaretSpan(lineContent string, startCol, endCol int) (trimStar
 	}
 
 	if !hasNonWS {
-		return startCol, startCol, 0, true
+		return startCol, startCol, 0
 	}
 
-	if hasNonWS {
-		if startCol < firstNonWS {
-			startCol = firstNonWS
-		}
-		if endCol > lastNonWS {
-			endCol = lastNonWS
-		}
-		if endCol < startCol {
-			endCol = startCol
-		}
+	if startCol < firstNonWS {
+		startCol = firstNonWS
+	}
+	if endCol > lastNonWS {
+		endCol = lastNonWS
+	}
+	if endCol < startCol {
+		endCol = startCol
 	}
 
 	highlightLen = endCol - startCol
 	maxHighlightLen := len(lineContent) - startCol
-	if maxHighlightLen < 1 {
-		if hasNonWS {
-			startCol = firstNonWS
-			endCol = firstNonWS + 1
-			highlightLen = 1
-			return startCol, endCol, highlightLen, true
-		}
-		return 0, 0, 0, false
-	}
-
-	if highlightLen < 1 {
-		if hasNonWS {
-			startCol = firstNonWS
-			endCol = firstNonWS + 1
-			highlightLen = 1
-			return startCol, endCol, highlightLen, true
-		}
-		return 0, 0, 0, false
+	if highlightLen < 1 || maxHighlightLen < 1 {
+		caretCol := startCol
+		return caretCol, caretCol + 1, 1
 	}
 
 	if highlightLen > maxHighlightLen {
 		highlightLen = maxHighlightLen
 	}
-	return startCol, endCol, highlightLen, true
+	return startCol, endCol, highlightLen
 }
 
 func buildPointer(lineContent string, startCol, highlightLen int) string {

--- a/corpus/integration/subset1/01-function/return6-e.txtar
+++ b/corpus/integration/subset1/01-function/return6-e.txtar
@@ -5,3 +5,7 @@ error[SEMANTIC_ERROR]: missing return statement
    |
 24 | function foo() returns boolean {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+25 |      
+   | 
+26 | } // @error
+   | ^

--- a/corpus/integration/subset2/02-function/main1-e.txtar
+++ b/corpus/integration/subset2/02-function/main1-e.txtar
@@ -5,3 +5,7 @@ error[SEMANTIC_ERROR]: 'main' function must be public
    |
 19 | function main() { // @error
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+20 |     io:println(1);
+   |     ^^^^^^^^^^^^^^
+21 | }
+   | ^

--- a/corpus/integration/subset2/02-function/main2-e.txtar
+++ b/corpus/integration/subset2/02-function/main2-e.txtar
@@ -5,3 +5,9 @@ error[SEMANTIC_ERROR]: 'main' function must have return type 'error?'
    |
 20 | public function main() returns int { // @error
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+21 |     io:println(1);
+   |     ^^^^^^^^^^^^^^
+22 |     return 0;
+   |     ^^^^^^^^^
+23 | }
+   | ^

--- a/corpus/integration/subset5/05-match/exhaustive2-e.txtar
+++ b/corpus/integration/subset5/05-match/exhaustive2-e.txtar
@@ -5,9 +5,17 @@ error[SEMANTIC_ERROR]: unmatchable match clause
    |
 27 |         2 => { // @error
    |         ^^^^^^^^^^^^^^^^
+28 |             io:println("2");
+   |             ^^^^^^^^^^^^^^^^
+29 |         }
+   |         ^
 
 error[SEMANTIC_ERROR]: unreachable match clause
   --> exhaustive2-e.bal:27:9
    |
 27 |         2 => { // @error
    |         ^^^^^^^^^^^^^^^^
+28 |             io:println("2");
+   |             ^^^^^^^^^^^^^^^^
+29 |         }
+   |         ^

--- a/corpus/integration/subset5/05-match/exhaustive3-e.txtar
+++ b/corpus/integration/subset5/05-match/exhaustive3-e.txtar
@@ -5,3 +5,7 @@ error[SEMANTIC_ERROR]: unmatchable match clause
    |
 27 |         "any" => { // @error
    |         ^^^^^^^^^^^^^^^^^^^^
+28 |             io:println("any");
+   |             ^^^^^^^^^^^^^^^^^^
+29 |         }
+   |         ^

--- a/corpus/integration/subset5/05-record/inclusion-cycle-e.txtar
+++ b/corpus/integration/subset5/05-record/inclusion-cycle-e.txtar
@@ -5,3 +5,9 @@ error[SEMANTIC_ERROR]: invalid cycle detected for type definition A
    |
 18 | type A record {| // @error
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+19 |     *B;
+   |     ^^^
+20 |     int x;
+   |     ^^^^^^
+21 | |};
+   | ^^^

--- a/corpus/integration/subset5/05-record/inclusion-dup-e.txtar
+++ b/corpus/integration/subset5/05-record/inclusion-dup-e.txtar
@@ -5,3 +5,9 @@ error[SEMANTIC_ERROR]: included field 'x' declared in multiple type inclusions m
    |
 26 | type R3 record {|
    |         ^^^^^^^^^
+27 |     *R1;
+   |     ^^^^
+28 |     *R2; // @error
+   |     ^^^^^^^^^^^^^^
+29 | |};
+   | ^^

--- a/corpus/integration/subset5/05-record/inclusion-rest-conflict-e.txtar
+++ b/corpus/integration/subset5/05-record/inclusion-rest-conflict-e.txtar
@@ -5,3 +5,9 @@ error[SEMANTIC_ERROR]: included rest type declared in multiple type inclusions m
    |
 28 | type R3 record {|
    |         ^^^^^^^^^
+29 |     *R1;
+   |     ^^^^
+30 |     *R2; // @error
+   |     ^^^^^^^^^^^^^^
+31 | |};
+   | ^^

--- a/corpus/integration/subset5/05-record/inclusion-self-e.txtar
+++ b/corpus/integration/subset5/05-record/inclusion-self-e.txtar
@@ -5,3 +5,9 @@ error[SEMANTIC_ERROR]: invalid cycle detected for type definition R1
    |
 18 | type R1 record {| // @error
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+19 |     *R1;
+   |     ^^^^
+20 |     int x;
+   |     ^^^^^^
+21 | |};
+   | ^^^

--- a/corpus/integration/subset6/06-object/inclusion-cycle-e.txtar
+++ b/corpus/integration/subset6/06-object/inclusion-cycle-e.txtar
@@ -5,9 +5,21 @@ error[SEMANTIC_ERROR]: cyclic type inclusion
    |
 17 | type A object { // @error
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
+18 |     *B;
+   |     ^^^
+19 |     int x;
+   |     ^^^^^^
+20 | };
+   | ^^
 
 error[SEMANTIC_ERROR]: cyclic type inclusion
   --> inclusion-cycle-e.bal:22:1
    |
 22 | type B object {
    | ^^^^^^^^^^^^^^^
+23 |     *A;
+   |     ^^^
+24 |     int y;
+   |     ^^^^^^
+25 | };
+   | ^^

--- a/corpus/integration/subset6/06-object/inclusion-dup-field-class-e.txtar
+++ b/corpus/integration/subset6/06-object/inclusion-dup-field-class-e.txtar
@@ -5,3 +5,11 @@ error[SEMANTIC_ERROR]: included field 'x' declared in multiple type inclusions m
    |
 25 | class Bar { // @error
    | ^^^^^^^^^^^^^^^^^^^^^
+26 |     *Foo;
+   |     ^^^^^
+27 |     *Baz;
+   |     ^^^^^
+28 |     function init() {}
+   |     ^^^^^^^^^^^^^^^^^^
+29 | }
+   | ^

--- a/corpus/integration/subset6/06-object/inclusion-dup-field-obj-e.txtar
+++ b/corpus/integration/subset6/06-object/inclusion-dup-field-obj-e.txtar
@@ -5,3 +5,9 @@ error[SEMANTIC_ERROR]: included member 'x' declared in multiple type inclusions 
    |
 25 | type Bar object { // @error
    |          ^^^^^^^^^^^^^^^^^^
+26 |     *Foo;
+   |     ^^^^^
+27 |     *Baz;
+   |     ^^^^^
+28 | };
+   | ^

--- a/corpus/integration/subset6/06-object/inclusion-dup-subtype-e.txtar
+++ b/corpus/integration/subset6/06-object/inclusion-dup-subtype-e.txtar
@@ -5,3 +5,11 @@ error[SEMANTIC_ERROR]: member 'x' that overrides included member is not a subtyp
    |
 25 | type Bar object { // @error
    |          ^^^^^^^^^^^^^^^^^^
+26 |     *Foo;
+   |     ^^^^^
+27 |     *Baz;
+   |     ^^^^^
+28 |     string x;
+   |     ^^^^^^^^^
+29 | };
+   | ^

--- a/corpus/integration/subset6/06-object/inclusion-missing-override-e.txtar
+++ b/corpus/integration/subset6/06-object/inclusion-missing-override-e.txtar
@@ -5,3 +5,9 @@ error[SEMANTIC_ERROR]: included method 'getX' must be overridden in class defini
    |
 22 | class Bar { // @error
    | ^^^^^^^^^^^^^^^^^^^^^
+23 |     *Foo;
+   |     ^^^^^
+24 |     function init() {}
+   |     ^^^^^^^^^^^^^^^^^^
+25 | }
+   | ^

--- a/corpus/integration/subset6/06-object/inclusion-subtype-e.txtar
+++ b/corpus/integration/subset6/06-object/inclusion-subtype-e.txtar
@@ -5,3 +5,9 @@ error[SEMANTIC_ERROR]: member 'x' that overrides included member is not a subtyp
    |
 21 | type Bar object { // @error
    |          ^^^^^^^^^^^^^^^^^^
+22 |     *Foo;
+   |     ^^^^^
+23 |     string x;
+   |     ^^^^^^^^^
+24 | };
+   | ^

--- a/corpus/integration/subset6/06-object/infiniteObject-e.txtar
+++ b/corpus/integration/subset6/06-object/infiniteObject-e.txtar
@@ -5,3 +5,9 @@ error[SEMANTIC_ERROR]: type definition O is empty
    |
 17 | type O object { // @error
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
+18 |     public O foo;
+   |     ^^^^^^^^^^^^^
+19 |     public int bar;
+   |     ^^^^^^^^^^^^^^^
+20 | };
+   | ^^

--- a/corpus/integration/subset6/06-object/method-missing-return-e.txtar
+++ b/corpus/integration/subset6/06-object/method-missing-return-e.txtar
@@ -5,3 +5,5 @@ error[SEMANTIC_ERROR]: missing return statement
    |
 21 |     function bar() returns int {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+22 |     } // @error
+   |     ^

--- a/corpus/integration/subset7/07-closure/unnarrow6-e.txtar
+++ b/corpus/integration/subset7/07-closure/unnarrow6-e.txtar
@@ -5,3 +5,9 @@ error[SEMANTIC_ERROR]: union types not supported for +
    |
 26 |         int res = runner(function(int a) returns int {
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+27 |                     v1 = true;
+   |                     ^^^^^^^^^^
+28 |                     return 5;
+   |                     ^^^^^^^^^
+29 |                   }, 2) + v1; // @error
+   |                   ^^^^^^^^^^

--- a/corpus/integration/subset7/07-syntax-errors/missing-iden-e.txtar
+++ b/corpus/integration/subset7/07-syntax-errors/missing-iden-e.txtar
@@ -4,22 +4,22 @@ error[SYNTAX_ERROR]: missing identifier
   --> missing-iden-e.bal:24:18
    |
 24 |     int[] arr = [, , 3];
-   |                  ^
+   |
 
 error[SYNTAX_ERROR]: missing identifier
   --> missing-iden-e.bal:24:20
    |
 24 |     int[] arr = [, , 3];
-   |                    ^
+   |
 
 error[SYNTAX_ERROR]: missing identifier
   --> missing-iden-e.bal:27:22
    |
 27 |     int result = add(,);
-   |                      ^
+   |
 
 error[SYNTAX_ERROR]: missing identifier
   --> missing-iden-e.bal:27:23
    |
 27 |     int result = add(,);
-   |                       ^
+   |

--- a/corpus/integration/subset7/07-syntax-errors/return-e.txtar
+++ b/corpus/integration/subset7/07-syntax-errors/return-e.txtar
@@ -4,4 +4,4 @@ error[SYNTAX_ERROR]: missing semicolon token
   --> return-e.bal:19:39
    |
 19 | function add(int a, int b) return int {
-   |                                       ^
+   |


### PR DESCRIPTION
## Purpose
Resolves #310
Depends on #264 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Diagnostics now render multi-line source context for ranged errors with per-line numbers and aligned pointers.
  * Highlighting is clamped to line bounds, trims surrounding whitespace, guarantees a minimal caret when needed, and skips invalid empty spans.

* **Tests**
  * Numerous diagnostic expectation fixtures updated to reflect expanded per-line spans (including inner statements and closing braces).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->