### PR TITLE
Skip corpus tests for unimplemented parser features

### DIFF
--- a/parser/corpus_parser_test.go
+++ b/parser/corpus_parser_test.go
@@ -330,7 +330,11 @@ func parseFile(t *testing.T, testCase test_util.TestCase) {
 	// Catch any panics and convert them to errors
 	defer func() {
 		if r := recover(); r != nil {
-			t.Fatalf("panic: %v", r)
+			if msg, ok := r.(string); ok && strings.HasSuffix(msg, "parser not implemented") {
+				t.Skipf("Skipping file due to unimplemented parser feature: %s", testCase.InputPath)
+			} else {
+				t.Fatalf("panic: %v", r)
+			}
 		}
 	}()
 


### PR DESCRIPTION
## Summary
- Convert panics with "parser not implemented" suffix to test skips instead of fatal failures
- Preserves existing fatal behavior for all other panics

## Test plan
- [ ] Run `go test ./parser/...` and verify unimplemented parser tests are skipped, not failed
- [ ] Verify other panics still cause test failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test behavior for unimplemented parser cases, allowing tests to skip gracefully rather than fail when parser functionality is not yet available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->