### PR TITLE
Remove leaking information about type resolution using the env.typeDefns map

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -360,6 +360,7 @@ type (
 		CompletedPhases         common.UnorderedSet[CompilerPhase]
 		LambdaFunctions         []BLangLambdaFunction
 		PackageID               *model.PackageID
+		Scope                   model.Scope
 		diagnostics             []diagnostics.Diagnostic
 		ModuleContextDataHolder *ModuleContextDataHolder
 		errorCount              int

--- a/ast/expressions.go
+++ b/ast/expressions.go
@@ -323,9 +323,9 @@ type (
 
 	BLangMappingConstructorExpr struct {
 		bLangExpressionBase
-		Fields                   []model.MappingField
-		AtomicType               semtypes.MappingAtomicType
-		ContextuallyExpectedType BType
+		Fields        []model.MappingField
+		AtomicType    semtypes.MappingAtomicType
+		FieldDefaults []model.FieldDefault
 	}
 
 	BLangNamedArgsExpression struct {

--- a/ast/types.go
+++ b/ast/types.go
@@ -90,7 +90,7 @@ type (
 
 	bStructureTypeBase struct {
 		names          []string
-		fields         []BField
+		fields         []BField // This is only directly included fields, not those included via type inclusions
 		TypeInclusions []BType
 	}
 
@@ -181,6 +181,7 @@ type (
 	BLangRecordType struct {
 		bLangTypeBase
 		bStructureTypeBase
+		Inclusions []model.SymbolRef
 		Definition semtypes.Definition
 		RestType   BType
 		IsOpen     bool

--- a/bir/bir_gen.go
+++ b/bir/bir_gen.go
@@ -824,15 +824,11 @@ func mappingConstructorExpression(ctx *stmtContext, curBB *BIRBasicBlock, expr *
 		}
 	}
 	var defaults []MappingConstructorDefaultEntry
-	if recType, ok := expr.ContextuallyExpectedType.(*ast.BLangRecordType); ok {
-		for fieldName, field := range recType.FieldPtrs() {
-			if field.DefaultExpr != nil {
-				defaults = append(defaults, MappingConstructorDefaultEntry{
-					FieldName:         fieldName,
-					FunctionLookupKey: buildFunctionLookupKeyFromSymbol(ctx.birCx, field.DefaultFnRef),
-				})
-			}
-		}
+	for _, fd := range expr.FieldDefaults {
+		defaults = append(defaults, MappingConstructorDefaultEntry{
+			FieldName:         fd.FieldName,
+			FunctionLookupKey: buildFunctionLookupKeyFromSymbol(ctx.birCx, fd.FnRef),
+		})
 	}
 	return mappingConstructorExpressionInner(ctx, curBB, expr.GetDeterminedType(), fields, defaults, expr.GetPosition())
 }

--- a/context/context.go
+++ b/context/context.go
@@ -118,14 +118,6 @@ func (this *CompilerContext) SetSymbolType(symbol model.SymbolRef, ty semtypes.S
 	this.GetSymbol(symbol).SetType(ty)
 }
 
-func (this *CompilerContext) SetTypeDefinition(symbol model.SymbolRef, defn model.TypeDefinition) {
-	this.env.SetTypeDefinition(symbol, defn)
-}
-
-func (this *CompilerContext) GetTypeDefinition(symbol model.SymbolRef) (model.TypeDefinition, bool) {
-	return this.env.GetTypeDefinition(symbol)
-}
-
 func (this *CompilerContext) GetDefaultPackage() *model.PackageID {
 	return this.env.GetDefaultPackage()
 }

--- a/context/env.go
+++ b/context/env.go
@@ -32,7 +32,6 @@ type CompilerEnvironment struct {
 	symbolSpacesMu   sync.RWMutex // we need this because desugaring add new init functions concurrently we shouldn't need this if the spaces are scoped to the module, may be we should do that?
 	typeEnv          semtypes.Env
 	underlyingSymbol sync.Map
-	typeDefns        map[model.SymbolRef]model.TypeDefinition
 	statsEnabled     bool
 }
 
@@ -137,22 +136,12 @@ func (this *CompilerEnvironment) NewPackageID(orgName model.Name, nameComps []mo
 	return model.NewPackageID(this.packageInterner, orgName, nameComps, version)
 }
 
-func (this *CompilerEnvironment) SetTypeDefinition(symbol model.SymbolRef, defn model.TypeDefinition) {
-	this.typeDefns[symbol] = defn
-}
-
-func (this *CompilerEnvironment) GetTypeDefinition(symbol model.SymbolRef) (model.TypeDefinition, bool) {
-	defn, ok := this.typeDefns[symbol]
-	return defn, ok
-}
-
 func NewCompilerEnvironment(typeEnv semtypes.Env, statsEnabled bool) *CompilerEnvironment {
 	return &CompilerEnvironment{
 		anonTypeCount:   make(map[*model.PackageID]int),
 		anonFuncCount:   make(map[*model.PackageID]int),
 		packageInterner: model.DefaultPackageIDInterner,
 		typeEnv:         typeEnv,
-		typeDefns:       make(map[model.SymbolRef]model.TypeDefinition),
 		statsEnabled:    statsEnabled,
 	}
 }

--- a/corpus/ast/subset7/07-record/inclusion-default-v.txt
+++ b/corpus/ast/subset7/07-record/inclusion-default-v.txt
@@ -1,0 +1,107 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (type-definition Base
+    (record-type
+      (field x
+        (value-type int)
+        (literal 10))
+      (field y
+        (value-type string)
+        (literal hello))))
+  (type-definition Inherited
+    (record-type
+      (field z
+        (value-type string))))
+  (type-definition OverriddenWithNewDefault
+    (record-type
+      (field x
+        (value-type int)
+        (literal 42))
+      (field z
+        (value-type string))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable r1 (type
+          (user-defined-type Inherited)) (expr
+          (mapping-constructor-expr
+            (key-value
+              (simple-var-ref z)
+              (literal world))))))
+      (expression-stmt
+        (invocation io println (
+          (field-based-access x
+            (simple-var-ref r1)))))
+      (expression-stmt
+        (invocation io println (
+          (field-based-access y
+            (simple-var-ref r1)))))
+      (expression-stmt
+        (invocation io println (
+          (field-based-access z
+            (simple-var-ref r1)))))
+      (var-def
+        (variable r2 (type
+          (user-defined-type Inherited)) (expr
+          (mapping-constructor-expr
+            (key-value
+              (simple-var-ref x)
+              (literal 5))
+            (key-value
+              (simple-var-ref z)
+              (literal world))))))
+      (expression-stmt
+        (invocation io println (
+          (field-based-access x
+            (simple-var-ref r2)))))
+      (expression-stmt
+        (invocation io println (
+          (field-based-access y
+            (simple-var-ref r2)))))
+      (expression-stmt
+        (invocation io println (
+          (field-based-access z
+            (simple-var-ref r2)))))
+      (var-def
+        (variable r3 (type
+          (user-defined-type OverriddenWithNewDefault)) (expr
+          (mapping-constructor-expr
+            (key-value
+              (simple-var-ref z)
+              (literal test))))))
+      (expression-stmt
+        (invocation io println (
+          (field-based-access x
+            (simple-var-ref r3)))))
+      (expression-stmt
+        (invocation io println (
+          (field-based-access y
+            (simple-var-ref r3)))))
+      (expression-stmt
+        (invocation io println (
+          (field-based-access z
+            (simple-var-ref r3)))))
+      (var-def
+        (variable r4 (type
+          (user-defined-type OverriddenWithNewDefault)) (expr
+          (mapping-constructor-expr
+            (key-value
+              (simple-var-ref x)
+              (literal 99))
+            (key-value
+              (simple-var-ref z)
+              (literal test))))))
+      (expression-stmt
+        (invocation io println (
+          (field-based-access x
+            (simple-var-ref r4)))))
+      (expression-stmt
+        (invocation io println (
+          (field-based-access y
+            (simple-var-ref r4)))))
+      (expression-stmt
+        (invocation io println (
+          (field-based-access z
+            (simple-var-ref r4))))))))

--- a/corpus/bal/subset7/07-record/inclusion-default-e.bal
+++ b/corpus/bal/subset7/07-record/inclusion-default-e.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+type Base record {|
+    int x = 10;
+    string y = "hello";
+|};
+
+type OverriddenWithoutDefault record {|
+    *Base;
+    int x;
+    string z;
+|};
+
+public function main() {
+    OverriddenWithoutDefault r = {z: "world"}; // @error
+    io:println(r);
+}

--- a/corpus/bal/subset7/07-record/inclusion-default-v.bal
+++ b/corpus/bal/subset7/07-record/inclusion-default-v.bal
@@ -1,0 +1,55 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+type Base record {|
+    int x = 10;
+    string y = "hello";
+|};
+
+type Inherited record {|
+    *Base;
+    string z;
+|};
+
+type OverriddenWithNewDefault record {|
+    *Base;
+    int x = 42;
+    string z;
+|};
+
+public function main() {
+    Inherited r1 = {z: "world"};
+    io:println(r1.x); // @output 10
+    io:println(r1.y); // @output hello
+    io:println(r1.z); // @output world
+
+    Inherited r2 = {x: 5, z: "world"};
+    io:println(r2.x); // @output 5
+    io:println(r2.y); // @output hello
+    io:println(r2.z); // @output world
+
+    OverriddenWithNewDefault r3 = {z: "test"};
+    io:println(r3.x); // @output 42
+    io:println(r3.y); // @output hello
+    io:println(r3.z); // @output test
+
+    OverriddenWithNewDefault r4 = {x: 99, z: "test"};
+    io:println(r4.x); // @output 99
+    io:println(r4.y); // @output hello
+    io:println(r4.z); // @output test
+}

--- a/corpus/bir/subset7/07-record/3-v.txt
+++ b/corpus/bir/subset7/07-record/3-v.txt
@@ -10,7 +10,7 @@ $desugar$0() -> int{
 main() -> nil{
   bb0 {
     %1 = fp $anon/.:$desugar$0
-    $desugar$1 = %1;
+    $desugar$0 = %1;
     %3 = newMap {| value: int, never... |}{} defaults{value=$anon/.:$desugar$0}
     f = %3;
     %6 = ConstantLoad value

--- a/corpus/bir/subset7/07-record/5-v.txt
+++ b/corpus/bir/subset7/07-record/5-v.txt
@@ -6,15 +6,33 @@ $desugar$0() -> int{
     return;
   }
 }
-$desugar$2() -> int{
+$desugar$1() -> int{
   bb0 {
     %0 = (1, c);
     return;
   }
 }
-$desugar$3() -> string{
+$desugar$2() -> string{
   bb0 {
     %0 = (1, s);
+    return;
+  }
+}
+$desugar$3() -> int{
+  bb0 {
+    %0 = (1, c);
+    return;
+  }
+}
+$desugar$4() -> string{
+  bb0 {
+    %0 = (1, s);
+    return;
+  }
+}
+$desugar$5() -> int{
+  bb0 {
+    %0 = (1, c);
     return;
   }
 }
@@ -30,31 +48,13 @@ $desugar$7() -> string{
     return;
   }
 }
-$desugar$10() -> int{
+$desugar$8() -> int{
   bb0 {
     %0 = (1, c);
     return;
   }
 }
-$desugar$12() -> int{
-  bb0 {
-    %0 = (1, c);
-    return;
-  }
-}
-$desugar$13() -> string{
-  bb0 {
-    %0 = (1, s);
-    return;
-  }
-}
-$desugar$16() -> int{
-  bb0 {
-    %0 = (1, c);
-    return;
-  }
-}
-$desugar$17() -> string{
+$desugar$9() -> string{
   bb0 {
     %0 = (1, s);
     return;
@@ -65,7 +65,7 @@ main() -> nil{
     %1 = ConstantLoad 10
     c = %1;
     %3 = closure_fp $anon/.:$desugar$0
-    $desugar$1 = %3;
+    $desugar$0 = %3;
     %5 = newMap {| value: int, never... |}{} defaults{value=$anon/.:$desugar$0}
     f = %5;
     %8 = ConstantLoad value
@@ -76,11 +76,11 @@ main() -> nil{
   bb1 {
     %11 = ConstantLoad hello
     s = %11;
-    %13 = closure_fp $anon/.:$desugar$2
-    $desugar$4 = %13;
-    %15 = closure_fp $anon/.:$desugar$3
-    $desugar$5 = %15;
-    %17 = newMap {| name: string, value: int, never... |}{} defaults{value=$anon/.:$desugar$2, name=$anon/.:$desugar$3}
+    %13 = closure_fp $anon/.:$desugar$1
+    $desugar$1 = %13;
+    %15 = closure_fp $anon/.:$desugar$2
+    $desugar$2 = %15;
+    %17 = newMap {| name: string, value: int, never... |}{} defaults{value=$anon/.:$desugar$1, name=$anon/.:$desugar$2}
     f2 = %17;
     %20 = ConstantLoad value
     %19 = f2[%20];
@@ -93,13 +93,13 @@ main() -> nil{
     %25 = println(%23) -> bb3;
   }
   bb3 {
-    %26 = closure_fp $anon/.:$desugar$6
-    $desugar$8 = %26;
-    %28 = closure_fp $anon/.:$desugar$7
-    $desugar$9 = %28;
+    %26 = closure_fp $anon/.:$desugar$3
+    $desugar$3 = %26;
+    %28 = closure_fp $anon/.:$desugar$4
+    $desugar$4 = %28;
     %30 = ConstantLoad value
     %31 = ConstantLoad 20
-    %32 = newMap {| name: string, value: int, never... |}{%30=%31} defaults{value=$anon/.:$desugar$6, name=$anon/.:$desugar$7}
+    %32 = newMap {| name: string, value: int, never... |}{%30=%31} defaults{value=$anon/.:$desugar$3, name=$anon/.:$desugar$4}
     f3 = %32;
     %35 = ConstantLoad value
     %34 = f3[%35];
@@ -112,11 +112,11 @@ main() -> nil{
     %40 = println(%38) -> bb5;
   }
   bb5 {
-    %41 = closure_fp $anon/.:$desugar$10
-    $desugar$11 = %41;
+    %41 = closure_fp $anon/.:$desugar$5
+    $desugar$5 = %41;
     %43 = ConstantLoad x
     %44 = ConstantLoad 1
-    %45 = newMap {| x: int, y: int, never... |}{%43=%44} defaults{y=$anon/.:$desugar$10}
+    %45 = newMap {| x: int, y: int, never... |}{%43=%44} defaults{y=$anon/.:$desugar$5}
     f4 = %45;
     %48 = ConstantLoad x
     %47 = f4[%48];
@@ -130,13 +130,13 @@ main() -> nil{
     %54 = println(%53) -> bb7;
   }
   bb7 {
-    %55 = closure_fp $anon/.:$desugar$12
-    $desugar$14 = %55;
-    %57 = closure_fp $anon/.:$desugar$13
-    $desugar$15 = %57;
+    %55 = closure_fp $anon/.:$desugar$6
+    $desugar$6 = %55;
+    %57 = closure_fp $anon/.:$desugar$7
+    $desugar$7 = %57;
     %59 = ConstantLoad x
     %60 = ConstantLoad 5
-    %61 = newMap {| name: string, x: int, y: int, never... |}{%59=%60} defaults{y=$anon/.:$desugar$12, name=$anon/.:$desugar$13}
+    %61 = newMap {| name: string, x: int, y: int, never... |}{%59=%60} defaults{y=$anon/.:$desugar$6, name=$anon/.:$desugar$7}
     f5 = %61;
     %64 = ConstantLoad x
     %63 = f5[%64];
@@ -155,17 +155,17 @@ main() -> nil{
     %73 = println(%71) -> bb10;
   }
   bb10 {
-    %74 = closure_fp $anon/.:$desugar$16
-    $desugar$18 = %74;
-    %76 = closure_fp $anon/.:$desugar$17
-    $desugar$19 = %76;
+    %74 = closure_fp $anon/.:$desugar$8
+    $desugar$8 = %74;
+    %76 = closure_fp $anon/.:$desugar$9
+    $desugar$9 = %76;
     %78 = ConstantLoad x
     %79 = ConstantLoad 5
     %80 = ConstantLoad y
     %81 = ConstantLoad 20
     %82 = ConstantLoad name
     %83 = ConstantLoad world
-    %84 = newMap {| name: string, x: int, y: int, never... |}{%78=%79, %80=%81, %82=%83} defaults{y=$anon/.:$desugar$16, name=$anon/.:$desugar$17}
+    %84 = newMap {| name: string, x: int, y: int, never... |}{%78=%79, %80=%81, %82=%83} defaults{y=$anon/.:$desugar$8, name=$anon/.:$desugar$9}
     f6 = %84;
     %87 = ConstantLoad x
     %86 = f6[%87];

--- a/corpus/bir/subset7/07-record/7-v.txt
+++ b/corpus/bir/subset7/07-record/7-v.txt
@@ -10,7 +10,7 @@ $desugar$0() -> int{
 main() -> nil{
   bb0 {
     %1 = fp $anon/.:$desugar$0
-    $desugar$1 = %1;
+    $desugar$0 = %1;
     %3 = newMap {| value: int, never... |}{} defaults{value=$anon/.:$desugar$0}
     f = %3;
     %6 = ConstantLoad value

--- a/corpus/bir/subset7/07-record/9-v.txt
+++ b/corpus/bir/subset7/07-record/9-v.txt
@@ -2,7 +2,7 @@ module $anon.. v 0.0.0;
 import ballerina.io v 0.0.0;
 import ballerina.io v 0.0.0;
 import ballerina.io v 0.0.0;
-$desugar$1() -> int{
+$desugar$0() -> int{
   bb0 {
     %0 = (2, i);
     return;
@@ -27,17 +27,17 @@ main() -> nil{
   }
   bb2 {
     PushScopeFrame 9
-    %0 = closure_fp $anon/.:$desugar$1
-    $desugar$2 = %0;
-    %2 = newMap {| value: int, never... |}{} defaults{value=$anon/.:$desugar$1}
+    %0 = closure_fp $anon/.:$desugar$0
+    $desugar$1 = %0;
+    %2 = newMap {| value: int, never... |}{} defaults{value=$anon/.:$desugar$0}
     f = %2;
     %4 = push((1, rs),f) -> bb4;
   }
   bb3 {
-    $desugar$3 = rs;
+    $desugar$2 = rs;
     %12 = ConstantLoad 0
-    $desugar$4 = %12;
-    %14 = length($desugar$3) -> bb5;
+    $desugar$3 = %12;
+    %14 = length($desugar$2) -> bb5;
   }
   bb4 {
     %6 = (1, i);
@@ -49,18 +49,18 @@ main() -> nil{
     GOTO bb1;
   }
   bb5 {
-    $desugar$5 = %14;
+    $desugar$4 = %14;
     GOTO bb6;
   }
   bb6 {
-    %17 = $desugar$4;
-    %18 = $desugar$5;
+    %17 = $desugar$3;
+    %18 = $desugar$4;
     %16 = < %17 %18;
     %16 ? bb7 : bb8;
   }
   bb7 {
     PushScopeFrame 10
-    %0 = (1, $desugar$3)[(1, $desugar$4)];
+    %0 = (1, $desugar$2)[(1, $desugar$3)];
     r = %0;
     %3 = ConstantLoad value
     %2 = r[%3];
@@ -71,11 +71,11 @@ main() -> nil{
     return;
   }
   bb9 {
-    %7 = (1, $desugar$4);
+    %7 = (1, $desugar$3);
     %8 = ConstantLoad 1
     %9 = %8;
     %6 = + %7 %9;
-    (1, $desugar$4) = %6;
+    (1, $desugar$3) = %6;
     PopScopeFrame
     GOTO bb6;
   }

--- a/corpus/bir/subset7/07-record/inclusion-default-v.txt
+++ b/corpus/bir/subset7/07-record/inclusion-default-v.txt
@@ -1,0 +1,112 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad z
+    %2 = ConstantLoad world
+    %3 = newMap {| x: int, y: string, z: string, never... |}{%1=%2} defaults{x=$anon/.:$desugar$0, y=$anon/.:$desugar$1}
+    r1 = %3;
+    %6 = ConstantLoad x
+    %5 = r1[%6];
+    %7 = %5;
+    %8 = println(%7) -> bb1;
+  }
+  bb1 {
+    %10 = ConstantLoad y
+    %9 = r1[%10];
+    %11 = println(%9) -> bb2;
+  }
+  bb2 {
+    %13 = ConstantLoad z
+    %12 = r1[%13];
+    %14 = println(%12) -> bb3;
+  }
+  bb3 {
+    %15 = ConstantLoad x
+    %16 = ConstantLoad 5
+    %17 = ConstantLoad z
+    %18 = ConstantLoad world
+    %19 = newMap {| x: int, y: string, z: string, never... |}{%15=%16, %17=%18} defaults{x=$anon/.:$desugar$0, y=$anon/.:$desugar$1}
+    r2 = %19;
+    %22 = ConstantLoad x
+    %21 = r2[%22];
+    %23 = %21;
+    %24 = println(%23) -> bb4;
+  }
+  bb4 {
+    %26 = ConstantLoad y
+    %25 = r2[%26];
+    %27 = println(%25) -> bb5;
+  }
+  bb5 {
+    %29 = ConstantLoad z
+    %28 = r2[%29];
+    %30 = println(%28) -> bb6;
+  }
+  bb6 {
+    %31 = ConstantLoad z
+    %32 = ConstantLoad test
+    %33 = newMap {| x: int, y: string, z: string, never... |}{%31=%32} defaults{x=$anon/.:$desugar$2, y=$anon/.:$desugar$1}
+    r3 = %33;
+    %36 = ConstantLoad x
+    %35 = r3[%36];
+    %37 = %35;
+    %38 = println(%37) -> bb7;
+  }
+  bb7 {
+    %40 = ConstantLoad y
+    %39 = r3[%40];
+    %41 = println(%39) -> bb8;
+  }
+  bb8 {
+    %43 = ConstantLoad z
+    %42 = r3[%43];
+    %44 = println(%42) -> bb9;
+  }
+  bb9 {
+    %45 = ConstantLoad x
+    %46 = ConstantLoad 99
+    %47 = ConstantLoad z
+    %48 = ConstantLoad test
+    %49 = newMap {| x: int, y: string, z: string, never... |}{%45=%46, %47=%48} defaults{x=$anon/.:$desugar$2, y=$anon/.:$desugar$1}
+    r4 = %49;
+    %52 = ConstantLoad x
+    %51 = r4[%52];
+    %53 = %51;
+    %54 = println(%53) -> bb10;
+  }
+  bb10 {
+    %56 = ConstantLoad y
+    %55 = r4[%56];
+    %57 = println(%55) -> bb11;
+  }
+  bb11 {
+    %59 = ConstantLoad z
+    %58 = r4[%59];
+    %60 = println(%58) -> bb12;
+  }
+  bb12 {
+    return;
+  }
+}
+$desugar$0() -> int{
+  bb0 {
+    %1 = ConstantLoad 10
+    %0 = %1;
+    return;
+  }
+}
+$desugar$1() -> string{
+  bb0 {
+    %1 = ConstantLoad hello
+    %0 = %1;
+    return;
+  }
+}
+$desugar$2() -> int{
+  bb0 {
+    %1 = ConstantLoad 42
+    %0 = %1;
+    return;
+  }
+}

--- a/corpus/cfg/subset7/07-record/inclusion-default-v.txt
+++ b/corpus/cfg/subset7/07-record/inclusion-default-v.txt
@@ -1,0 +1,86 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable r1 (type
+        (user-defined-type Inherited)) (expr
+        (mapping-constructor-expr
+          (key-value
+            (simple-var-ref z)
+            (literal world))))))
+    (expression-stmt
+      (invocation io println (
+        (field-based-access x
+          (simple-var-ref r1)))))
+    (expression-stmt
+      (invocation io println (
+        (field-based-access y
+          (simple-var-ref r1)))))
+    (expression-stmt
+      (invocation io println (
+        (field-based-access z
+          (simple-var-ref r1)))))
+    (var-def
+      (variable r2 (type
+        (user-defined-type Inherited)) (expr
+        (mapping-constructor-expr
+          (key-value
+            (simple-var-ref x)
+            (literal 5))
+          (key-value
+            (simple-var-ref z)
+            (literal world))))))
+    (expression-stmt
+      (invocation io println (
+        (field-based-access x
+          (simple-var-ref r2)))))
+    (expression-stmt
+      (invocation io println (
+        (field-based-access y
+          (simple-var-ref r2)))))
+    (expression-stmt
+      (invocation io println (
+        (field-based-access z
+          (simple-var-ref r2)))))
+    (var-def
+      (variable r3 (type
+        (user-defined-type OverriddenWithNewDefault)) (expr
+        (mapping-constructor-expr
+          (key-value
+            (simple-var-ref z)
+            (literal test))))))
+    (expression-stmt
+      (invocation io println (
+        (field-based-access x
+          (simple-var-ref r3)))))
+    (expression-stmt
+      (invocation io println (
+        (field-based-access y
+          (simple-var-ref r3)))))
+    (expression-stmt
+      (invocation io println (
+        (field-based-access z
+          (simple-var-ref r3)))))
+    (var-def
+      (variable r4 (type
+        (user-defined-type OverriddenWithNewDefault)) (expr
+        (mapping-constructor-expr
+          (key-value
+            (simple-var-ref x)
+            (literal 99))
+          (key-value
+            (simple-var-ref z)
+            (literal test))))))
+    (expression-stmt
+      (invocation io println (
+        (field-based-access x
+          (simple-var-ref r4)))))
+    (expression-stmt
+      (invocation io println (
+        (field-based-access y
+          (simple-var-ref r4)))))
+    (expression-stmt
+      (invocation io println (
+        (field-based-access z
+          (simple-var-ref r4)))))
+  )
+)

--- a/corpus/desugared/subset7/07-record/3-v.txt
+++ b/corpus/desugared/subset7/07-record/3-v.txt
@@ -4,7 +4,7 @@
     (value-type null))
     (block-function-body
       (var-def
-        (variable $desugar$1 (expr
+        (variable $desugar$0 (expr
           (lambda
             (function $desugar$0 () ()
               (block-function-body

--- a/corpus/desugared/subset7/07-record/5-v.txt
+++ b/corpus/desugared/subset7/07-record/5-v.txt
@@ -8,7 +8,7 @@
           (value-type int)) (expr
           (literal 10))))
       (var-def
-        (variable $desugar$1 (expr
+        (variable $desugar$0 (expr
           (lambda
             (function $desugar$0 () ()
               (block-function-body
@@ -31,16 +31,16 @@
           (value-type string)) (expr
           (literal hello))))
       (var-def
-        (variable $desugar$4 (expr
+        (variable $desugar$1 (expr
           (lambda
-            (function $desugar$2 () ()
+            (function $desugar$1 () ()
               (block-function-body
                 (return
                   (simple-var-ref c))))))))
       (var-def
-        (variable $desugar$5 (expr
+        (variable $desugar$2 (expr
           (lambda
-            (function $desugar$3 () ()
+            (function $desugar$2 () ()
               (block-function-body
                 (return
                   (simple-var-ref s))))))))
@@ -65,16 +65,16 @@
             (simple-var-ref f2)
             (literal name)))))
       (var-def
-        (variable $desugar$8 (expr
+        (variable $desugar$3 (expr
           (lambda
-            (function $desugar$6 () ()
+            (function $desugar$3 () ()
               (block-function-body
                 (return
                   (simple-var-ref c))))))))
       (var-def
-        (variable $desugar$9 (expr
+        (variable $desugar$4 (expr
           (lambda
-            (function $desugar$7 () ()
+            (function $desugar$4 () ()
               (block-function-body
                 (return
                   (simple-var-ref s))))))))
@@ -102,9 +102,9 @@
             (simple-var-ref f3)
             (literal name)))))
       (var-def
-        (variable $desugar$11 (expr
+        (variable $desugar$5 (expr
           (lambda
-            (function $desugar$10 () ()
+            (function $desugar$5 () ()
               (block-function-body
                 (return
                   (simple-var-ref c))))))))
@@ -131,16 +131,16 @@
             (simple-var-ref f4)
             (literal y)))))
       (var-def
-        (variable $desugar$14 (expr
+        (variable $desugar$6 (expr
           (lambda
-            (function $desugar$12 () ()
+            (function $desugar$6 () ()
               (block-function-body
                 (return
                   (simple-var-ref c))))))))
       (var-def
-        (variable $desugar$15 (expr
+        (variable $desugar$7 (expr
           (lambda
-            (function $desugar$13 () ()
+            (function $desugar$7 () ()
               (block-function-body
                 (return
                   (simple-var-ref s))))))))
@@ -175,16 +175,16 @@
             (simple-var-ref f5)
             (literal name)))))
       (var-def
-        (variable $desugar$18 (expr
+        (variable $desugar$8 (expr
           (lambda
-            (function $desugar$16 () ()
+            (function $desugar$8 () ()
               (block-function-body
                 (return
                   (simple-var-ref c))))))))
       (var-def
-        (variable $desugar$19 (expr
+        (variable $desugar$9 (expr
           (lambda
-            (function $desugar$17 () ()
+            (function $desugar$9 () ()
               (block-function-body
                 (return
                   (simple-var-ref s))))))))

--- a/corpus/desugared/subset7/07-record/7-v.txt
+++ b/corpus/desugared/subset7/07-record/7-v.txt
@@ -10,7 +10,7 @@
     (value-type null))
     (block-function-body
       (var-def
-        (variable $desugar$1 (expr
+        (variable $desugar$0 (expr
           (lambda
             (function $desugar$0 () ()
               (block-function-body

--- a/corpus/desugared/subset7/07-record/9-v.txt
+++ b/corpus/desugared/subset7/07-record/9-v.txt
@@ -27,9 +27,9 @@
           (simple-var-ref $desugar$0))
         (block-stmt
           (var-def
-            (variable $desugar$2 (expr
+            (variable $desugar$1 (expr
               (lambda
-                (function $desugar$1 () ()
+                (function $desugar$0 () ()
                   (block-function-body
                     (return
                       (simple-var-ref i))))))))
@@ -50,33 +50,33 @@
               (simple-var-ref i)
               (numeric-literal 1)))))
       (var-def
-        (variable $desugar$3 (expr
+        (variable $desugar$2 (expr
           (simple-var-ref rs))))
       (var-def
-        (variable $desugar$4 (expr
+        (variable $desugar$3 (expr
           (numeric-literal 0))))
       (var-def
-        (variable $desugar$5 (expr
+        (variable $desugar$4 (expr
           (invocation lang.array length (
-            (simple-var-ref $desugar$3))))))
+            (simple-var-ref $desugar$2))))))
       (while
         (binary-expr <
-          (simple-var-ref $desugar$4)
-          (simple-var-ref $desugar$5))
+          (simple-var-ref $desugar$3)
+          (simple-var-ref $desugar$4))
         (block-stmt
           (var-def
             (variable r (type
               (user-defined-type R)) (expr
               (index-based-access
-                (simple-var-ref $desugar$3)
-                (simple-var-ref $desugar$4)))))
+                (simple-var-ref $desugar$2)
+                (simple-var-ref $desugar$3)))))
           (expression-stmt
             (invocation io println (
               (index-based-access
                 (simple-var-ref r)
                 (literal value)))))
           (assignment
-            (simple-var-ref $desugar$4)
+            (simple-var-ref $desugar$3)
             (binary-expr +
-              (simple-var-ref $desugar$4)
+              (simple-var-ref $desugar$3)
               (numeric-literal 1))))))))

--- a/corpus/desugared/subset7/07-record/inclusion-default-v.txt
+++ b/corpus/desugared/subset7/07-record/inclusion-default-v.txt
@@ -1,0 +1,130 @@
+(package
+  (import-package ballerina io (as io))
+  (type-definition Base
+    (record-type
+      (field x
+        (value-type int)
+        (literal 10))
+      (field y
+        (value-type string)
+        (literal hello))))
+  (type-definition Inherited
+    (record-type
+      (field z
+        (value-type string))))
+  (type-definition OverriddenWithNewDefault
+    (record-type
+      (field x
+        (value-type int)
+        (literal 42))
+      (field z
+        (value-type string))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable r1 (type
+          (user-defined-type Inherited)) (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal z)
+              (literal world))))))
+      (expression-stmt
+        (invocation io println (
+          (index-based-access
+            (simple-var-ref r1)
+            (literal x)))))
+      (expression-stmt
+        (invocation io println (
+          (index-based-access
+            (simple-var-ref r1)
+            (literal y)))))
+      (expression-stmt
+        (invocation io println (
+          (index-based-access
+            (simple-var-ref r1)
+            (literal z)))))
+      (var-def
+        (variable r2 (type
+          (user-defined-type Inherited)) (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal x)
+              (literal 5))
+            (key-value
+              (literal z)
+              (literal world))))))
+      (expression-stmt
+        (invocation io println (
+          (index-based-access
+            (simple-var-ref r2)
+            (literal x)))))
+      (expression-stmt
+        (invocation io println (
+          (index-based-access
+            (simple-var-ref r2)
+            (literal y)))))
+      (expression-stmt
+        (invocation io println (
+          (index-based-access
+            (simple-var-ref r2)
+            (literal z)))))
+      (var-def
+        (variable r3 (type
+          (user-defined-type OverriddenWithNewDefault)) (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal z)
+              (literal test))))))
+      (expression-stmt
+        (invocation io println (
+          (index-based-access
+            (simple-var-ref r3)
+            (literal x)))))
+      (expression-stmt
+        (invocation io println (
+          (index-based-access
+            (simple-var-ref r3)
+            (literal y)))))
+      (expression-stmt
+        (invocation io println (
+          (index-based-access
+            (simple-var-ref r3)
+            (literal z)))))
+      (var-def
+        (variable r4 (type
+          (user-defined-type OverriddenWithNewDefault)) (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal x)
+              (literal 99))
+            (key-value
+              (literal z)
+              (literal test))))))
+      (expression-stmt
+        (invocation io println (
+          (index-based-access
+            (simple-var-ref r4)
+            (literal x)))))
+      (expression-stmt
+        (invocation io println (
+          (index-based-access
+            (simple-var-ref r4)
+            (literal y)))))
+      (expression-stmt
+        (invocation io println (
+          (index-based-access
+            (simple-var-ref r4)
+            (literal z)))))))
+  (function $desugar$0 () ()
+    (block-function-body
+      (return
+        (literal 10))))
+  (function $desugar$1 () ()
+    (block-function-body
+      (return
+        (literal hello))))
+  (function $desugar$2 () ()
+    (block-function-body
+      (return
+        (literal 42)))))

--- a/corpus/integration/project/inclusion-default-e.txtar
+++ b/corpus/integration/project/inclusion-default-e.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: missing non-defaultable required record field 'x'
+  --> main.bal:28:34
+   |
+28 |     OverriddenWithoutDefault r = {z: "world"}; // @error
+   |                                  ^^^^^^^^^^^^

--- a/corpus/integration/project/inclusion-default-v.txtar
+++ b/corpus/integration/project/inclusion-default-v.txtar
@@ -1,0 +1,14 @@
+-- stdout --
+10
+hello
+world
+5
+hello
+world
+42
+hello
+test
+99
+hello
+test
+-- stderr --

--- a/corpus/integration/subset6/06-object/inclusion-cycle-e.txtar
+++ b/corpus/integration/subset6/06-object/inclusion-cycle-e.txtar
@@ -1,6 +1,30 @@
 -- stdout --
 -- stderr --
-error[SEMANTIC_ERROR]: cyclic type inclusion
+error[SEMANTIC_ERROR]: error resolving type inclusion
+  --> inclusion-cycle-e.bal:17:8
+   |
+17 | type A object { // @error
+   |        ^^^^^^^^^^^^^^^^^^
+18 |     *B;
+   |     ^^^
+19 |     int x;
+   |     ^^^^^^
+20 | };
+   | ^
+
+error[SEMANTIC_ERROR]: error resolving type inclusion
+  --> inclusion-cycle-e.bal:22:8
+   |
+22 | type B object {
+   |        ^^^^^^^^
+23 |     *A;
+   |     ^^^
+24 |     int y;
+   |     ^^^^^^
+25 | };
+   | ^
+
+error[SEMANTIC_ERROR]: invalid cycle detected for type definition A
   --> inclusion-cycle-e.bal:17:1
    |
 17 | type A object { // @error
@@ -10,16 +34,4 @@ error[SEMANTIC_ERROR]: cyclic type inclusion
 19 |     int x;
    |     ^^^^^^
 20 | };
-   | ^^
-
-error[SEMANTIC_ERROR]: cyclic type inclusion
-  --> inclusion-cycle-e.bal:22:1
-   |
-22 | type B object {
-   | ^^^^^^^^^^^^^^^
-23 |     *A;
-   |     ^^^
-24 |     int y;
-   |     ^^^^^^
-25 | };
    | ^^

--- a/corpus/integration/subset6/06-object/inclusion-dup-field-class-e.txtar
+++ b/corpus/integration/subset6/06-object/inclusion-dup-field-class-e.txtar
@@ -1,6 +1,6 @@
 -- stdout --
 -- stderr --
-error[SEMANTIC_ERROR]: included field 'x' declared in multiple type inclusions must be overridden
+error[SEMANTIC_ERROR]: included member 'x' declared in multiple type inclusions must be overridden
   --> inclusion-dup-field-class-e.bal:25:1
    |
 25 | class Bar { // @error

--- a/corpus/integration/subset7/07-record/inclusion-default-e.txtar
+++ b/corpus/integration/subset7/07-record/inclusion-default-e.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: missing non-defaultable required record field 'x'
+  --> inclusion-default-e.bal:31:34
+   |
+31 |     OverriddenWithoutDefault r = {z: "world"}; // @error
+   |                                  ^^^^^^^^^^^^

--- a/corpus/integration/subset7/07-record/inclusion-default-v.txtar
+++ b/corpus/integration/subset7/07-record/inclusion-default-v.txtar
@@ -1,0 +1,14 @@
+-- stdout --
+10
+hello
+world
+5
+hello
+world
+42
+hello
+test
+99
+hello
+test
+-- stderr --

--- a/corpus/integration_test.go
+++ b/corpus/integration_test.go
@@ -26,10 +26,14 @@ import (
 	"strings"
 	"testing"
 
+	"ballerina-lang-go/ast"
 	"ballerina-lang-go/bir"
 	bircodec "ballerina-lang-go/bir/codec"
 	"ballerina-lang-go/context"
+	"ballerina-lang-go/desugar"
+	"ballerina-lang-go/model"
 	"ballerina-lang-go/model/symbolpool"
+	"ballerina-lang-go/parser"
 	"ballerina-lang-go/projects"
 	"ballerina-lang-go/projects/directory"
 	"ballerina-lang-go/runtime"
@@ -455,13 +459,20 @@ func runProjectSerializationRoundtrip(projectDir string) (stdout, stderr string)
 	var stdoutBuf bytes.Buffer
 	var stderrBuf bytes.Buffer
 
+	absProjectDir, err := filepath.Abs(projectDir)
+	if err != nil {
+		fmt.Fprintf(&stdoutBuf, "%s\n", err.Error())
+		return stdoutBuf.String(), stderrBuf.String()
+	}
+
 	fsys := os.DirFS(projectDir)
 	result, err := directory.LoadProject(fsys, ".")
 	if err != nil {
 		fmt.Fprintf(&stdoutBuf, "%s\n", err.Error())
 		return stdoutBuf.String(), stderrBuf.String()
 	}
-	currentPkg := result.Project().CurrentPackage()
+	project := result.Project()
+	currentPkg := project.CurrentPackage()
 	compilation := currentPkg.Compilation()
 
 	printDiagnostics(fsys, &stderrBuf, compilation.DiagnosticResult())
@@ -478,10 +489,13 @@ func runProjectSerializationRoundtrip(projectDir string) (stdout, stderr string)
 	}
 
 	deps := birPkgs[:len(birPkgs)-1]
-	mainPkg := birPkgs[len(birPkgs)-1]
 
-	freshEnv := context.NewCompilerEnvironment(semtypes.CreateTypeEnv(), false)
-	deserialized := make([]*bir.BIRPackage, 0, len(birPkgs))
+	// Step 1: Serialize dep symbols and BIR to byte arrays
+	type serializedModule struct {
+		symBytes []byte
+		birBytes []byte
+	}
+	serializedDeps := make([]serializedModule, 0, len(deps))
 
 	for _, dep := range deps {
 		pkgIdent := semantics.PackageIdentifier{
@@ -500,20 +514,36 @@ func runProjectSerializationRoundtrip(projectDir string) (stdout, stderr string)
 			return stdoutBuf.String(), stderrBuf.String()
 		}
 
-		_, err = symbolpool.Unmarshal(freshEnv, symBytes)
-		if err != nil {
-			fmt.Fprintf(&stdoutBuf, "symbol deserialization failed: %v\n", err)
-			return stdoutBuf.String(), stderrBuf.String()
-		}
-
 		birBytes, err := bircodec.Marshal(dep)
 		if err != nil {
 			fmt.Fprintf(&stdoutBuf, "BIR serialization failed: %v\n", err)
 			return stdoutBuf.String(), stderrBuf.String()
 		}
 
+		serializedDeps = append(serializedDeps, serializedModule{symBytes: symBytes, birBytes: birBytes})
+	}
+
+	// Step 2: Create fresh compiler and deserialize dep symbols + BIR
+	freshEnv := context.NewCompilerEnvironment(semtypes.CreateTypeEnv(), false)
+	publicSymbols := make(map[semantics.PackageIdentifier]model.ExportedSymbolSpace)
+	deserialized := make([]*bir.BIRPackage, 0, len(birPkgs))
+
+	for i, sd := range serializedDeps {
+		exported, err := symbolpool.Unmarshal(freshEnv, sd.symBytes)
+		if err != nil {
+			fmt.Fprintf(&stdoutBuf, "symbol deserialization failed: %v\n", err)
+			return stdoutBuf.String(), stderrBuf.String()
+		}
+
+		dep := deps[i]
+		pkgIdent := semantics.PackageIdentifier{
+			OrgName:    dep.PackageID.OrgName.Value(),
+			ModuleName: dep.PackageID.PkgName.Value(),
+		}
+		publicSymbols[pkgIdent] = exported
+
 		freshCtx := context.NewCompilerContext(freshEnv)
-		deserializedPkg, err := bircodec.Unmarshal(freshCtx, birBytes)
+		deserializedPkg, err := bircodec.Unmarshal(freshCtx, sd.birBytes)
 		if err != nil {
 			fmt.Fprintf(&stdoutBuf, "BIR deserialization failed: %v\n", err)
 			return stdoutBuf.String(), stderrBuf.String()
@@ -522,21 +552,123 @@ func runProjectSerializationRoundtrip(projectDir string) (stdout, stderr string)
 		deserialized = append(deserialized, deserializedPkg)
 	}
 
-	mainBirBytes, err := bircodec.Marshal(mainPkg)
+	// Step 3: Recompile the main (default) module from source using deserialized dep symbols
+	defaultModule := currentPkg.DefaultModule()
+	defaultDesc := defaultModule.Descriptor()
+	defaultOrg := defaultDesc.Org().Value()
+
+	mainBirPkg, err := compileModuleFromSource(freshEnv, project, defaultModule, absProjectDir, publicSymbols, defaultOrg)
 	if err != nil {
-		fmt.Fprintf(&stdoutBuf, "BIR serialization failed: %v\n", err)
+		fmt.Fprintf(&stdoutBuf, "main module recompilation failed: %v\n", err)
 		return stdoutBuf.String(), stderrBuf.String()
 	}
 
-	freshCtx := context.NewCompilerContext(freshEnv)
-	deserializedMain, err := bircodec.Unmarshal(freshCtx, mainBirBytes)
-	if err != nil {
-		fmt.Fprintf(&stdoutBuf, "BIR deserialization failed: %v\n", err)
-		return stdoutBuf.String(), stderrBuf.String()
-	}
-
-	deserialized = append(deserialized, deserializedMain)
+	deserialized = append(deserialized, mainBirPkg)
 
 	runProjectInterpretPhase(deserialized, &stdoutBuf, &stderrBuf)
 	return stdoutBuf.String(), stderrBuf.String()
+}
+
+func compileModuleFromSource(env *context.CompilerEnvironment, project projects.Project, module *projects.Module,
+	absProjectDir string, publicSymbols map[semantics.PackageIdentifier]model.ExportedSymbolSpace, defaultOrg string,
+) (*bir.BIRPackage, error) {
+	cx := context.NewCompilerContext(env)
+
+	// Parse all source files in the module
+	docIDs := module.DocumentIDs()
+	var syntaxTrees []*ast.BLangCompilationUnit
+	for _, docID := range docIDs {
+		relPath := project.DocumentPath(docID)
+		absPath := filepath.Join(absProjectDir, relPath)
+		st, err := parser.GetSyntaxTree(cx, absPath)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %s: %v", relPath, err)
+		}
+		cu := ast.GetCompilationUnit(cx, st)
+		syntaxTrees = append(syntaxTrees, cu)
+	}
+
+	// Build package from compilation units
+	var pkg *ast.BLangPackage
+	if len(syntaxTrees) == 1 {
+		pkg = ast.ToPackage(syntaxTrees[0])
+	} else {
+		pkg = &ast.BLangPackage{}
+		for _, cu := range syntaxTrees {
+			if pkg.PackageID == nil {
+				pkg.PackageID = cu.GetPackageID()
+			}
+			for _, node := range cu.GetTopLevelNodes() {
+				switch n := node.(type) {
+				case *ast.BLangImportPackage:
+					pkg.Imports = append(pkg.Imports, *n)
+				case *ast.BLangConstant:
+					pkg.Constants = append(pkg.Constants, *n)
+				case *ast.BLangService:
+					pkg.Services = append(pkg.Services, *n)
+				case *ast.BLangFunction:
+					pkg.Functions = append(pkg.Functions, *n)
+				case *ast.BLangTypeDefinition:
+					pkg.TypeDefinitions = append(pkg.TypeDefinitions, *n)
+				case *ast.BLangAnnotation:
+					pkg.Annotations = append(pkg.Annotations, *n)
+				case *ast.BLangClassDefinition:
+					pkg.ClassDefinitions = append(pkg.ClassDefinitions, *n)
+				default:
+					pkg.TopLevelNodes = append(pkg.TopLevelNodes, node)
+				}
+			}
+		}
+	}
+
+	// Set the package ID to match the module descriptor
+	desc := module.Descriptor()
+	orgName := model.Name(desc.Org().Value())
+	moduleName := desc.Name().String()
+	nameComps := make([]model.Name, 0)
+	for _, part := range strings.Split(moduleName, ".") {
+		nameComps = append(nameComps, model.Name(part))
+	}
+	version := model.Name(desc.Version().String())
+	if version == "" {
+		version = model.DEFAULT_VERSION
+	}
+	pkg.PackageID = cx.NewPackageID(orgName, nameComps, version)
+
+	// Run compilation pipeline
+	importedSymbols := semantics.ResolveImports(cx, pkg, semantics.GetImplicitImports(cx), publicSymbols, defaultOrg)
+	semantics.ResolveSymbols(cx, pkg, importedSymbols)
+	if cx.HasDiagnostics() {
+		return nil, fmt.Errorf("symbol resolution failed")
+	}
+
+	semantics.ResolveTopLevelNodes(cx, pkg, importedSymbols)
+	if cx.HasDiagnostics() {
+		return nil, fmt.Errorf("top-level type resolution failed")
+	}
+
+	semantics.ResolveLocalNodes(cx, pkg, importedSymbols)
+	if cx.HasDiagnostics() {
+		return nil, fmt.Errorf("local type resolution failed")
+	}
+
+	analyzer := semantics.NewSemanticAnalyzer(cx)
+	analyzer.Analyze(pkg)
+	if cx.HasDiagnostics() {
+		return nil, fmt.Errorf("semantic analysis failed")
+	}
+
+	cfg := semantics.CreateControlFlowGraph(cx, pkg)
+	if cx.HasDiagnostics() {
+		return nil, fmt.Errorf("CFG creation failed")
+	}
+
+	semantics.AnalyzeCFG(cx, pkg, cfg)
+	if cx.HasDiagnostics() {
+		return nil, fmt.Errorf("CFG analysis failed")
+	}
+
+	pkg = desugar.DesugarPackage(cx, pkg, importedSymbols)
+
+	return bir.GenBir(cx, pkg), nil
 }

--- a/corpus/project/inclusion-default-e/Ballerina.toml
+++ b/corpus/project/inclusion-default-e/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "testorg"
+name = "inclusiondefault"
+version = "0.1.0"

--- a/corpus/project/inclusion-default-e/main.bal
+++ b/corpus/project/inclusion-default-e/main.bal
@@ -1,0 +1,30 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+import testorg/inclusiondefault.types;
+
+type OverriddenWithoutDefault record {|
+    *types:Base;
+    int x;
+    string z;
+|};
+
+public function main() {
+    OverriddenWithoutDefault r = {z: "world"}; // @error
+    io:println(r);
+}

--- a/corpus/project/inclusion-default-e/modules/types/types.bal
+++ b/corpus/project/inclusion-default-e/modules/types/types.bal
@@ -1,0 +1,20 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public type Base record {|
+    int x = 10;
+    string y = "hello";
+|};

--- a/corpus/project/inclusion-default-v/Ballerina.toml
+++ b/corpus/project/inclusion-default-v/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "testorg"
+name = "inclusiondefault"
+version = "0.1.0"

--- a/corpus/project/inclusion-default-v/main.bal
+++ b/corpus/project/inclusion-default-v/main.bal
@@ -1,0 +1,52 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+import testorg/inclusiondefault.types;
+
+type Inherited record {|
+    *types:Base;
+    string z;
+|};
+
+type OverriddenWithNewDefault record {|
+    *types:Base;
+    int x = 42;
+    string z;
+|};
+
+public function main() {
+    Inherited r1 = {z: "world"};
+    io:println(r1.x); // @output 10
+    io:println(r1.y); // @output hello
+    io:println(r1.z); // @output world
+
+    Inherited r2 = {x: 5, z: "world"};
+    io:println(r2.x); // @output 5
+    io:println(r2.y); // @output hello
+    io:println(r2.z); // @output world
+
+    OverriddenWithNewDefault r3 = {z: "test"};
+    io:println(r3.x); // @output 42
+    io:println(r3.y); // @output hello
+    io:println(r3.z); // @output test
+
+    OverriddenWithNewDefault r4 = {x: 99, z: "test"};
+    io:println(r4.x); // @output 99
+    io:println(r4.y); // @output hello
+    io:println(r4.z); // @output test
+}

--- a/corpus/project/inclusion-default-v/modules/types/types.bal
+++ b/corpus/project/inclusion-default-v/modules/types/types.bal
@@ -1,0 +1,20 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public type Base record {|
+    int x = 10;
+    string y = "hello";
+|};

--- a/desugar/desugar.go
+++ b/desugar/desugar.go
@@ -380,24 +380,12 @@ func desugarRecordTypeDesc(ctx desugarContext, recType *ast.BLangRecordType, own
 		if field.DefaultExpr == nil {
 			continue
 		}
-		fieldSemType := field.Type.(ast.BLangNode).GetDeterminedType()
-		fnName := ctx.nextDesugarSymbolName()
-		signature := model.FunctionSignature{ReturnType: fieldSemType}
-		fnSymbol := model.NewFunctionSymbol(fnName, signature, false)
-		env := ctx.typeEnv()
-		paramListDefn := semtypes.NewListDefinition()
-		paramListTy := paramListDefn.TupleTypeWrapped(env)
-		fnDefn := semtypes.NewFunctionDefinition()
-		fnType := fnDefn.Define(env, paramListTy, fieldSemType, semtypes.FunctionQualifiersFrom(env, false, false))
-		fnSymbol.SetType(fnType)
-		symRef := ctx.addSymbolToSameSpace(ownerSymRef, fnName, fnSymbol)
+		symRef := field.DefaultFnRef
+		fn := createDefaultValueFunction(ctx.getSymbol(symRef).Name(), field.DefaultExpr)
 		fnScope := ctx.newFunctionScope(parentScope)
-
-		fn := createDefaultValueFunction(fnName, field.DefaultExpr)
 		fn.SetSymbol(symRef)
 		fn.SetScope(fnScope)
 
-		field.DefaultFnRef = symRef
 		fields = append(fields, desugaredRecordFieldResult{fn: fn, symRef: symRef})
 	}
 	return desugaredTypeDescResult{recordFields: fields}

--- a/model/symbol.go
+++ b/model/symbol.go
@@ -136,10 +136,16 @@ type (
 
 	TypeSymbol struct {
 		symbolBase
+		inclusionMembers []InclusionMember
 	}
 
 	ClassSymbol struct {
 		TypeSymbol
+	}
+
+	FieldDefault struct {
+		FieldName string
+		FnRef     SymbolRef
 	}
 
 	ValueSymbol struct {
@@ -165,6 +171,89 @@ type (
 		// RestParamType is nil if there is no rest param
 		RestParamType semtypes.SemType
 	}
+)
+
+type InclusionMemberKind uint8
+
+const (
+	InclusionMemberKindField InclusionMemberKind = iota
+	InclusionMemberKindMethod
+	InclusionMemberKindRemoteMethod
+	InclusionMemberKindResourceMethod
+	InclusionMemberKindRestType
+)
+
+type InclusionMember interface {
+	MemberName() string
+	MemberKind() InclusionMemberKind
+	MemberType() semtypes.SemType
+	SetMemberType(semtypes.SemType)
+}
+
+type FieldDescriptorFlag uint8
+
+const (
+	FieldDescriptorReadonly FieldDescriptorFlag = 1 << iota
+	FieldDescriptorOptional
+	FieldDescriptorHasDefault
+)
+
+type FieldDescriptor struct {
+	name         string
+	ty           semtypes.SemType
+	flags        FieldDescriptorFlag
+	DefaultFnRef SymbolRef
+	visibility   Visibility
+}
+
+func NewFieldDescriptor(name string, flags FieldDescriptorFlag, visibility Visibility) FieldDescriptor {
+	return FieldDescriptor{name: name, flags: flags, visibility: visibility}
+}
+
+func (f *FieldDescriptor) MemberName() string                { return f.name }
+func (f *FieldDescriptor) MemberKind() InclusionMemberKind   { return InclusionMemberKindField }
+func (f *FieldDescriptor) MemberType() semtypes.SemType      { return f.ty }
+func (f *FieldDescriptor) SetMemberType(ty semtypes.SemType) { f.ty = ty }
+func (f *FieldDescriptor) Visibility() Visibility            { return f.visibility }
+func (f *FieldDescriptor) IsReadonly() bool                  { return f.flags&FieldDescriptorReadonly != 0 }
+func (f *FieldDescriptor) IsOptional() bool                  { return f.flags&FieldDescriptorOptional != 0 }
+func (f *FieldDescriptor) HasDefault() bool                  { return f.flags&FieldDescriptorHasDefault != 0 }
+
+type MethodDescriptor struct {
+	name       string
+	kind       InclusionMemberKind
+	ty         semtypes.SemType
+	MethodRef  SymbolRef
+	visibility Visibility
+}
+
+func NewMethodDescriptor(name string, kind InclusionMemberKind, visibility Visibility, methodRef SymbolRef) MethodDescriptor {
+	return MethodDescriptor{name: name, kind: kind, visibility: visibility, MethodRef: methodRef}
+}
+
+func (m *MethodDescriptor) MemberName() string                { return m.name }
+func (m *MethodDescriptor) MemberKind() InclusionMemberKind   { return m.kind }
+func (m *MethodDescriptor) MemberType() semtypes.SemType      { return m.ty }
+func (m *MethodDescriptor) SetMemberType(ty semtypes.SemType) { m.ty = ty }
+func (m *MethodDescriptor) Visibility() Visibility            { return m.visibility }
+
+type RestTypeDescriptor struct {
+	ty semtypes.SemType
+}
+
+func NewRestTypeDescriptor() RestTypeDescriptor {
+	return RestTypeDescriptor{}
+}
+
+func (r *RestTypeDescriptor) MemberName() string                { panic("RestTypeDescriptor has no name") }
+func (r *RestTypeDescriptor) MemberKind() InclusionMemberKind   { return InclusionMemberKindRestType }
+func (r *RestTypeDescriptor) MemberType() semtypes.SemType      { return r.ty }
+func (r *RestTypeDescriptor) SetMemberType(ty semtypes.SemType) { r.ty = ty }
+
+var (
+	_ InclusionMember = &FieldDescriptor{}
+	_ InclusionMember = &MethodDescriptor{}
+	_ InclusionMember = &RestTypeDescriptor{}
 )
 
 var (
@@ -306,6 +395,19 @@ func NewExportedSymbolSpace(main, annotation *SymbolSpace) ExportedSymbolSpace {
 	return ExportedSymbolSpace{Main: main, Annotation: annotation}
 }
 
+func (space *ExportedSymbolSpace) PublicMainSymbols() iter.Seq2[SymbolRef, Symbol] {
+	return func(yield func(SymbolRef, Symbol) bool) {
+		for i, sym := range space.Main.Symbols() {
+			if !sym.IsPublic() {
+				continue
+			}
+			if !yield(space.Main.RefAt(i), sym) {
+				return
+			}
+		}
+	}
+}
+
 func (space *ExportedSymbolSpace) GetSymbol(name string) (SymbolRef, bool) {
 	ref, ok := space.Main.GetSymbol(name)
 	if !ok {
@@ -384,6 +486,21 @@ func (ts *TypeSymbol) Kind() SymbolKind {
 
 func (ts *TypeSymbol) Copy() Symbol {
 	panic("TypeSymbol cannot be copied")
+}
+
+func (ts *TypeSymbol) InclusionMembers() []InclusionMember { return ts.inclusionMembers }
+func (ts *TypeSymbol) AddInclusionMember(m InclusionMember) {
+	ts.inclusionMembers = append(ts.inclusionMembers, m)
+}
+
+func (ts *TypeSymbol) FieldDefaults() []FieldDefault {
+	var defaults []FieldDefault
+	for _, m := range ts.inclusionMembers {
+		if fd, ok := m.(*FieldDescriptor); ok && fd.DefaultFnRef != (SymbolRef{}) {
+			defaults = append(defaults, FieldDefault{FieldName: fd.name, FnRef: fd.DefaultFnRef})
+		}
+	}
+	return defaults
 }
 
 func (vs *ValueSymbol) Kind() SymbolKind {

--- a/model/symbolpool/deserializer.go
+++ b/model/symbolpool/deserializer.go
@@ -137,13 +137,88 @@ func (sr *symbolReader) readTypeSymbol(space *model.SymbolSpace) {
 	name, isPublic, ty := sr.readSymbolBase()
 	sym := model.NewTypeSymbol(name, isPublic)
 	sym.SetType(ty)
+	for _, m := range sr.readInclusionMembers(space) {
+		sym.AddInclusionMember(m)
+	}
 	space.AddSymbol(name, &sym)
+}
+
+func (sr *symbolReader) readInclusionMembers(space *model.SymbolSpace) []model.InclusionMember {
+	var count int64
+	read(sr.r, &count)
+	members := make([]model.InclusionMember, 0, count)
+	for i := int64(0); i < count; i++ {
+		var tag uint8
+		read(sr.r, &tag)
+		switch tag {
+		case inclusionMemberTagField:
+			name := sr.readStringCP()
+			ty := sr.readType()
+			var vis uint8
+			read(sr.r, &vis)
+			var flags uint8
+			read(sr.r, &flags)
+			var fdFlags model.FieldDescriptorFlag
+			if flags&1 != 0 {
+				fdFlags |= model.FieldDescriptorReadonly
+			}
+			if flags&2 != 0 {
+				fdFlags |= model.FieldDescriptorOptional
+			}
+			if flags&4 != 0 {
+				fdFlags |= model.FieldDescriptorHasDefault
+			}
+			fd := model.NewFieldDescriptor(name, fdFlags, model.Visibility(vis))
+			fd.SetMemberType(ty)
+			fd.DefaultFnRef = sr.readSymbolRef(space)
+			members = append(members, &fd)
+		case inclusionMemberTagMethod:
+			name := sr.readStringCP()
+			ty := sr.readType()
+			var kind uint8
+			read(sr.r, &kind)
+			var vis uint8
+			read(sr.r, &vis)
+			methodRef := sr.readSymbolRef(space)
+			md := model.NewMethodDescriptor(name, model.InclusionMemberKind(kind), model.Visibility(vis), methodRef)
+			md.SetMemberType(ty)
+			members = append(members, &md)
+		case inclusionMemberTagRestType:
+			ty := sr.readType()
+			rd := model.NewRestTypeDescriptor()
+			rd.SetMemberType(ty)
+			members = append(members, &rd)
+		}
+	}
+	return members
+}
+
+func (sr *symbolReader) readSymbolRef(space *model.SymbolSpace) model.SymbolRef {
+	org := sr.readStringCP()
+	pkg := sr.readStringCP()
+	version := sr.readStringCP()
+	var index, spaceIndex int32
+	read(sr.r, &index)
+	read(sr.r, &spaceIndex)
+	_ = spaceIndex // use the current space's index instead of the serialized one
+	return model.SymbolRef{
+		Package: model.PackageIdentifier{
+			Organization: org,
+			Package:      pkg,
+			Version:      version,
+		},
+		Index:      int(index),
+		SpaceIndex: space.SpaceIndex(),
+	}
 }
 
 func (sr *symbolReader) readClassSymbol(space *model.SymbolSpace) {
 	name, isPublic, ty := sr.readSymbolBase()
 	sym := model.NewClassSymbol(name, isPublic)
 	sym.SetType(ty)
+	for _, m := range sr.readInclusionMembers(space) {
+		sym.AddInclusionMember(m)
+	}
 	space.AddSymbol(name, &sym)
 }
 

--- a/model/symbolpool/serializer.go
+++ b/model/symbolpool/serializer.go
@@ -37,6 +37,12 @@ const (
 	symTagFunction uint8 = 3
 )
 
+const (
+	inclusionMemberTagField    uint8 = 0
+	inclusionMemberTagMethod   uint8 = 1
+	inclusionMemberTagRestType uint8 = 2
+)
+
 type symbolWriter struct {
 	cp  *constantPool
 	tp  *semtypes.TypePool
@@ -151,14 +157,104 @@ func (sw *symbolWriter) writeTypeSymbol(buf *bytes.Buffer, sym *model.TypeSymbol
 	if err := write(buf, symTagType); err != nil {
 		return err
 	}
-	return sw.writeSymbolBase(buf, sym)
+	if err := sw.writeSymbolBase(buf, sym); err != nil {
+		return err
+	}
+	return sw.writeInclusionMembers(buf, sym.InclusionMembers())
+}
+
+func (sw *symbolWriter) writeInclusionMembers(buf *bytes.Buffer, members []model.InclusionMember) error {
+	if err := write(buf, int64(len(members))); err != nil {
+		return err
+	}
+	for _, m := range members {
+		switch member := m.(type) {
+		case *model.FieldDescriptor:
+			if err := write(buf, inclusionMemberTagField); err != nil {
+				return err
+			}
+			if err := sw.writeStringCP(buf, member.MemberName()); err != nil {
+				return err
+			}
+			if err := sw.writeType(buf, member.MemberType()); err != nil {
+				return err
+			}
+			if err := write(buf, uint8(member.Visibility())); err != nil {
+				return err
+			}
+			var flags uint8
+			if member.IsReadonly() {
+				flags |= 1
+			}
+			if member.IsOptional() {
+				flags |= 2
+			}
+			if member.HasDefault() {
+				flags |= 4
+			}
+			if err := write(buf, flags); err != nil {
+				return err
+			}
+			if err := sw.writeSymbolRef(buf, member.DefaultFnRef); err != nil {
+				return err
+			}
+		case *model.MethodDescriptor:
+			if err := write(buf, inclusionMemberTagMethod); err != nil {
+				return err
+			}
+			if err := sw.writeStringCP(buf, member.MemberName()); err != nil {
+				return err
+			}
+			if err := sw.writeType(buf, member.MemberType()); err != nil {
+				return err
+			}
+			if err := write(buf, uint8(member.MemberKind())); err != nil {
+				return err
+			}
+			if err := write(buf, uint8(member.Visibility())); err != nil {
+				return err
+			}
+			if err := sw.writeSymbolRef(buf, member.MethodRef); err != nil {
+				return err
+			}
+		case *model.RestTypeDescriptor:
+			if err := write(buf, inclusionMemberTagRestType); err != nil {
+				return err
+			}
+			if err := sw.writeType(buf, member.MemberType()); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unknown inclusion member type: %T", m)
+		}
+	}
+	return nil
+}
+
+func (sw *symbolWriter) writeSymbolRef(buf *bytes.Buffer, ref model.SymbolRef) error {
+	if err := sw.writeStringCP(buf, ref.Package.Organization); err != nil {
+		return err
+	}
+	if err := sw.writeStringCP(buf, ref.Package.Package); err != nil {
+		return err
+	}
+	if err := sw.writeStringCP(buf, ref.Package.Version); err != nil {
+		return err
+	}
+	if err := write(buf, int32(ref.Index)); err != nil {
+		return err
+	}
+	return write(buf, int32(ref.SpaceIndex))
 }
 
 func (sw *symbolWriter) writeClassSymbol(buf *bytes.Buffer, sym *model.ClassSymbol) error {
 	if err := write(buf, symTagClass); err != nil {
 		return err
 	}
-	return sw.writeSymbolBase(buf, sym)
+	if err := sw.writeSymbolBase(buf, sym); err != nil {
+		return err
+	}
+	return sw.writeInclusionMembers(buf, sym.InclusionMembers())
 }
 
 func (sw *symbolWriter) writeValueSymbol(buf *bytes.Buffer, sym *model.ValueSymbol) error {

--- a/semantics/inclusion.go
+++ b/semantics/inclusion.go
@@ -17,68 +17,24 @@
 package semantics
 
 import (
-	"ballerina-lang-go/ast"
-	"ballerina-lang-go/context"
 	"ballerina-lang-go/model"
 )
 
-type transitiveInclusionResult struct {
-	defns   []model.TypeDefinition
-	members []includedMember
-}
-
-type includedMember struct {
-	objectMember model.ObjectMember
-	classField   *ast.BLangSimpleVariable
-	classMethod  *ast.BLangFunction
-}
-
-func collectTransitiveInclusions(ctx *context.CompilerContext, inclusions []model.SymbolRef) transitiveInclusionResult {
-	visited := make(map[model.SymbolRef]bool)
-	return collectTransitiveInclusionsInner(ctx, inclusions, visited)
-}
-
-func collectTransitiveInclusionsInner(ctx *context.CompilerContext, inclusions []model.SymbolRef, visited map[model.SymbolRef]bool) transitiveInclusionResult {
-	var result transitiveInclusionResult
+// collectIncludedMembers resolves each included type, validates it is a subtype of expectedBasicType,
+// and returns all their flattened InclusionMembers.
+func collectIncludedMembers(t typeResolver, inclusions []model.SymbolRef, depth int) ([]model.InclusionMember, bool) {
+	var result []model.InclusionMember
 	for _, symRef := range inclusions {
-		if visited[symRef] {
-			tDefn, ok := ctx.GetTypeDefinition(symRef)
-			if ok {
-				ctx.SemanticError("cyclic type inclusion", tDefn.(model.Node).GetPosition())
-			}
-			continue
+		t.ensureResolved(symRef, depth)
+		incSym := getTypeSymbol(t, symRef)
+		if incSym == nil {
+			t.internalError("inclusion symbol is not a type symbol", nil)
+			return nil, true
 		}
-		visited[symRef] = true
-		tDefn, ok := ctx.GetTypeDefinition(symRef)
-		if !ok {
-			ctx.InternalError("type definition not found for inclusion", nil)
-			continue
+		if incSym.Type() == nil {
+			return nil, true
 		}
-		switch defn := tDefn.(type) {
-		case *ast.BLangTypeDefinition:
-			objTy := defn.GetTypeData().TypeDescriptor.(*ast.BLangObjectType)
-			sub := collectTransitiveInclusionsInner(ctx, objTy.Inclusions, visited)
-			result.defns = append(result.defns, sub.defns...)
-			result.members = append(result.members, sub.members...)
-			result.defns = append(result.defns, defn)
-			for m := range objTy.Members() {
-				result.members = append(result.members, includedMember{objectMember: m})
-			}
-		case *ast.BLangClassDefinition:
-			sub := collectTransitiveInclusionsInner(ctx, defn.Inclusions, visited)
-			result.defns = append(result.defns, sub.defns...)
-			result.members = append(result.members, sub.members...)
-			result.defns = append(result.defns, defn)
-			for _, f := range defn.Fields {
-				field := f.(*ast.BLangSimpleVariable)
-				result.members = append(result.members, includedMember{classField: field})
-			}
-			for _, method := range defn.Methods {
-				result.members = append(result.members, includedMember{classMethod: method})
-			}
-		default:
-			ctx.InternalError("unexpected type definition kind for inclusion", tDefn.(model.Node).GetPosition())
-		}
+		result = append(result, incSym.InclusionMembers()...)
 	}
-	return result
+	return result, false
 }

--- a/semantics/semantic_analyzer.go
+++ b/semantics/semantic_analyzer.go
@@ -831,13 +831,28 @@ func analyzeMappingConstructorExpr[A analyzer](a A, expr *ast.BLangMappingConstr
 	// The type resolver has already selected the inherent type and re-resolved field values
 	// with per-field expected types. We only need to validate fields here.
 	mat := expr.AtomicType
+	hasValue := make(map[string]bool, len(expr.Fields)+len(expr.FieldDefaults))
+	for _, fd := range expr.FieldDefaults {
+		hasValue[fd.FieldName] = true
+	}
 	for _, f := range expr.Fields {
 		kv := f.(*ast.BLangMappingKeyValueField)
 		keyName := recordKeyName(kv.Key)
+		hasValue[keyName] = true
 		fieldExpectedType := mat.FieldInnerVal(keyName)
 		if !analyzeExpression(a, kv.ValueExpr, fieldExpectedType) {
 			return false
 		}
+	}
+	for _, name := range mat.Names {
+		if hasValue[name] {
+			continue
+		}
+		if mat.IsOptional(a.tyCtx(), name) {
+			continue
+		}
+		a.semanticErr(fmt.Sprintf("missing non-defaultable required record field '%s'", name), expr.GetPosition())
+		return false
 	}
 	return validateResolvedType(a, expr, expectedType)
 }

--- a/semantics/symbol_resolver.go
+++ b/semantics/symbol_resolver.go
@@ -47,13 +47,15 @@ type symbolResolver interface {
 	GetPkgID() model.PackageID
 	GetScope() model.Scope
 	GetCtx() *context.CompilerContext
+	GetTypeDefns() map[model.SymbolRef]model.TypeDefinition
 }
 
 type (
 	moduleSymbolResolver struct {
-		ctx   *context.CompilerContext
-		scope *model.ModuleScope
-		pkgID model.PackageID
+		ctx       *context.CompilerContext
+		scope     *model.ModuleScope
+		pkgID     model.PackageID
+		typeDefns map[model.SymbolRef]model.TypeDefinition
 	}
 
 	blockSymbolResolver struct {
@@ -78,9 +80,10 @@ func newModuleSymbolResolver(ctx *context.CompilerContext, pkgID model.PackageID
 		Annotation: ctx.NewSymbolSpace(pkgID),
 	}
 	return &moduleSymbolResolver{
-		ctx:   ctx,
-		scope: scope,
-		pkgID: pkgID,
+		ctx:       ctx,
+		scope:     scope,
+		pkgID:     pkgID,
+		typeDefns: make(map[model.SymbolRef]model.TypeDefinition),
 	}
 }
 
@@ -131,6 +134,10 @@ func (ms *moduleSymbolResolver) GetCtx() *context.CompilerContext {
 	return ms.ctx
 }
 
+func (ms *moduleSymbolResolver) GetTypeDefns() map[model.SymbolRef]model.TypeDefinition {
+	return ms.typeDefns
+}
+
 func (bs *blockSymbolResolver) GetSymbol(name string) (model.SymbolRef, scopeKind, bool) {
 	ref, ok := bs.scope.MainSpace().GetSymbol(name)
 	if ok {
@@ -157,6 +164,10 @@ func (bs *blockSymbolResolver) GetScope() model.Scope {
 
 func (bs *blockSymbolResolver) GetCtx() *context.CompilerContext {
 	return bs.parent.GetCtx()
+}
+
+func (bs *blockSymbolResolver) GetTypeDefns() map[model.SymbolRef]model.TypeDefinition {
+	return bs.parent.GetTypeDefns()
 }
 
 func addTopLevelSymbol(resolver *moduleSymbolResolver, name string, symbol model.Symbol, pos diagnostics.Location) {
@@ -209,7 +220,7 @@ func ResolveSymbols(cx *context.CompilerContext, pkg *ast.BLangPackage, imported
 		symbol := model.NewTypeSymbol(name, isPublic)
 		addTopLevelSymbol(moduleResolver, name, &symbol, typeDef.Name.GetPosition())
 		symRef, _, _ := moduleResolver.GetSymbol(name)
-		cx.SetTypeDefinition(symRef, typeDef)
+		moduleResolver.typeDefns[symRef] = typeDef
 	}
 	for i := range pkg.ClassDefinitions {
 		classDef := &pkg.ClassDefinitions[i]
@@ -218,9 +229,10 @@ func ResolveSymbols(cx *context.CompilerContext, pkg *ast.BLangPackage, imported
 		symbol := model.NewClassSymbol(name, isPublic)
 		addTopLevelSymbol(moduleResolver, name, &symbol, classDef.Name.GetPosition())
 		symRef, _, _ := moduleResolver.GetSymbol(name)
-		cx.SetTypeDefinition(symRef, classDef)
+		moduleResolver.typeDefns[symRef] = classDef
 	}
 	ast.Walk(moduleResolver, pkg)
+	pkg.Scope = moduleResolver.scope
 	return moduleResolver.scope.Exports()
 }
 
@@ -417,7 +429,9 @@ func visitInnerSymbolResolver[T symbolResolver](resolver T, node ast.BLangNode) 
 	case *ast.BLangUserDefinedType:
 		referUserDefinedType(resolver, n)
 	case *ast.BLangObjectType:
-		n.Inclusions = resolveObjectInclusions(resolver, n.PopUnresolvedInclusions())
+		n.Inclusions, _ = resolveObjectInclusions(resolver, n.PopUnresolvedInclusions())
+	case *ast.BLangRecordType:
+		n.Inclusions = resolveRecordTypeInclusions(resolver, n.TypeInclusions)
 	}
 	return resolver
 }
@@ -704,41 +718,168 @@ func (ms *moduleSymbolResolver) VisitTypeData(typeData *model.TypeData) ast.Visi
 	return ms
 }
 
+type inclusionMemberForSymbolResolution struct {
+	name     string
+	isPublic bool
+}
+
 // resolveObjectInclusions update the AST node references with correct symbol references. Will add semantic errors if the type
 // reference is for something that can't be included. This means after this stage we have the gurantee symbol ref always refer
 // to a valid AST node.
-func resolveObjectInclusions[T symbolResolver](resolver T, unresolvedInclusions []*ast.BLangUserDefinedType) []model.SymbolRef {
+func resolveObjectInclusions[T symbolResolver](resolver T, unresolvedInclusions []*ast.BLangUserDefinedType) ([]model.SymbolRef, []inclusionMemberForSymbolResolution) {
 	ctx := resolver.GetCtx()
+	localDefns := resolver.GetTypeDefns()
 	inclusions := make([]model.SymbolRef, 0, len(unresolvedInclusions))
+	var includedFields []inclusionMemberForSymbolResolution
 	for _, inc := range unresolvedInclusions {
 		ast.Walk(resolver, inc)
 		symRef := inc.Symbol()
-		tDefn, ok := ctx.GetTypeDefinition(symRef)
-		if !ok {
-			ctx.InternalError("type definition not found for inclusion", inc.GetPosition())
-			continue
-		}
-		switch defn := tDefn.(type) {
-		case *ast.BLangTypeDefinition:
-			if _, ok := defn.GetTypeData().TypeDescriptor.(*ast.BLangObjectType); !ok {
+		if tDefn, ok := localDefns[symRef]; ok {
+			switch tDefn.(type) {
+			case *ast.BLangTypeDefinition:
+				if _, ok := tDefn.GetTypeData().TypeDescriptor.(*ast.BLangObjectType); !ok {
+					ctx.SemanticError("type inclusion must be an object type or class", inc.GetPosition())
+					continue
+				}
+			case *ast.BLangClassDefinition:
+			default:
+				ctx.InternalError("unexpected type definition kind for inclusion", inc.GetPosition())
+				continue
+			}
+			includedFields = append(includedFields, collectTransitiveFieldsFromDefn(ctx, tDefn, localDefns)...)
+		} else {
+			sym := ctx.GetSymbol(symRef)
+			var typeSym *model.TypeSymbol
+			switch s := sym.(type) {
+			case *model.ClassSymbol:
+				typeSym = &s.TypeSymbol
+			case *model.TypeSymbol:
+				if s.Type() == nil || !semtypes.IsSubtypeSimple(s.Type(), semtypes.OBJECT) {
+					ctx.SemanticError("type inclusion must be an object type or class", inc.GetPosition())
+					continue
+				}
+				typeSym = s
+			default:
 				ctx.SemanticError("type inclusion must be an object type or class", inc.GetPosition())
 				continue
 			}
-		case *ast.BLangClassDefinition:
-		default:
-			ctx.InternalError("unexpected type definition kind for inclusion", inc.GetPosition())
+			for _, m := range typeSym.InclusionMembers() {
+				if m.MemberKind() != model.InclusionMemberKindField {
+					continue
+				}
+				fd := m.(*model.FieldDescriptor)
+				includedFields = append(includedFields, inclusionMemberForSymbolResolution{
+					name:     fd.MemberName(),
+					isPublic: fd.Visibility() == model.VisibilityPublic,
+				})
+			}
+		}
+		inclusions = append(inclusions, symRef)
+	}
+	return inclusions, includedFields
+}
+
+func resolveRecordTypeInclusions[T symbolResolver](resolver T, typeInclusions []ast.BType) []model.SymbolRef {
+	ctx := resolver.GetCtx()
+	localDefns := resolver.GetTypeDefns()
+	var inclusions []model.SymbolRef
+	for _, inc := range typeInclusions {
+		udt, ok := inc.(*ast.BLangUserDefinedType)
+		if !ok {
+			ctx.SemanticError("type inclusion must be a user-defined type", inc.(ast.BLangNode).GetPosition())
 			continue
+		}
+		ast.Walk(resolver, udt)
+		symRef := udt.Symbol()
+		if tDefn, ok := localDefns[symRef]; ok {
+			if _, ok := tDefn.GetTypeData().TypeDescriptor.(*ast.BLangRecordType); !ok {
+				ctx.SemanticError("included type is not a record type", udt.GetPosition())
+				continue
+			}
+		} else {
+			sym := ctx.GetSymbol(symRef)
+			typeSym, ok := sym.(*model.TypeSymbol)
+			if !ok || typeSym.Type() == nil || !semtypes.IsSubtypeSimple(typeSym.Type(), semtypes.MAPPING) {
+				ctx.SemanticError("included type is not a record type", udt.GetPosition())
+				continue
+			}
 		}
 		inclusions = append(inclusions, symRef)
 	}
 	return inclusions
 }
 
+func collectTransitiveFields(ctx *context.CompilerContext, inclusions []model.SymbolRef, directFields []inclusionMemberForSymbolResolution, localDefns map[model.SymbolRef]model.TypeDefinition) []inclusionMemberForSymbolResolution {
+	var result []inclusionMemberForSymbolResolution
+	for _, symRef := range inclusions {
+		if tDefn, ok := localDefns[symRef]; ok {
+			result = append(result, collectTransitiveFieldsFromDefn(ctx, tDefn, localDefns)...)
+		} else {
+			sym := ctx.GetSymbol(symRef)
+			var typeSym *model.TypeSymbol
+			switch s := sym.(type) {
+			case *model.TypeSymbol:
+				typeSym = s
+			case *model.ClassSymbol:
+				typeSym = &s.TypeSymbol
+			default:
+				continue
+			}
+			for _, m := range typeSym.InclusionMembers() {
+				if m.MemberKind() != model.InclusionMemberKindField {
+					continue
+				}
+				fd := m.(*model.FieldDescriptor)
+				result = append(result, inclusionMemberForSymbolResolution{
+					name:     fd.MemberName(),
+					isPublic: fd.Visibility() == model.VisibilityPublic,
+				})
+			}
+		}
+	}
+	result = append(result, directFields...)
+	return result
+}
+
+func collectTransitiveFieldsFromDefn(ctx *context.CompilerContext, tDefn model.TypeDefinition, localDefns map[model.SymbolRef]model.TypeDefinition) []inclusionMemberForSymbolResolution {
+	switch defn := tDefn.(type) {
+	case *ast.BLangTypeDefinition:
+		objTy, ok := defn.GetTypeData().TypeDescriptor.(*ast.BLangObjectType)
+		if !ok {
+			return nil
+		}
+		var directFields []inclusionMemberForSymbolResolution
+		for m := range objTy.Members() {
+			if m.MemberKind() != model.ObjectMemberKindField {
+				continue
+			}
+			directFields = append(directFields, inclusionMemberForSymbolResolution{
+				name:     m.Name(),
+				isPublic: m.Visibility() == model.VisibilityPublic,
+			})
+		}
+		return collectTransitiveFields(ctx, objTy.Inclusions, directFields, localDefns)
+	case *ast.BLangClassDefinition:
+		var directFields []inclusionMemberForSymbolResolution
+		for _, f := range defn.Fields {
+			field := f.(*ast.BLangSimpleVariable)
+			directFields = append(directFields, inclusionMemberForSymbolResolution{
+				name:     field.Name.Value,
+				isPublic: field.FlagSet.Contains(model.Flag_PUBLIC),
+			})
+		}
+		return collectTransitiveFields(ctx, defn.Inclusions, directFields, localDefns)
+	default:
+		return nil
+	}
+}
+
 func resolveClassDefinition(ms *moduleSymbolResolver, classDef *ast.BLangClassDefinition) {
 	classResolver := newBlockSymbolResolverWithBlockScope(ms, classDef)
 	classDef.SetScope(classResolver.scope)
 
-	classDef.Inclusions = resolveObjectInclusions(ms, classDef.PopUnresolvedInclusions())
+	var includedFields []inclusionMemberForSymbolResolution
+	classDef.Inclusions, includedFields = resolveObjectInclusions(ms, classDef.PopUnresolvedInclusions())
 
 	for _, field := range classDef.Fields {
 		name := field.GetName().GetValue()
@@ -763,29 +904,12 @@ func resolveClassDefinition(ms *moduleSymbolResolver, classDef *ast.BLangClassDe
 		addSymbolAndSetOnNode(classResolver, methodName, symbol, method)
 	}
 
-	inc := collectTransitiveInclusions(ms.ctx, classDef.Inclusions)
-	for _, m := range inc.members {
-		switch {
-		case m.objectMember != nil:
-			if m.objectMember.MemberKind() != model.ObjectMemberKindField {
-				continue
-			}
-			name := m.objectMember.Name()
-			if _, _, exists := classResolver.GetSymbol(name); exists {
-				continue
-			}
-			isPublic := m.objectMember.Visibility() == model.VisibilityPublic
-			symbol := model.NewValueSymbol(name, isPublic, false, false)
-			classResolver.AddSymbol(name, &symbol)
-		case m.classField != nil:
-			name := m.classField.Name.Value
-			if _, _, exists := classResolver.GetSymbol(name); exists {
-				continue
-			}
-			isPublic := m.classField.FlagSet.Contains(model.Flag_PUBLIC)
-			symbol := model.NewValueSymbol(name, isPublic, false, false)
-			classResolver.AddSymbol(name, &symbol)
+	for _, m := range includedFields {
+		if _, _, exists := classResolver.GetSymbol(m.name); exists {
+			continue
 		}
+		symbol := model.NewValueSymbol(m.name, m.isPublic, false, false)
+		classResolver.AddSymbol(m.name, &symbol)
 	}
 
 	if classDef.InitFunction != nil {

--- a/semantics/type_resolver.go
+++ b/semantics/type_resolver.go
@@ -55,8 +55,6 @@ type typeResolver interface {
 	getSymbol(ref model.SymbolRef) model.Symbol
 	unnarrowedSymbol(ref model.SymbolRef) model.SymbolRef
 	symbolName(ref model.SymbolRef) string
-	setTypeDefinition(ref model.SymbolRef, defn model.TypeDefinition)
-	getTypeDefinition(ref model.SymbolRef) (model.TypeDefinition, bool)
 	createNarrowedSymbol(ref model.SymbolRef) model.SymbolRef
 	createFunctionSymbol(space *model.SymbolSpace, name string, sig model.FunctionSignature, fnTy semtypes.SemType) model.SymbolRef
 	compilerContext() *context.CompilerContext
@@ -71,10 +69,16 @@ type typeResolver interface {
 	getCapturedVars() map[model.SymbolRef]bool
 	setCapturedVars(vars map[model.SymbolRef]bool)
 
-	ensureResolved(ref model.SymbolRef) bool
+	ensureResolved(ref model.SymbolRef, depth int) bool
 
 	setMappingAtomBType(mat *semtypes.MappingAtomicType, bType ast.BType)
 	getMappingAtomBType(mat *semtypes.MappingAtomicType) (ast.BType, bool)
+
+	setMappingAtomSymRef(mat *semtypes.MappingAtomicType, ref model.SymbolRef)
+	getMappingAtomSymRef(mat *semtypes.MappingAtomicType) (model.SymbolRef, bool)
+	currentScope() model.Scope
+	setCurrentScope(scope model.Scope)
+	nextDefaultFnName() string
 }
 
 type packageTypeResolver struct {
@@ -89,9 +93,13 @@ type packageTypeResolver struct {
 
 	// packageVarNodes maps a constant's symbol ref to its AST node.
 	// While a constant is being resolved, its entry is set to nil (cycle detection).
-	packageVarNodes    map[model.SymbolRef]*ast.BLangConstant
-	functionNodes      map[model.SymbolRef]*ast.BLangFunction
-	mappingAtomToBType map[*semtypes.MappingAtomicType]ast.BType
+	packageVarNodes      map[model.SymbolRef]*ast.BLangConstant
+	functionNodes        map[model.SymbolRef]*ast.BLangFunction
+	mappingAtomToBType   map[*semtypes.MappingAtomicType]ast.BType
+	typeDefnNodes        map[model.SymbolRef]model.TypeDefinition
+	defaultFnSymbolCount int
+	scope                model.Scope
+	mappingAtomToSymRef  map[*semtypes.MappingAtomicType]model.SymbolRef
 }
 
 func (t *packageTypeResolver) typeContext() semtypes.Context        { return t.tyCtx }
@@ -135,14 +143,6 @@ func (t *packageTypeResolver) symbolName(ref model.SymbolRef) string {
 	return t.ctx.SymbolName(ref)
 }
 
-func (t *packageTypeResolver) setTypeDefinition(ref model.SymbolRef, defn model.TypeDefinition) {
-	t.ctx.SetTypeDefinition(ref, defn)
-}
-
-func (t *packageTypeResolver) getTypeDefinition(ref model.SymbolRef) (model.TypeDefinition, bool) {
-	return t.ctx.GetTypeDefinition(ref)
-}
-
 func (t *packageTypeResolver) createNarrowedSymbol(ref model.SymbolRef) model.SymbolRef {
 	return t.ctx.CreateNarrowedSymbol(ref)
 }
@@ -162,6 +162,24 @@ func (t *packageTypeResolver) setMappingAtomBType(mat *semtypes.MappingAtomicTyp
 func (t *packageTypeResolver) getMappingAtomBType(mat *semtypes.MappingAtomicType) (ast.BType, bool) {
 	bType, ok := t.mappingAtomToBType[mat]
 	return bType, ok
+}
+
+func (t *packageTypeResolver) setMappingAtomSymRef(mat *semtypes.MappingAtomicType, ref model.SymbolRef) {
+	t.mappingAtomToSymRef[mat] = ref
+}
+
+func (t *packageTypeResolver) getMappingAtomSymRef(mat *semtypes.MappingAtomicType) (model.SymbolRef, bool) {
+	ref, ok := t.mappingAtomToSymRef[mat]
+	return ref, ok
+}
+
+func (t *packageTypeResolver) currentScope() model.Scope     { return t.scope }
+func (t *packageTypeResolver) setCurrentScope(s model.Scope) { t.scope = s }
+
+func (t *packageTypeResolver) nextDefaultFnName() string {
+	name := fmt.Sprintf("$desugar$%d", t.defaultFnSymbolCount)
+	t.defaultFnSymbolCount++
+	return name
 }
 
 func (t *packageTypeResolver) lookupImportedSymbols(name string) (model.ExportedSymbolSpace, bool) {
@@ -199,6 +217,9 @@ type functionTypeResolver struct {
 	implicitImports      map[string]ast.BLangImportPackage
 	capturedNarrowedVars map[model.SymbolRef]bool
 	mappingAtomToBType   map[*semtypes.MappingAtomicType]ast.BType
+	defaultFnSymbolCount int
+	scope                model.Scope
+	mappingAtomToSymRef  map[*semtypes.MappingAtomicType]model.SymbolRef
 }
 
 func (f *functionTypeResolver) typeContext() semtypes.Context        { return f.tyCtx }
@@ -242,14 +263,6 @@ func (f *functionTypeResolver) symbolName(ref model.SymbolRef) string {
 	return f.parentResolver.symbolName(ref)
 }
 
-func (f *functionTypeResolver) setTypeDefinition(ref model.SymbolRef, defn model.TypeDefinition) {
-	f.parentResolver.setTypeDefinition(ref, defn)
-}
-
-func (f *functionTypeResolver) getTypeDefinition(ref model.SymbolRef) (model.TypeDefinition, bool) {
-	return f.parentResolver.getTypeDefinition(ref)
-}
-
 func (f *functionTypeResolver) createNarrowedSymbol(ref model.SymbolRef) model.SymbolRef {
 	return f.parentResolver.createNarrowedSymbol(ref)
 }
@@ -289,8 +302,8 @@ func (f *functionTypeResolver) setCapturedVars(vars map[model.SymbolRef]bool) {
 	f.capturedNarrowedVars = vars
 }
 
-func (f *functionTypeResolver) ensureResolved(ref model.SymbolRef) bool {
-	return f.parentResolver.ensureResolved(ref)
+func (f *functionTypeResolver) ensureResolved(ref model.SymbolRef, depth int) bool {
+	return f.parentResolver.ensureResolved(ref, depth)
 }
 
 func (f *functionTypeResolver) setMappingAtomBType(mat *semtypes.MappingAtomicType, bType ast.BType) {
@@ -304,26 +317,48 @@ func (f *functionTypeResolver) getMappingAtomBType(mat *semtypes.MappingAtomicTy
 	return f.parentResolver.getMappingAtomBType(mat)
 }
 
-func newPackageTypeResolver(ctx *context.CompilerContext, pkg *ast.BLangPackage, importedSymbols map[string]model.ExportedSymbolSpace) *packageTypeResolver {
+func (f *functionTypeResolver) setMappingAtomSymRef(mat *semtypes.MappingAtomicType, ref model.SymbolRef) {
+	f.mappingAtomToSymRef[mat] = ref
+}
+
+func (f *functionTypeResolver) getMappingAtomSymRef(mat *semtypes.MappingAtomicType) (model.SymbolRef, bool) {
+	if ref, ok := f.mappingAtomToSymRef[mat]; ok {
+		return ref, ok
+	}
+	return f.parentResolver.getMappingAtomSymRef(mat)
+}
+
+func (f *functionTypeResolver) currentScope() model.Scope     { return f.scope }
+func (f *functionTypeResolver) setCurrentScope(s model.Scope) { f.scope = s }
+
+func (f *functionTypeResolver) nextDefaultFnName() string {
+	name := fmt.Sprintf("$desugar$%d", f.defaultFnSymbolCount)
+	f.defaultFnSymbolCount++
+	return name
+}
+
+func newPackageTypeResolver(ctx *context.CompilerContext, pkg *ast.BLangPackage, importedSymbols map[string]model.ExportedSymbolSpace, moduleScope model.Scope) *packageTypeResolver {
 	return &packageTypeResolver{
-		ctx:                ctx,
-		tyCtx:              semtypes.ContextFrom(ctx.GetTypeEnv()),
-		importedSymbols:    importedSymbols,
-		pkg:                pkg,
-		implicitImports:    make(map[string]ast.BLangImportPackage),
-		packageVarNodes:    make(map[model.SymbolRef]*ast.BLangConstant),
-		functionNodes:      make(map[model.SymbolRef]*ast.BLangFunction),
-		mappingAtomToBType: make(map[*semtypes.MappingAtomicType]ast.BType),
+		ctx:                 ctx,
+		tyCtx:               semtypes.ContextFrom(ctx.GetTypeEnv()),
+		importedSymbols:     importedSymbols,
+		pkg:                 pkg,
+		implicitImports:     make(map[string]ast.BLangImportPackage),
+		packageVarNodes:     make(map[model.SymbolRef]*ast.BLangConstant),
+		functionNodes:       make(map[model.SymbolRef]*ast.BLangFunction),
+		mappingAtomToBType:  make(map[*semtypes.MappingAtomicType]ast.BType),
+		typeDefnNodes:       make(map[model.SymbolRef]model.TypeDefinition),
+		mappingAtomToSymRef: make(map[*semtypes.MappingAtomicType]model.SymbolRef),
+		scope:               moduleScope,
 	}
 }
 
-func (t *packageTypeResolver) ensureResolved(ref model.SymbolRef) bool {
+func (t *packageTypeResolver) ensureResolved(ref model.SymbolRef, depth int) bool {
 	if t.symbolType(ref) != nil {
 		return true
 	}
-	// Type definitions manage their own cycle detection via CycleDepth
-	if defn, ok := t.getTypeDefinition(ref); ok {
-		_, ok := resolveTypeDefinition(t, defn, 0)
+	if defn, ok := t.typeDefnNodes[ref]; ok {
+		_, ok := resolveTypeDefinition(t, defn, depth)
 		return ok
 	}
 	if c, inMap := t.packageVarNodes[ref]; inMap {
@@ -347,62 +382,34 @@ func (t *packageTypeResolver) ensureResolved(ref model.SymbolRef) bool {
 // After this (for the given package) all the semtypes are known. This means after resolving types of all the packages
 // it is safe to use the closed world assumption to optimize type checks.
 func ResolveTopLevelNodes(ctx *context.CompilerContext, pkg *ast.BLangPackage, importedSymbols map[string]model.ExportedSymbolSpace) {
-	t := newPackageTypeResolver(ctx, pkg, importedSymbols)
-	t.resolveTopLevelTypes(ctx, pkg)
+	t := newPackageTypeResolver(ctx, pkg, importedSymbols, pkg.Scope)
+	t.resolveTopLevelTypes(pkg)
 }
 
-func populateMappingAtomBTypes(t typeResolver, pkg *ast.BLangPackage, importedSymbols map[string]model.ExportedSymbolSpace) {
+func populateMappingAtomMaps(t typeResolver, pkg *ast.BLangPackage, importedSymbols map[string]model.ExportedSymbolSpace) {
 	for i := range pkg.TypeDefinitions {
 		defn := &pkg.TypeDefinitions[i]
 		semType := t.symbolType(defn.Symbol())
-		if semType == nil {
-			continue
-		}
-		switch bType := defn.GetTypeData().TypeDescriptor.(type) {
-		case *ast.BLangRecordType:
+		if _, ok := defn.GetTypeData().TypeDescriptor.(*ast.BLangRecordType); ok {
 			mat := semtypes.ToMappingAtomicType(t.typeContext(), semType)
 			if mat == nil {
 				t.internalError("failed to extract mapping atomic type for record type", defn.GetPosition())
 			}
-			t.setMappingAtomBType(mat, bType)
-		case *ast.BLangConstrainedType:
-			if bType.GetTypeKind() == model.TypeKind_MAP {
-				mat := semtypes.ToMappingAtomicType(t.typeContext(), semType)
-				if mat == nil {
-					t.internalError("failed to extract mapping atomic type for map type", defn.GetPosition())
-				}
-				t.setMappingAtomBType(mat, bType)
-			}
+			t.setMappingAtomSymRef(mat, defn.Symbol())
 		}
 	}
 	for _, symbolSpace := range importedSymbols {
-		main := symbolSpace.Main
-		for i, sym := range main.Symbols() {
-			if sym.Kind() != model.SymbolKindType || !sym.IsPublic() {
-				continue
-			}
-			ref := main.RefAt(i)
-			defn, ok := t.getTypeDefinition(ref)
-			if !ok {
+		for ref, sym := range symbolSpace.PublicMainSymbols() {
+			if sym.Kind() != model.SymbolKindType {
 				continue
 			}
 			semType := t.symbolType(ref)
 			if semType == nil {
 				continue
 			}
-			switch bType := defn.GetTypeData().TypeDescriptor.(type) {
-			case *ast.BLangRecordType:
-				mat := semtypes.ToMappingAtomicType(t.typeContext(), semType)
-				if mat != nil {
-					t.setMappingAtomBType(mat, bType)
-				}
-			case *ast.BLangConstrainedType:
-				if bType.GetTypeKind() == model.TypeKind_MAP {
-					mat := semtypes.ToMappingAtomicType(t.typeContext(), semType)
-					if mat != nil {
-						t.setMappingAtomBType(mat, bType)
-					}
-				}
+			mat := semtypes.ToMappingAtomicType(t.typeContext(), semType)
+			if mat != nil {
+				t.setMappingAtomSymRef(mat, ref)
 			}
 		}
 	}
@@ -410,8 +417,8 @@ func populateMappingAtomBTypes(t typeResolver, pkg *ast.BLangPackage, importedSy
 
 // ResolveLocalNodes resolves the types of function bodies and remaining inner nodes.
 func ResolveLocalNodes(ctx *context.CompilerContext, pkg *ast.BLangPackage, importedSymbols map[string]model.ExportedSymbolSpace) {
-	p := newPackageTypeResolver(ctx, pkg, importedSymbols)
-	populateMappingAtomBTypes(p, pkg, importedSymbols)
+	p := newPackageTypeResolver(ctx, pkg, importedSymbols, pkg.Scope)
+	populateMappingAtomMaps(p, pkg, importedSymbols)
 	var fns []*ast.BLangFunction
 	for i := range pkg.Functions {
 		fns = append(fns, &pkg.Functions[i])
@@ -433,10 +440,12 @@ func ResolveLocalNodes(ctx *context.CompilerContext, pkg *ast.BLangPackage, impo
 	for i := range pkg.ClassDefinitions {
 		classDef := &pkg.ClassDefinitions[i]
 		ft := &functionTypeResolver{
-			parentResolver:     p,
-			tyCtx:              semtypes.ContextFrom(p.typeEnv()),
-			implicitImports:    make(map[string]ast.BLangImportPackage),
-			mappingAtomToBType: make(map[*semtypes.MappingAtomicType]ast.BType),
+			parentResolver:      p,
+			tyCtx:               semtypes.ContextFrom(p.typeEnv()),
+			implicitImports:     make(map[string]ast.BLangImportPackage),
+			mappingAtomToBType:  make(map[*semtypes.MappingAtomicType]ast.BType),
+			scope:               classDef.Scope(),
+			mappingAtomToSymRef: make(map[*semtypes.MappingAtomicType]model.SymbolRef),
 		}
 		for _, f := range classDef.Fields {
 			field := f.(*ast.BLangSimpleVariable)
@@ -474,11 +483,13 @@ func resolveFunctionBody(p *packageTypeResolver, fn *ast.BLangFunction) *functio
 		return nil
 	}
 	ft := &functionTypeResolver{
-		parentResolver:     p,
-		tyCtx:              semtypes.ContextFrom(p.typeEnv()),
-		retTy:              fnSym.Signature().ReturnType,
-		implicitImports:    make(map[string]ast.BLangImportPackage),
-		mappingAtomToBType: make(map[*semtypes.MappingAtomicType]ast.BType),
+		parentResolver:      p,
+		tyCtx:               semtypes.ContextFrom(p.typeEnv()),
+		retTy:               fnSym.Signature().ReturnType,
+		implicitImports:     make(map[string]ast.BLangImportPackage),
+		mappingAtomToBType:  make(map[*semtypes.MappingAtomicType]ast.BType),
+		scope:               fn.Scope(),
+		mappingAtomToSymRef: make(map[*semtypes.MappingAtomicType]model.SymbolRef),
 	}
 	switch body := fn.Body.(type) {
 	case *ast.BLangExternFunctionBody:
@@ -494,10 +505,14 @@ func resolveFunctionBody(p *packageTypeResolver, fn *ast.BLangFunction) *functio
 	return ft
 }
 
-func (t *packageTypeResolver) resolveTopLevelTypes(ctx *context.CompilerContext, pkg *ast.BLangPackage) {
+func (t *packageTypeResolver) resolveTopLevelTypes(pkg *ast.BLangPackage) {
 	for i := range pkg.TypeDefinitions {
 		defn := &pkg.TypeDefinitions[i]
-		ctx.SetTypeDefinition(defn.Symbol(), defn)
+		t.typeDefnNodes[defn.Symbol()] = defn
+	}
+	for i := range pkg.ClassDefinitions {
+		classDef := &pkg.ClassDefinitions[i]
+		t.typeDefnNodes[classDef.Symbol()] = classDef
 	}
 	for i := range pkg.Constants {
 		t.packageVarNodes[pkg.Constants[i].Symbol()] = &pkg.Constants[i]
@@ -611,6 +626,13 @@ func resolveAssignment(t typeResolver, chain *binding, s assignmentNode) (statem
 }
 
 func resolveStatementInner(t typeResolver, chain *binding, stmt ast.BLangStatement) (statementEffect, bool) {
+	if scoped, ok := stmt.(ast.NodeWithScope); ok {
+		if scope := scoped.Scope(); scope != nil {
+			prev := t.currentScope()
+			t.setCurrentScope(scope)
+			defer t.setCurrentScope(prev)
+		}
+	}
 	switch s := stmt.(type) {
 	case *ast.BLangSimpleVariableDef:
 		return resolveVariableDefStmt(t, chain, s)
@@ -780,11 +802,13 @@ func resolveLambdaFunctionExpr(t typeResolver, chain *binding, e *ast.BLangLambd
 	// Create a function type resolver for the lambda so expectedReturnType() is correct
 	fnSym := t.getSymbol(e.Function.Symbol()).(model.FunctionSymbol)
 	ft := &functionTypeResolver{
-		parentResolver:     t,
-		tyCtx:              semtypes.ContextFrom(t.typeEnv()),
-		retTy:              fnSym.Signature().ReturnType,
-		implicitImports:    make(map[string]ast.BLangImportPackage),
-		mappingAtomToBType: make(map[*semtypes.MappingAtomicType]ast.BType),
+		parentResolver:      t,
+		tyCtx:               semtypes.ContextFrom(t.typeEnv()),
+		retTy:               fnSym.Signature().ReturnType,
+		implicitImports:     make(map[string]ast.BLangImportPackage),
+		mappingAtomToBType:  make(map[*semtypes.MappingAtomicType]ast.BType),
+		scope:               e.Function.Scope(),
+		mappingAtomToSymRef: make(map[*semtypes.MappingAtomicType]model.SymbolRef),
 	}
 
 	// Push function boundary marker onto the chain
@@ -860,6 +884,16 @@ func setOtherNodesAsNever(node ast.BLangNode) {
 	ast.Walk(neverVisitor{}, node)
 }
 
+func allocateDefaultFnSymbol(t typeResolver, fieldTy semtypes.SemType) model.SymbolRef {
+	fnName := t.nextDefaultFnName()
+	sig := model.FunctionSignature{ReturnType: fieldTy}
+	fnSymbol := model.NewFunctionSymbol(fnName, sig, false)
+	scope := t.currentScope()
+	scope.AddSymbol(fnName, fnSymbol)
+	ref, _ := scope.GetSymbol(fnName)
+	return ref
+}
+
 func resolveTypeDefinition(t typeResolver, defn model.TypeDefinition, depth int) (semtypes.SemType, bool) {
 	if ty := t.symbolType(defn.Symbol()); ty != nil {
 		return ty, true
@@ -886,6 +920,7 @@ func resolveTypeDefinition(t typeResolver, defn model.TypeDefinition, depth int)
 		typeData := defn.GetTypeData()
 		typeData.Type = semType
 		defn.SetTypeData(typeData)
+		addInclusionsToTypeSymbol(t, defn)
 		return semType, true
 	} else {
 		// This can happen with recursion
@@ -893,6 +928,216 @@ func resolveTypeDefinition(t typeResolver, defn model.TypeDefinition, depth int)
 		// and throw away the others
 		return defn.GetDeterminedType(), true
 	}
+}
+
+// addInclusionsToTypeSymbol addes all the inclusions (both transitive and direct) to the type symbol
+// This should be called only after resolving the underlying type
+func addInclusionsToTypeSymbol(t typeResolver, defn model.TypeDefinition) {
+	typeSym := getTypeSymFromDefn(t, defn)
+	var members []model.InclusionMember
+	switch d := defn.(type) {
+	case *ast.BLangTypeDefinition:
+		typeDesc := d.GetTypeData().TypeDescriptor
+		switch td := typeDesc.(type) {
+		case *ast.BLangRecordType:
+			members = recordTypeMembers(t, td)
+		case *ast.BLangObjectType:
+			members = objectTypeMembers(t, td)
+		}
+	case *ast.BLangClassDefinition:
+		members = classMembers(t, d)
+	}
+	for _, m := range members {
+		typeSym.AddInclusionMember(m)
+	}
+}
+
+func getTypeSymFromDefn(t typeResolver, defn model.TypeDefinition) *model.TypeSymbol {
+	sym := t.getSymbol(defn.Symbol())
+	switch s := sym.(type) {
+	case *model.TypeSymbol:
+		return s
+	case *model.ClassSymbol:
+		return &s.TypeSymbol
+	default:
+		t.internalError("Unexpected type defintion", defn.GetPosition())
+		return nil
+	}
+}
+
+func getTypeSymbol(t typeResolver, ref model.SymbolRef) *model.TypeSymbol {
+	sym := t.getSymbol(ref)
+	switch s := sym.(type) {
+	case *model.TypeSymbol:
+		return s
+	case *model.ClassSymbol:
+		return &s.TypeSymbol
+	default:
+		return nil
+	}
+}
+
+// recordTypeMembers accumulates members both added by type inclusion and defined in the record type itself
+func recordTypeMembers(t typeResolver, td *ast.BLangRecordType) []model.InclusionMember {
+	var members []model.InclusionMember
+	directFields := make(map[string]bool)
+	for name := range td.Fields() {
+		directFields[name] = true
+	}
+
+	// Add direct fields
+	for name, field := range td.FieldPtrs() {
+		fd := createFieldDescriptor(name, *field)
+		members = append(members, &fd)
+	}
+
+	// Collect transitive members from included types
+	for _, symRef := range td.Inclusions {
+		incSym := getTypeSymbol(t, symRef)
+		if incSym == nil {
+			t.internalError("failed to find included symbol", td.GetPosition())
+			continue
+		}
+		for _, m := range incSym.InclusionMembers() {
+			switch member := m.(type) {
+			case *model.FieldDescriptor:
+				if directFields[member.MemberName()] {
+					continue
+				}
+				members = append(members, member)
+			case *model.RestTypeDescriptor:
+				members = append(members, member)
+			default:
+				t.internalError("unexpected member kind", td.GetPosition())
+			}
+		}
+	}
+
+	// Add rest type from this record's own rest type
+	if td.RestType != nil {
+		rd := model.NewRestTypeDescriptor()
+		rd.SetMemberType(td.RestType.(ast.BLangNode).GetDeterminedType())
+		members = append(members, &rd)
+	}
+	return members
+}
+
+// objectTypeMembers accumulate members both added by type inclusion and defined in the type desc itself
+func objectTypeMembers(t typeResolver, td *ast.BLangObjectType) []model.InclusionMember {
+	var members []model.InclusionMember
+	// Collect transitive members from included types
+	for _, symRef := range td.Inclusions {
+		incSym := getTypeSymbol(t, symRef)
+		if incSym == nil {
+			t.internalError("failed to find included symbol", td.GetPosition())
+			return nil
+		}
+		members = append(members, incSym.InclusionMembers()...)
+	}
+	// Add direct members
+	for m := range td.Members() {
+		switch member := m.(type) {
+		case *ast.BObjectField:
+			fd := objectFieldDescriptor(member)
+			members = append(members, &fd)
+		case *ast.BMethodDecl:
+			md := methodDescriptor(member, model.SymbolRef{})
+			members = append(members, &md)
+		}
+	}
+	return members
+}
+
+// classMembers accumulate members both added by type inclusion and defined in the class decl itself
+func classMembers(t typeResolver, classDef *ast.BLangClassDefinition) []model.InclusionMember {
+	var members []model.InclusionMember
+	// Collect transitive members from included types
+	for _, symRef := range classDef.Inclusions {
+		incSym := getTypeSymbol(t, symRef)
+		if incSym == nil {
+			t.internalError("failed to find included symbol", classDef.GetPosition())
+			return nil
+		}
+		members = append(members, incSym.InclusionMembers()...)
+	}
+	// Add direct members
+	for _, f := range classDef.Fields {
+		field := f.(*ast.BLangSimpleVariable)
+		fd := classFieldDescriptor(t, field)
+		members = append(members, &fd)
+	}
+	for name := range classDef.Methods {
+		method := classDef.Methods[name]
+		md := classMethodDescriptor(t, name, method)
+		members = append(members, &md)
+	}
+	return members
+}
+
+func objectFieldDescriptor(field *ast.BObjectField) model.FieldDescriptor {
+	fd := model.NewFieldDescriptor(field.Name(), 0, field.Visibility())
+	fd.SetMemberType(field.GetDeterminedType())
+	return fd
+}
+
+func methodDescriptor(method *ast.BMethodDecl, fnRef model.SymbolRef) model.MethodDescriptor {
+	kind := model.InclusionMemberKindMethod
+	switch method.MemberKind() {
+	case model.ObjectMemberKindRemoteMethod:
+		kind = model.InclusionMemberKindRemoteMethod
+	case model.ObjectMemberKindResourceMethod:
+		kind = model.InclusionMemberKindResourceMethod
+	}
+	md := model.NewMethodDescriptor(method.Name(), kind, method.Visibility(), fnRef)
+	md.SetMemberType(method.GetDeterminedType())
+	return md
+}
+
+func classFieldDescriptor(t typeResolver, field *ast.BLangSimpleVariable) model.FieldDescriptor {
+	vis := model.VisibilityPrivate
+	if field.FlagSet.Contains(model.Flag_PUBLIC) {
+		vis = model.VisibilityPublic
+	}
+	var flags model.FieldDescriptorFlag
+	if field.FlagSet.Contains(model.Flag_READONLY) {
+		flags |= model.FieldDescriptorReadonly
+	}
+	fd := model.NewFieldDescriptor(field.Name.Value, flags, vis)
+	fd.SetMemberType(t.symbolType(field.Symbol()))
+	return fd
+}
+
+func classMethodDescriptor(t typeResolver, name string, method *ast.BLangFunction) model.MethodDescriptor {
+	vis := model.VisibilityPrivate
+	if method.FlagSet.Contains(model.Flag_PUBLIC) {
+		vis = model.VisibilityPublic
+	}
+	kind := model.InclusionMemberKindMethod
+	if method.FlagSet.Contains(model.Flag_REMOTE) {
+		kind = model.InclusionMemberKindRemoteMethod
+	} else if method.FlagSet.Contains(model.Flag_RESOURCE) {
+		kind = model.InclusionMemberKindResourceMethod
+	}
+	md := model.NewMethodDescriptor(name, kind, vis, method.Symbol())
+	md.SetMemberType(t.symbolType(method.Symbol()))
+	return md
+}
+
+func createFieldDescriptor(name string, field ast.BField) model.FieldDescriptor {
+	var flags model.FieldDescriptorFlag
+	if field.FlagSet.Contains(model.Flag_READONLY) {
+		flags |= model.FieldDescriptorReadonly
+	}
+	if field.FlagSet.Contains(model.Flag_OPTIONAL) {
+		flags |= model.FieldDescriptorOptional
+	}
+	if field.DefaultExpr != nil {
+		flags |= model.FieldDescriptorHasDefault
+	}
+	fd := model.NewFieldDescriptor(name, flags, model.VisibilityPublic)
+	fd.SetMemberType(field.Type.(ast.BLangNode).GetDeterminedType())
+	fd.DefaultFnRef = field.DefaultFnRef
+	return fd
 }
 
 func resolveClassDefinitionType(t typeResolver, classDef *ast.BLangClassDefinition, depth int) (semtypes.SemType, bool) {
@@ -940,22 +1185,23 @@ func resolveClassDefinitionType(t typeResolver, classDef *ast.BLangClassDefiniti
 		method.Name.SetDeterminedType(semtypes.NEVER)
 	}
 
-	// Collect included members
+	// Collect included members from symbols
 	includedMembers := make(map[string][]semtypes.Member)
-	inc := collectTransitiveInclusions(t.compilerContext(), classDef.Inclusions)
-	if !resolveIncludedDefns(t, inc.defns, depth) {
+	incMembers, err := collectIncludedMembers(t, classDef.Inclusions, depth)
+	if err {
+		t.semanticError("error resolving type inclusion", classDef.GetPosition())
 		return nil, false
 	}
-	for _, m := range inc.members {
-		member, ok := resolveIncludedMember(t, m, depth)
-		if !ok {
-			return nil, false
+	for _, m := range incMembers {
+		if m.MemberKind() == model.InclusionMemberKindRestType {
+			t.internalError("unexpected rest inclusion", classDef.GetPosition())
 		}
+		member := inclusionMemberToSemtypeMember(m)
 		includedMembers[member.Name] = append(includedMembers[member.Name], member)
 	}
 
-	// Build direct field members
-	var members []semtypes.Member
+	// Build direct members
+	var directMembers []directMember
 	for _, f := range classDef.Fields {
 		field := f.(*ast.BLangSimpleVariable)
 		fieldTy := field.GetDeterminedType()
@@ -963,32 +1209,13 @@ func resolveClassDefinitionType(t typeResolver, classDef *ast.BLangClassDefiniti
 		if field.FlagSet.Contains(model.Flag_PUBLIC) {
 			vis = semtypes.VisibilityPublic
 		}
-		name := field.Name.Value
-		if incMembers, exists := includedMembers[name]; exists {
-			for _, incMember := range incMembers {
-				if incMember.Kind != semtypes.MemberKindField {
-					t.semanticError(
-						fmt.Sprintf("field '%s' conflicts with included member of different kind", name),
-						field.GetPosition(),
-					)
-					return nil, false
-				}
-				if !semtypes.IsSubtype(t.typeContext(), fieldTy, incMember.ValueTy) {
-					t.semanticError(
-						fmt.Sprintf("field '%s' that overrides included field is not a subtype of the included field type", name),
-						field.GetPosition(),
-					)
-					return nil, false
-				}
-			}
-			delete(includedMembers, name)
-		}
-		members = append(members, semtypes.Member{
-			Name:       name,
-			ValueTy:    fieldTy,
-			Kind:       semtypes.MemberKindField,
-			Visibility: vis,
-			Immutable:  false,
+		directMembers = append(directMembers, directMember{
+			name:       field.Name.Value,
+			valueTy:    fieldTy,
+			kind:       semtypes.MemberKindField,
+			visibility: vis,
+			immutable:  false,
+			pos:        field.GetPosition(),
 		})
 	}
 
@@ -1000,12 +1227,13 @@ func resolveClassDefinitionType(t typeResolver, classDef *ast.BLangClassDefiniti
 		if !semtypes.IsSubtype(tyCtx, sig.ReturnType, semtypes.Union(semtypes.ERROR, semtypes.NIL)) {
 			t.semanticError("invalid return type for init function", classDef.InitFunction.GetPosition())
 		}
-		members = append(members, semtypes.Member{
-			Name:       "init",
-			ValueTy:    t.symbolType(classDef.InitFunction.Symbol()),
-			Kind:       semtypes.MemberKindMethod,
-			Visibility: semtypes.VisibilityPublic,
-			Immutable:  true,
+		directMembers = append(directMembers, directMember{
+			name:       "init",
+			valueTy:    t.symbolType(classDef.InitFunction.Symbol()),
+			kind:       semtypes.MemberKindMethod,
+			visibility: semtypes.VisibilityPublic,
+			immutable:  true,
+			pos:        classDef.InitFunction.GetPosition(),
 		})
 	} else {
 		// Add implicit init member with no parameters and return type ()
@@ -1014,12 +1242,12 @@ func resolveClassDefinitionType(t typeResolver, classDef *ast.BLangClassDefiniti
 		functionDefn := semtypes.NewFunctionDefinition()
 		initFnType := functionDefn.Define(t.typeEnv(), paramListTy, semtypes.NIL,
 			semtypes.FunctionQualifiersFrom(t.typeEnv(), false, false))
-		members = append(members, semtypes.Member{
-			Name:       "init",
-			ValueTy:    initFnType,
-			Kind:       semtypes.MemberKindMethod,
-			Visibility: semtypes.VisibilityPublic,
-			Immutable:  true,
+		directMembers = append(directMembers, directMember{
+			name:       "init",
+			valueTy:    initFnType,
+			kind:       semtypes.MemberKindMethod,
+			visibility: semtypes.VisibilityPublic,
+			immutable:  true,
 		})
 	}
 	for name := range classDef.Methods {
@@ -1035,60 +1263,18 @@ func resolveClassDefinitionType(t typeResolver, classDef *ast.BLangClassDefiniti
 		} else if method.FlagSet.Contains(model.Flag_RESOURCE) {
 			memberKind = semtypes.MemberKindResourceMethod
 		}
-		if incMembers, exists := includedMembers[name]; exists {
-			for _, incMember := range incMembers {
-				if incMember.Kind != memberKind {
-					t.semanticError(
-						fmt.Sprintf("method '%s' conflicts with included member of different kind", name),
-						method.GetPosition(),
-					)
-					return nil, false
-				}
-				if !semtypes.IsSubtype(t.typeContext(), methodTy, incMember.ValueTy) {
-					t.semanticError(
-						fmt.Sprintf("method '%s' that overrides included method is not a subtype of the included method type", name),
-						method.GetPosition(),
-					)
-					return nil, false
-				}
-			}
-			delete(includedMembers, name)
-		}
-		members = append(members, semtypes.Member{
-			Name:       name,
-			ValueTy:    methodTy,
-			Kind:       memberKind,
-			Visibility: vis,
-			Immutable:  true,
+		directMembers = append(directMembers, directMember{
+			name:       name,
+			valueTy:    methodTy,
+			kind:       memberKind,
+			visibility: vis,
+			immutable:  true,
+			pos:        method.GetPosition(),
 		})
 	}
 
-	// Verify all included members are overridden
-	for name, incMembers := range includedMembers {
-		// Included fields without override are inherited
-		if len(incMembers) == 1 && incMembers[0].Kind == semtypes.MemberKindField {
-			members = append(members, incMembers[0])
-			continue
-		}
-		// Multiple included fields with same name must be overridden
-		allFields := true
-		for _, m := range incMembers {
-			if m.Kind != semtypes.MemberKindField {
-				allFields = false
-				break
-			}
-		}
-		if allFields {
-			t.semanticError(
-				fmt.Sprintf("included field '%s' declared in multiple type inclusions must be overridden", name),
-				classDef.GetPosition(),
-			)
-			return nil, false
-		}
-		t.semanticError(
-			fmt.Sprintf("included method '%s' must be overridden in class definition", name),
-			classDef.GetPosition(),
-		)
+	members, ok := validateOverridesAndMerge(t, directMembers, includedMembers, classDef.GetPosition(), false)
+	if !ok {
 		return nil, false
 	}
 
@@ -1108,6 +1294,7 @@ func resolveClassDefinitionType(t typeResolver, classDef *ast.BLangClassDefiniti
 	typeData := classDef.GetTypeData()
 	typeData.Type = semType
 	classDef.SetTypeData(typeData)
+	addInclusionsToTypeSymbol(t, classDef)
 
 	// Set self symbol type
 	selfRef, ok := classDef.Scope().GetSymbol("self")
@@ -1656,7 +1843,7 @@ func resolveMappingConstructorWithExpectedType(t typeResolver, chain *binding, e
 
 	resultType, mat, ok := selectMappingInherentType(t, e, expectedType)
 	if !ok {
-		return resolveMappingConstructorBottomUp(t, chain, e)
+		return nil, expressionEffect{}, false
 	}
 
 	for _, f := range e.Fields {
@@ -1670,9 +1857,19 @@ func resolveMappingConstructorWithExpectedType(t typeResolver, chain *binding, e
 	}
 
 	e.AtomicType = *mat
-	// We can have cases where this is no the case like any a = {foo:"bar"}
-	if bType, ok := t.getMappingAtomBType(mat); ok {
-		e.ContextuallyExpectedType = bType
+	if ref, ok := t.getMappingAtomSymRef(mat); ok {
+		typeSym := t.getSymbol(ref).(*model.TypeSymbol)
+		e.FieldDefaults = typeSym.FieldDefaults()
+	} else if bType, ok := t.getMappingAtomBType(mat); ok {
+		// This happens for inline record type definitions given they don't have type symbol. Need to think of a way
+		// to properly handle this
+		if recTy, ok := bType.(*ast.BLangRecordType); ok {
+			for name, field := range recTy.Fields() {
+				if field.DefaultExpr != nil {
+					e.FieldDefaults = append(e.FieldDefaults, model.FieldDefault{FieldName: name, FnRef: field.DefaultFnRef})
+				}
+			}
+		}
 	}
 	setExpectedType(e, resultType)
 	return resultType, defaultExpressionEffect(chain), true
@@ -1964,6 +2161,7 @@ func mapQuerySelectExpectedType(env semtypes.Env) semtypes.SemType {
 	valueTy := semtypes.Union(semtypes.ANY, semtypes.ERROR)
 	return ld.DefineListTypeWrapped(env, []semtypes.SemType{semtypes.STRING, valueTy}, 2, semtypes.NEVER, semtypes.CellMutability_CELL_MUT_LIMITED)
 }
+
 func resolveQueryIntermediateClauses(t typeResolver, chain *binding, queryExpr *ast.BLangQueryExpr) (*binding, bool) {
 	currentChain := chain
 	for i := 1; i < len(queryExpr.QueryClauseList)-1; i++ {
@@ -2033,7 +2231,7 @@ func resolveSimpleVarRef(t typeResolver, chain *binding, expr *ast.BLangSimpleVa
 	if isCaptured {
 		t.trackCapturedVar(baseSymbol)
 	}
-	if !t.ensureResolved(sym) {
+	if !t.ensureResolved(sym, 0) {
 		return nil, defaultExpressionEffect(chain), false
 	}
 	ty := t.symbolType(sym)
@@ -2051,7 +2249,7 @@ func resolveConstRef(t typeResolver, chain *binding, expr *ast.BLangConstRef) (s
 	if isNarrowed {
 		expr.SetSymbol(sym)
 	}
-	if !t.ensureResolved(sym) {
+	if !t.ensureResolved(sym, 0) {
 		return nil, defaultExpressionEffect(chain), false
 	}
 	ty := t.symbolType(sym)
@@ -2978,12 +3176,10 @@ func resolveBTypeInner(t typeResolver, btype ast.BType, depth int) (semtypes.Sem
 		if ty.PkgAlias.Value != "" {
 			return t.symbolType(symbol), true
 		}
-		defn, ok := t.getTypeDefinition(symbol)
-		if !ok {
-			t.internalError("type definition not found", nil)
+		if !t.ensureResolved(symbol, depth) {
 			return nil, false
 		}
-		return resolveTypeDefinition(t, defn, depth)
+		return t.symbolType(symbol), true
 	case *ast.BLangFiniteTypeNode:
 		var result semtypes.SemType = semtypes.NEVER
 		for _, value := range ty.ValueSpace {
@@ -3058,14 +3254,16 @@ func resolveBTypeInner(t typeResolver, btype ast.BType, depth int) (semtypes.Sem
 		d := semtypes.NewMappingDefinition()
 		ty.Definition = &d
 
-		includedFields := make(map[string][]ast.BField)
-		needsRestOverride, includedRest, ok := accumIncludedFields(t, ty, includedFields, false, nil)
+		// Resolve and collect included members from symbols
+		result, ok := resolveRecordInclusions(t, ty, depth)
 		if !ok {
 			return nil, false
 		}
+
 		seen := make(map[string]bool)
 		var fields []semtypes.Field
-		for name, field := range ty.Fields() {
+		// TODO: need to think of a way to unify this with objects
+		for name, field := range ty.FieldPtrs() {
 			if seen[name] {
 				t.semanticError(fmt.Sprintf("duplicate field name '%s'", name), field.GetPosition())
 				return nil, false
@@ -3075,49 +3273,40 @@ func resolveBTypeInner(t typeResolver, btype ast.BType, depth int) (semtypes.Sem
 			if !ok {
 				return nil, false
 			}
-			if overridden, exists := includedFields[name]; exists {
-				for _, incField := range overridden {
-					incFieldTy, ok := resolveBType(t, incField.Type, depth+1)
-					if !ok {
-						return nil, false
-					}
-					if !semtypes.IsSubtype(t.typeContext(), fieldTy, incFieldTy) {
+			if incMembers, exists := result.includedFields[name]; exists {
+				for _, incMember := range incMembers {
+					if !semtypes.IsSubtype(t.typeContext(), fieldTy, incMember.MemberType()) {
 						t.semanticError(
 							fmt.Sprintf("field '%s' of type that overrides included field is not a subtype of the included field type", name),
 							field.GetPosition(),
 						)
 					}
 				}
-				delete(includedFields, name)
+				delete(result.includedFields, name)
 			}
 			if field.DefaultExpr != nil {
 				if _, _, ok := resolveExpression(t, nil, field.DefaultExpr, fieldTy); !ok {
 					return nil, false
 				}
+				field.DefaultFnRef = allocateDefaultFnSymbol(t, fieldTy)
 			}
 			ro := field.FlagSet.Contains(model.Flag_READONLY)
 			opt := field.FlagSet.Contains(model.Flag_OPTIONAL)
 			fields = append(fields, semtypes.FieldFrom(name, fieldTy, ro, opt))
 		}
 
-		for name, incFields := range includedFields {
-			if len(incFields) > 1 {
+		for name, incMembers := range result.includedFields {
+			if len(incMembers) > 1 {
 				t.semanticError(fmt.Sprintf("included field '%s' declared in multiple type inclusions must be overridden", name), ty.GetPosition())
 			}
 		}
 
-		for name, incFields := range includedFields {
-			if len(incFields) > 1 {
+		for name, incMembers := range result.includedFields {
+			if len(incMembers) > 1 {
 				continue
 			}
-			field := incFields[0]
-			fieldTy, ok := resolveBType(t, field.Type, depth+1)
-			if !ok {
-				return nil, false
-			}
-			ro := field.FlagSet.Contains(model.Flag_READONLY)
-			opt := field.FlagSet.Contains(model.Flag_OPTIONAL)
-			fields = append(fields, semtypes.FieldFrom(name, fieldTy, ro, opt))
+			fd := incMembers[0]
+			fields = append(fields, semtypes.FieldFrom(name, fd.MemberType(), fd.IsReadonly(), fd.IsOptional()))
 		}
 
 		var rest semtypes.SemType
@@ -3129,15 +3318,11 @@ func resolveBTypeInner(t typeResolver, btype ast.BType, depth int) (semtypes.Sem
 			}
 		} else if ty.IsOpen {
 			rest = semtypes.CreateAnydata(t.typeContext())
-		} else if needsRestOverride {
+		} else if result.multpleRestTy {
 			t.semanticError("included rest type declared in multiple type inclusions must be overridden", ty.GetPosition())
 			rest = semtypes.NEVER
-		} else if includedRest != nil {
-			var ok bool
-			rest, ok = resolveBType(t, includedRest, depth+1)
-			if !ok {
-				return nil, false
-			}
+		} else if result.includedRestTy != nil {
+			rest = result.includedRestTy
 		} else {
 			rest = semtypes.NEVER
 		}
@@ -3193,120 +3378,161 @@ func resolveBTypeInner(t typeResolver, btype ast.BType, depth int) (semtypes.Sem
 			semtypes.FunctionQualifiersFrom(t.typeEnv(), isolated, transactional))
 		return fnType, true
 	case *ast.BLangObjectType:
-		defn := ty.Definition
-		if defn != nil {
-			return defn.GetSemType(t.typeEnv()), true
-		}
-		od := semtypes.NewObjectDefinition()
-		ty.Definition = &od
-
-		// Step 1: Accumulate included members
-		includedMembers := make(map[string][]semtypes.Member)
-		inc := collectTransitiveInclusions(t.compilerContext(), ty.Inclusions)
-		if !resolveIncludedDefns(t, inc.defns, depth) {
-			return nil, false
-		}
-		for _, m := range inc.members {
-			member, ok := resolveIncludedMember(t, m, depth)
-			if !ok {
-				return nil, false
-			}
-			includedMembers[member.Name] = append(includedMembers[member.Name], member)
-		}
-
-		// Step 2: Build members from direct members
-		var members []semtypes.Member
-		for m := range ty.Members() {
-			valueTy, ok := resolveObjectMemberType(t, m, depth)
-			if !ok {
-				return nil, false
-			}
-
-			name := m.Name()
-			// Check overrides against included members
-			if incMembers, exists := includedMembers[name]; exists {
-				for _, incMember := range incMembers {
-					if !semtypes.IsSubtype(t.typeContext(), valueTy, incMember.ValueTy) {
-						t.semanticError(
-							fmt.Sprintf("member '%s' that overrides included member is not a subtype of the included member type", name),
-							ty.GetPosition(),
-						)
-						return nil, false
-					}
-				}
-				delete(includedMembers, name)
-			}
-
-			members = append(members, semtypes.Member{
-				Name:       name,
-				ValueTy:    valueTy,
-				Kind:       semtypeMemberKind(m.MemberKind()),
-				Visibility: semtypeVisibility(m.Visibility()),
-				Immutable:  m.MemberKind() != model.ObjectMemberKindField,
-			})
-		}
-
-		// Inherit unoverridden included members
-		for name, incMembers := range includedMembers {
-			if len(incMembers) > 1 {
-				t.semanticError(fmt.Sprintf("included member '%s' declared in multiple type inclusions must be overridden", name), ty.GetPosition())
-				return nil, false
-			}
-			members = append(members, incMembers[0])
-		}
-
-		// Step 3: Create semtype
-		networkQual := semtypeNetworkQualifier(ty.NetworkQuals)
-		qualifiers := semtypes.ObjectQualifiersFrom(ty.Isolated, false, networkQual)
-		return od.Define(t.typeEnv(), qualifiers, members), true
+		return resolveObjectType(t, ty, depth)
 	default:
 		t.unimplemented("unsupported type", nil)
 		return nil, false
 	}
 }
 
-func accumIncludedFields(t typeResolver, recordTy *ast.BLangRecordType, includedFields map[string][]ast.BField, needsRestOverride bool, includedRest ast.BType) (bool, ast.BType, bool) {
+func resolveObjectType(t typeResolver, ty *ast.BLangObjectType, depth int) (semtypes.SemType, bool) {
+	defn := ty.Definition
+	if defn != nil {
+		return defn.GetSemType(t.typeEnv()), true
+	}
+	od := semtypes.NewObjectDefinition()
+	ty.Definition = &od
+	// Step 1: Accumulate included members from symbols
+	includedMembers := make(map[string][]semtypes.Member)
+	incMembers, err := collectIncludedMembers(t, ty.Inclusions, depth)
+	if err {
+		t.semanticError("error resolving type inclusion", ty.GetPosition())
+		return nil, false
+	}
+	for _, m := range incMembers {
+		if m.MemberKind() == model.InclusionMemberKindRestType {
+			t.internalError("unexpected rest inclusion", ty.GetPosition())
+		}
+		member := inclusionMemberToSemtypeMember(m)
+		includedMembers[member.Name] = append(includedMembers[member.Name], member)
+	}
+
+	// Step 2: Build direct members and validate overrides
+	var directMembers []directMember
+	for m := range ty.Members() {
+		valueTy, ok := resolveObjectMemberType(t, m, depth)
+		if !ok {
+			return nil, false
+		}
+		directMembers = append(directMembers, directMember{
+			name:       m.Name(),
+			valueTy:    valueTy,
+			kind:       semtypeMemberKind(m.MemberKind()),
+			visibility: semtypeVisibility(m.Visibility()),
+			immutable:  m.MemberKind() != model.ObjectMemberKindField,
+			pos:        ty.GetPosition(),
+		})
+	}
+
+	members, ok := validateOverridesAndMerge(t, directMembers, includedMembers, ty.GetPosition(), true)
+	if !ok {
+		return nil, false
+	}
+
+	// Step 3: Create semtype
+	networkQual := semtypeNetworkQualifier(ty.NetworkQuals)
+	qualifiers := semtypes.ObjectQualifiersFrom(ty.Isolated, false, networkQual)
+	return od.Define(t.typeEnv(), qualifiers, members), true
+}
+
+// directMember represents a member declared directly on a type (not inherited via inclusion).
+type directMember struct {
+	name       string
+	valueTy    semtypes.SemType
+	kind       semtypes.MemberKind
+	visibility semtypes.Visibility
+	immutable  bool
+	pos        diagnostics.Location
+}
+
+func validateOverridesAndMerge(t typeResolver, directMembers []directMember, includedMembers map[string][]semtypes.Member, pos diagnostics.Location, isObject bool) ([]semtypes.Member, bool) {
+	var members []semtypes.Member
+	for _, dm := range directMembers {
+		if incMembers, exists := includedMembers[dm.name]; exists {
+			for _, incMember := range incMembers {
+				if incMember.Kind != dm.kind {
+					t.semanticError(
+						fmt.Sprintf("member '%s' conflicts with included member of different kind", dm.name),
+						dm.pos,
+					)
+					return nil, false
+				}
+				if !semtypes.IsSubtype(t.typeContext(), dm.valueTy, incMember.ValueTy) {
+					t.semanticError(
+						fmt.Sprintf("member '%s' that overrides included member is not a subtype of the included member type", dm.name),
+						dm.pos,
+					)
+					return nil, false
+				}
+			}
+			delete(includedMembers, dm.name)
+		}
+		members = append(members, semtypes.Member{
+			Name:       dm.name,
+			ValueTy:    dm.valueTy,
+			Kind:       dm.kind,
+			Visibility: dm.visibility,
+			Immutable:  dm.immutable,
+		})
+	}
+
+	for name, incMembers := range includedMembers {
+		if len(incMembers) == 1 {
+			if isObject || incMembers[0].Kind == semtypes.MemberKindField {
+				members = append(members, incMembers[0])
+				continue
+			}
+			t.semanticError(
+				fmt.Sprintf("included method '%s' must be overridden in class definition", name),
+				pos,
+			)
+			return nil, false
+		}
+		t.semanticError(
+			fmt.Sprintf("included member '%s' declared in multiple type inclusions must be overridden", name),
+			pos,
+		)
+		return nil, false
+	}
+
+	return members, true
+}
+
+type recordInclusionResolutionResult struct {
+	includedFields map[string][]model.FieldDescriptor
+	includedRestTy semtypes.SemType
+	multpleRestTy  bool
+}
+
+func resolveRecordInclusions(t typeResolver, recordTy *ast.BLangRecordType, depth int) (recordInclusionResolutionResult, bool) {
+	// Resolve UDT nodes to set their DeterminedType
 	for _, inc := range recordTy.TypeInclusions {
-		udt, ok := inc.(*ast.BLangUserDefinedType)
-		if !ok {
-			t.semanticError("type inclusion must be a user-defined type", inc.(ast.BLangNode).GetPosition())
-			continue
+		if _, ok := resolveBType(t, inc, 0); !ok {
+			return recordInclusionResolutionResult{}, false
 		}
+	}
 
-		_, ok = resolveBType(t, inc, 0)
-		if !ok {
-			return false, nil, false
-		}
+	incMembers, err := collectIncludedMembers(t, recordTy.Inclusions, depth)
+	if err {
+		return recordInclusionResolutionResult{}, false
+	}
 
-		symbol := udt.Symbol()
-		tDefn, ok := t.getTypeDefinition(symbol)
-		if !ok {
-			t.internalError("type definition not found for inclusion", udt.GetPosition())
-			continue
-		}
-		recTy, ok := tDefn.GetTypeData().TypeDescriptor.(*ast.BLangRecordType)
-		if !ok {
-			t.semanticError("included type is not a record type", udt.GetPosition())
-			continue
-		}
-
-		needsRestOverride, includedRest, ok = accumIncludedFields(t, recTy, includedFields, needsRestOverride, includedRest)
-		if !ok {
-			return false, nil, false
-		}
-
-		for name, field := range recTy.Fields() {
-			includedFields[name] = append(includedFields[name], field)
-		}
-
-		if recTy.RestType != nil {
+	includedFields := make(map[string][]model.FieldDescriptor)
+	var includedRest semtypes.SemType
+	needsRestOverride := false
+	for _, m := range incMembers {
+		switch member := m.(type) {
+		case *model.FieldDescriptor:
+			includedFields[member.MemberName()] = append(includedFields[member.MemberName()], *member)
+		case *model.RestTypeDescriptor:
+			restTy := member.MemberType()
 			if includedRest != nil {
 				needsRestOverride = true
 			}
-			includedRest = recTy.RestType
+			includedRest = restTy
 		}
 	}
-	return needsRestOverride, includedRest, true
+	return recordInclusionResolutionResult{includedFields, includedRest, needsRestOverride}, true
 }
 
 func resolveConstant(t typeResolver, constant *ast.BLangConstant) bool {
@@ -3342,54 +3568,6 @@ func resolveConstant(t typeResolver, constant *ast.BLangConstant) bool {
 	t.setSymbolType(symbol, expectedType)
 
 	return true
-}
-
-// TODO: most of this is repeated code need to think about how to refactor this
-func resolveIncludedMember(t typeResolver, m includedMember, depth int) (semtypes.Member, bool) {
-	switch {
-	case m.objectMember != nil:
-		kind := m.objectMember.MemberKind()
-		valueTy, ok := resolveObjectMemberType(t, m.objectMember, depth)
-		if !ok {
-			return semtypes.Member{}, false
-		}
-		return semtypes.Member{
-			Name:       m.objectMember.Name(),
-			ValueTy:    valueTy,
-			Kind:       semtypeMemberKind(kind),
-			Visibility: semtypeVisibility(m.objectMember.Visibility()),
-			Immutable:  kind != model.ObjectMemberKindField,
-		}, true
-	case m.classField != nil:
-		fieldTy := t.symbolType(m.classField.Symbol())
-		vis := semtypes.VisibilityPrivate
-		if m.classField.FlagSet.Contains(model.Flag_PUBLIC) {
-			vis = semtypes.VisibilityPublic
-		}
-		return semtypes.Member{
-			Name:       m.classField.Name.Value,
-			ValueTy:    fieldTy,
-			Kind:       semtypes.MemberKindField,
-			Visibility: vis,
-			Immutable:  false,
-		}, true
-	case m.classMethod != nil:
-		methodTy := t.symbolType(m.classMethod.Symbol())
-		vis := semtypes.VisibilityPrivate
-		if m.classMethod.FlagSet.Contains(model.Flag_PUBLIC) {
-			vis = semtypes.VisibilityPublic
-		}
-		return semtypes.Member{
-			Name:       m.classMethod.Name.Value,
-			ValueTy:    methodTy,
-			Kind:       semtypes.MemberKindMethod,
-			Visibility: vis,
-			Immutable:  true,
-		}, true
-	default:
-		t.internalError("unexpected included member kind", nil)
-		return semtypes.Member{}, false
-	}
 }
 
 func resolveMatchStatement(t typeResolver, chain *binding, stmt *ast.BLangMatchStatement) (statementEffect, bool) {
@@ -3501,23 +3679,6 @@ func matchClauseAcceptedType(t typeResolver, chain *binding, clause *ast.BLangMa
 	return acceptedTy, chain, true
 }
 
-func resolveIncludedDefns(t typeResolver, defns []model.TypeDefinition, depth int) bool {
-	for _, d := range defns {
-		switch defn := d.(type) {
-		case *ast.BLangTypeDefinition:
-			objTy := defn.GetTypeData().TypeDescriptor.(*ast.BLangObjectType)
-			if _, ok := resolveBType(t, objTy, depth+1); !ok {
-				return false
-			}
-		case *ast.BLangClassDefinition:
-			if _, ok := resolveClassDefinitionType(t, defn, depth+1); !ok {
-				return false
-			}
-		}
-	}
-	return true
-}
-
 func resolveObjectMemberType(t typeResolver, m model.ObjectMember, depth int) (semtypes.SemType, bool) {
 	switch m := m.(type) {
 	case *ast.BObjectField:
@@ -3580,6 +3741,38 @@ func semtypeMemberKind(kind model.ObjectMemberKind) semtypes.MemberKind {
 		return semtypes.MemberKindResourceMethod
 	default:
 		panic("invalid member kind")
+	}
+}
+
+func inclusionMemberKindToSemtype(kind model.InclusionMemberKind) semtypes.MemberKind {
+	switch kind {
+	case model.InclusionMemberKindField:
+		return semtypes.MemberKindField
+	case model.InclusionMemberKindMethod:
+		return semtypes.MemberKindMethod
+	case model.InclusionMemberKindRemoteMethod:
+		return semtypes.MemberKindRemoteMethod
+	case model.InclusionMemberKindResourceMethod:
+		return semtypes.MemberKindResourceMethod
+	default:
+		panic("invalid inclusion member kind")
+	}
+}
+
+func inclusionMemberToSemtypeMember(m model.InclusionMember) semtypes.Member {
+	kind := m.MemberKind()
+	vis := semtypes.VisibilityPrivate
+	if fd, ok := m.(*model.FieldDescriptor); ok {
+		vis = semtypeVisibility(fd.Visibility())
+	} else if md, ok := m.(*model.MethodDescriptor); ok {
+		vis = semtypeVisibility(md.Visibility())
+	}
+	return semtypes.Member{
+		Name:       m.MemberName(),
+		ValueTy:    m.MemberType(),
+		Kind:       inclusionMemberKindToSemtype(kind),
+		Visibility: vis,
+		Immutable:  kind != model.InclusionMemberKindField,
 	}
 }
 

--- a/semantics/type_resolver_query_test.go
+++ b/semantics/type_resolver_query_test.go
@@ -272,7 +272,7 @@ func TestResolveQueryExprMapConstructTypeInvalidSelect(t *testing.T) {
 func newTestQueryResolver() (*packageTypeResolver, *context.CompilerContext) {
 	env := context.NewCompilerEnvironment(semtypes.CreateTypeEnv(), false)
 	cx := context.NewCompilerContext(env)
-	return newPackageTypeResolver(cx, &ast.BLangPackage{}, nil), cx
+	return newPackageTypeResolver(cx, &ast.BLangPackage{}, nil, nil), cx
 }
 
 func assertDiagnosticContains(t *testing.T, cx *context.CompilerContext, substr string) {

--- a/semtypes/mapping_atomic_type.go
+++ b/semtypes/mapping_atomic_type.go
@@ -58,3 +58,12 @@ func (this *MappingAtomicType) FieldInnerVal(name string) SemType {
 	}
 	return CellInnerVal(this.Rest)
 }
+
+func (this *MappingAtomicType) IsOptional(cx Context, name string) bool {
+	for i, n := range this.Names {
+		if n == name {
+			return IsSubtype(cx, UNDEF, CellInnerVal(&this.Types[i]))
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Purpose
$subject
Resolves #348
Depends on #331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Record-type inclusion: inherited and overridable default field values; sample projects demonstrating behavior.

* **Bug Fixes**
  * Improved diagnostics for missing non-defaultable required record fields.
  * Clearer, more specific error messages for type-inclusion resolution and cycles.
  * Mapping/constructor validation now enforces required-field presence.

* **Tests**
  * Added integration fixtures validating inclusion/default scenarios and expected outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->