### PR TITLE
Increase native CI timeouts

### DIFF
--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           mkdir -p .cover/cli_executable
           BAL_GOCOVERDIR="$PWD/.cover/cli_executable" \
-            go test -race -count=1 -skip 'TestParseCorpusFiles|TestJBalUnitTests|TestJBalUnitBIRTests' -coverpkg=./... -coverprofile=coverage.out -covermode=atomic ./...
+            go test -race -count=1 -timeout 30m -skip 'TestParseCorpusFiles|TestJBalUnitTests|TestJBalUnitBIRTests' -coverpkg=./... -coverprofile=coverage.out -covermode=atomic ./...
           go tool covdata textfmt -i=.cover/cli_executable -o=coverage-cli-executable.out
 
       - name: Upload coverage to Codecov
@@ -55,4 +55,4 @@ jobs:
           go-version: '1.26'
 
       - name: Run tests
-        run: go test -race -count=1 -skip 'TestParseCorpusFiles|TestJBalUnitTests|TestJBalUnitBIRTests' ./...
+        run: go test -race -count=1 -timeout 30m -skip 'TestParseCorpusFiles|TestJBalUnitTests|TestJBalUnitBIRTests' ./...

--- a/.github/workflows/wasm-ci.yml
+++ b/.github/workflows/wasm-ci.yml
@@ -23,4 +23,4 @@ jobs:
         run: |
           export GOOS=js
           export GOARCH=wasm
-          go test -skip 'TestParseCorpusFiles|TestJBalUnitTests|TestJBalUnitBIRTests' -timeout 5m ./... -exec="$(go env GOROOT)/lib/wasm/go_js_wasm_exec"
+          go test -skip 'TestParseCorpusFiles|TestJBalUnitTests|TestJBalUnitBIRTests' -timeout 30m ./... -exec="$(go env GOROOT)/lib/wasm/go_js_wasm_exec"


### PR DESCRIPTION
## Purpose
Given we run native tests with race detection they will take a while to complete with more and more tests



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI configuration for test execution reliability.

**Note:** This release contains internal infrastructure improvements only. No end-user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->