### PR TITLE
Fix binary expression type resolution breaking comparable check

### DIFF
--- a/corpus/ast/08-comparable/5-v.txt
+++ b/corpus/ast/08-comparable/5-v.txt
@@ -1,0 +1,51 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (value-type any)) (expr
+          (binary-expr <
+            (list-constructor-expr
+              (literal 1)
+              (literal 2))
+            (list-constructor-expr
+              (literal 3)
+              (literal 1))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref a))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (list-constructor-expr
+              (literal 1)
+              (literal 2))
+            (list-constructor-expr
+              (literal 1)
+              (literal 2))))))
+      (var-def
+        (variable b (type
+          (value-type boolean)) (expr
+          (binary-expr >
+            (list-constructor-expr
+              (literal 1)
+              (literal 2))
+            (list-constructor-expr
+              (literal 3))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref b))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (list-constructor-expr
+              (literal 10)
+              (unary-expr -
+                (literal 1))
+              (unary-expr -
+                (literal 1)))
+            (list-constructor-expr
+              (literal 0)))))))))

--- a/corpus/ast/08-comparable/arr1-v.txt
+++ b/corpus/ast/08-comparable/arr1-v.txt
@@ -1,0 +1,134 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (array-type
+            (value-type int) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 1)
+            (literal 2)
+            (literal 3)))))
+      (var-def
+        (variable b (type
+          (array-type
+            (union-type
+              (value-type int)
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 1)
+            (literal <nil>)
+            (literal 3)))))
+      (var-def
+        (variable c (type
+          (array-type
+            (union-type
+              (value-type int)
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 1)
+            (literal <nil>)
+            (literal 4)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref c)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref c)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref c)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref c)
+            (simple-var-ref b))))))))

--- a/corpus/ast/08-comparable/arr2-v.txt
+++ b/corpus/ast/08-comparable/arr2-v.txt
@@ -1,0 +1,134 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (array-type
+            (value-type float) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 0.1)
+            (literal 2)
+            (literal 3.5)))))
+      (var-def
+        (variable b (type
+          (array-type
+            (union-type
+              (value-type float)
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 0.1)
+            (literal <nil>)
+            (literal 3.5)))))
+      (var-def
+        (variable c (type
+          (array-type
+            (union-type
+              (value-type float)
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 0.1)
+            (literal <nil>)
+            (literal 4.7)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref c)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref c)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref c)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref c)
+            (simple-var-ref b))))))))

--- a/corpus/ast/08-comparable/arr3-v.txt
+++ b/corpus/ast/08-comparable/arr3-v.txt
@@ -1,0 +1,134 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (array-type
+            (value-type string) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal abc)
+            (literal abd)
+            (literal abcd)))))
+      (var-def
+        (variable b (type
+          (array-type
+            (union-type
+              (value-type string)
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal abc)
+            (literal <nil>)
+            (literal abcd)))))
+      (var-def
+        (variable c (type
+          (array-type
+            (union-type
+              (value-type string)
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal abc)
+            (literal <nil>)
+            (literal xyz)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref c)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref c)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref c)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref c)
+            (simple-var-ref b))))))))

--- a/corpus/ast/08-comparable/arr4-v.txt
+++ b/corpus/ast/08-comparable/arr4-v.txt
@@ -1,0 +1,134 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (array-type
+            (value-type boolean) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal false)
+            (literal true)
+            (literal false)))))
+      (var-def
+        (variable b (type
+          (array-type
+            (union-type
+              (value-type boolean)
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal false)
+            (literal <nil>)
+            (literal false)))))
+      (var-def
+        (variable c (type
+          (array-type
+            (union-type
+              (value-type boolean)
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal false)
+            (literal <nil>)
+            (literal true)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref c)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref c)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref c)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref c)
+            (simple-var-ref b))))))))

--- a/corpus/ast/08-comparable/booleansubtypecompare-v.txt
+++ b/corpus/ast/08-comparable/booleansubtypecompare-v.txt
@@ -1,0 +1,63 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (type-definition A
+    (finite-type
+      (literal false)))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (array-type
+            (user-defined-type A) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal false)
+            (literal false)))))
+      (var-def
+        (variable b (type
+          (array-type
+            (value-type boolean) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal true)
+            (literal true)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref a))))))))

--- a/corpus/ast/08-comparable/comp1-v.txt
+++ b/corpus/ast/08-comparable/comp1-v.txt
@@ -1,0 +1,108 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (type-definition INTSTR
+    (tuple-type
+      (value-type int)
+      (value-type string)))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (user-defined-type INTSTR)) (expr
+          (list-constructor-expr
+            (literal 0)
+            (literal b)))))
+      (var-def
+        (variable b (type
+          (user-defined-type INTSTR)) (expr
+          (list-constructor-expr
+            (literal 1)
+            (literal a)))))
+      (var-def
+        (variable c (type
+          (user-defined-type INTSTR)) (expr
+          (list-constructor-expr
+            (literal 0)
+            (literal a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref c)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref c)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref c)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref c)
+            (simple-var-ref a))))))))

--- a/corpus/ast/08-comparable/comp10-v.txt
+++ b/corpus/ast/08-comparable/comp10-v.txt
@@ -1,0 +1,66 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (type-definition A
+    (tuple-type
+      (value-type int)
+      (value-type int)))
+  (type-definition B
+    (tuple-type
+      (value-type int)
+      (value-type byte)))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (user-defined-type A)) (expr
+          (list-constructor-expr
+            (literal 0)
+            (literal 500)))))
+      (var-def
+        (variable b (type
+          (user-defined-type B)) (expr
+          (list-constructor-expr
+            (literal 0)
+            (literal 5)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref a))))))))

--- a/corpus/ast/08-comparable/comp11-v.txt
+++ b/corpus/ast/08-comparable/comp11-v.txt
@@ -1,0 +1,120 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (type-definition A
+    (tuple-type
+      (value-type int)
+      (value-type float)
+      (value-type decimal) (rest
+        (value-type int))))
+  (type-definition B
+    (tuple-type
+      (value-type byte)))
+  (type-definition C
+    (tuple-type
+      (value-type byte) (rest
+        (value-type int))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (user-defined-type A)) (expr
+          (list-constructor-expr
+            (literal 1)
+            (literal 6.4)
+            (literal 100)
+            (literal 10)
+            (literal 11)))))
+      (var-def
+        (variable b (type
+          (user-defined-type B)) (expr
+          (list-constructor-expr
+            (literal 5)))))
+      (var-def
+        (variable c (type
+          (user-defined-type C)) (expr
+          (list-constructor-expr
+            (literal 0)
+            (literal 4)
+            (literal 10)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref c)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref c)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref c)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref c)
+            (simple-var-ref b))))))))

--- a/corpus/ast/08-comparable/comp2-v.txt
+++ b/corpus/ast/08-comparable/comp2-v.txt
@@ -1,0 +1,112 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (type-definition T
+    (tuple-type
+      (value-type int)
+      (value-type int)
+      (value-type int)))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (user-defined-type T)) (expr
+          (list-constructor-expr
+            (literal 0)
+            (literal 1)
+            (literal 2)))))
+      (var-def
+        (variable b (type
+          (user-defined-type T)) (expr
+          (list-constructor-expr
+            (literal 1)
+            (literal 0)
+            (literal 3)))))
+      (var-def
+        (variable c (type
+          (user-defined-type T)) (expr
+          (list-constructor-expr
+            (literal 0)
+            (literal 1)
+            (literal 0)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref c)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref c)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref c)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref c)
+            (simple-var-ref a))))))))

--- a/corpus/ast/08-comparable/comp3-v.txt
+++ b/corpus/ast/08-comparable/comp3-v.txt
@@ -1,0 +1,110 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (type-definition T1
+    (tuple-type
+      (value-type int)
+      (value-type int)))
+  (type-definition T2
+    (tuple-type
+      (value-type int)))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (user-defined-type T1)) (expr
+          (list-constructor-expr
+            (literal 0)
+            (literal 5)))))
+      (var-def
+        (variable b (type
+          (user-defined-type T2)) (expr
+          (list-constructor-expr
+            (literal 2)))))
+      (var-def
+        (variable c (type
+          (user-defined-type T2)) (expr
+          (list-constructor-expr
+            (unary-expr -
+              (literal 1))))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref c)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref c)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref c)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref c)
+            (simple-var-ref a))))))))

--- a/corpus/ast/08-comparable/comp5-v.txt
+++ b/corpus/ast/08-comparable/comp5-v.txt
@@ -1,0 +1,74 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (type-definition A
+    (tuple-type
+      (value-type int)
+      (tuple-type
+        (value-type int)
+        (value-type int))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable arr1 (type
+          (user-defined-type A)) (expr
+          (list-constructor-expr
+            (literal 5)
+            (list-constructor-expr
+              (literal 1)
+              (literal 2))))))
+      (var-def
+        (variable arr2 (type
+          (user-defined-type A)) (expr
+          (list-constructor-expr
+            (literal 5)
+            (list-constructor-expr
+              (literal 0)
+              (literal 2))))))
+      (var-def
+        (variable arr3 (type
+          (user-defined-type A)) (expr
+          (list-constructor-expr
+            (literal 5)
+            (list-constructor-expr
+              (literal 2)
+              (literal 2))))))
+      (var-def
+        (variable arr4 (type
+          (user-defined-type A)) (expr
+          (list-constructor-expr
+            (literal 3)
+            (list-constructor-expr
+              (literal 1)
+              (literal 2))))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref arr1)
+            (simple-var-ref arr2)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref arr1)
+            (simple-var-ref arr3)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref arr1)
+            (simple-var-ref arr4)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref arr1)
+            (simple-var-ref arr2)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref arr1)
+            (simple-var-ref arr3)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref arr1)
+            (simple-var-ref arr4))))))))

--- a/corpus/ast/08-comparable/comp7-v.txt
+++ b/corpus/ast/08-comparable/comp7-v.txt
@@ -1,0 +1,121 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (type-definition T1
+    (tuple-type
+      (value-type int)
+      (value-type float)
+      (value-type int)))
+  (type-definition T2
+    (tuple-type
+      (value-type int)
+      (value-type float)
+      (value-type int)
+      (value-type int)))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (user-defined-type T1)) (expr
+          (list-constructor-expr
+            (literal 0)
+            (literal 5.0)
+            (literal 1)))))
+      (var-def
+        (variable b (type
+          (user-defined-type T2)) (expr
+          (list-constructor-expr
+            (literal 0)
+            (literal 5.0)
+            (literal 1)
+            (literal 2)))))
+      (var-def
+        (variable c (type
+          (user-defined-type T2)) (expr
+          (list-constructor-expr
+            (literal 0)
+            (literal 5.0)
+            (literal 1)
+            (unary-expr -
+              (literal 1))))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref c)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref c)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref c)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref c)
+            (simple-var-ref a))))))))

--- a/corpus/ast/08-comparable/floatsubtypecompare-v.txt
+++ b/corpus/ast/08-comparable/floatsubtypecompare-v.txt
@@ -1,0 +1,71 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (type-definition A
+    (union-type
+      (union-type
+        (finite-type
+          (literal 1.0))
+        (finite-type
+          (literal 2.0)))
+      (finite-type
+        (literal 3.0))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (array-type
+            (user-defined-type A) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 1.0)
+            (literal 2.0)
+            (literal 3.0)))))
+      (var-def
+        (variable b (type
+          (array-type
+            (value-type float) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 4.0)
+            (literal 5.0)
+            (literal 6.0)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref a))))))))

--- a/corpus/ast/08-comparable/intsubtypecompare-v.txt
+++ b/corpus/ast/08-comparable/intsubtypecompare-v.txt
@@ -1,0 +1,41 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (type-definition A
+    (union-type
+      (union-type
+        (finite-type
+          (literal 1))
+        (finite-type
+          (literal 2)))
+      (finite-type
+        (literal 3))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (array-type
+            (user-defined-type A) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 1)
+            (literal 2)
+            (literal 3)))))
+      (var-def
+        (variable b (type
+          (array-type
+            (value-type int) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 4)
+            (literal 5)
+            (literal 6)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref b))))))))

--- a/corpus/ast/08-comparable/order1-v.txt
+++ b/corpus/ast/08-comparable/order1-v.txt
@@ -1,0 +1,102 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (array-type
+            (value-type int) dimensions: 2 ([][]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (literal 1))
+            (list-constructor-expr
+              (literal 2))))))
+      (var-def
+        (variable b (type
+          (array-type
+            (value-type int) dimensions: 2 ([][]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (literal 1))
+            (list-constructor-expr
+              (literal 3))))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (var-def
+        (variable c (type
+          (array-type
+            (union-type
+              (array-type
+                (value-type int) dimensions: 1 ([]))
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (literal 0))
+            (list-constructor-expr
+              (unary-expr -
+                (literal 1)))))))
+      (var-def
+        (variable d (type
+          (array-type
+            (value-type int) dimensions: 2 ([][]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (literal 0))
+            (list-constructor-expr
+              (unary-expr -
+                (literal 2)))))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref c)
+            (simple-var-ref d)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref c)
+            (simple-var-ref d)))))
+      (var-def
+        (variable e (type
+          (array-type
+            (union-type
+              (array-type
+                (value-type int) dimensions: 1 ([]))
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal <nil>)
+            (list-constructor-expr
+              (literal 1))))))
+      (var-def
+        (variable f (type
+          (array-type
+            (value-type int) dimensions: 2 ([][]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (literal 0))
+            (list-constructor-expr
+              (literal 1))))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr ==
+            (simple-var-ref e)
+            (simple-var-ref f)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref e)
+            (simple-var-ref f)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref e)
+            (simple-var-ref f))))))))

--- a/corpus/ast/08-comparable/order2-v.txt
+++ b/corpus/ast/08-comparable/order2-v.txt
@@ -1,0 +1,200 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (literal 1)
+            (literal <nil>)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (literal <nil>)
+            (literal <nil>)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (literal <nil>)
+            (literal <nil>)))))
+      (var-def
+        (variable a (type
+          (union-type
+            (array-type
+              (value-type int) dimensions: 1 ([]))
+            (value-type null))) (expr
+          (list-constructor-expr
+            (literal 1)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (literal <nil>)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (literal <nil>)
+            (simple-var-ref a)))))
+      (var-def
+        (variable b (type
+          (array-type
+            (union-type
+              (array-type
+                (value-type int) dimensions: 1 ([]))
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (literal 1))))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (literal <nil>)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (literal <nil>)
+            (simple-var-ref b)))))
+      (var-def
+        (variable c (type
+          (array-type
+            (union-type
+              (array-type
+                (value-type int) dimensions: 1 ([]))
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal <nil>)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (var-def
+        (variable d (type
+          (array-type
+            (union-type
+              (value-type int)
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 1)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref d)
+            (literal <nil>)))))
+      (var-def
+        (variable e (type
+          (array-type
+            (union-type
+              (value-type int)
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal <nil>)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref d)
+            (simple-var-ref e)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref e)
+            (simple-var-ref d)))))
+      (var-def
+        (variable f (type
+          (array-type
+            (value-type int) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 1)
+            (literal 2)
+            (literal 3)))))
+      (var-def
+        (variable g (type
+          (array-type
+            (value-type null) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal <nil>)
+            (literal <nil>)
+            (literal <nil>)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref f)
+            (simple-var-ref g)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref g)
+            (simple-var-ref f)))))
+      (var-def
+        (variable h (type
+          (array-type
+            (union-type
+              (value-type int)
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 1)
+            (literal 2)
+            (literal 3)))))
+      (var-def
+        (variable i (type
+          (array-type
+            (value-type null) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal <nil>)
+            (literal <nil>)
+            (literal <nil>)
+            (literal <nil>)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref h)
+            (simple-var-ref i)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref i)
+            (simple-var-ref h)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref g)
+            (simple-var-ref i)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref i)
+            (simple-var-ref g)))))
+      (var-def
+        (variable j (type
+          (array-type
+            (value-type null) dimensions: 2 ([][]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (literal <nil>))
+            (list-constructor-expr
+              (literal <nil>)
+              (literal <nil>))))))
+      (var-def
+        (variable k (type
+          (array-type
+            (value-type null) dimensions: 2 ([][]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (literal <nil>))
+            (list-constructor-expr
+              (literal <nil>)
+              (literal <nil>)
+              (literal <nil>))))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref j)
+            (simple-var-ref k)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref k)
+            (simple-var-ref j))))))))

--- a/corpus/ast/08-comparable/order3-v.txt
+++ b/corpus/ast/08-comparable/order3-v.txt
@@ -1,0 +1,36 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable v1 (type
+          (array-type
+            (value-type int) dimensions: 1 ([]))) (expr
+          (list-constructor-expr))))
+      (if
+        (type-test-expr is
+          (simple-var-ref v1)
+          (array-type
+            (value-type string) dimensions: 1 ([])))
+        (block-stmt
+          (var-def
+            (variable j (type
+              (array-type
+                (value-type string) dimensions: 1 ([]))) (expr
+              (list-constructor-expr))))
+          (expression-stmt
+            (invocation io println (
+              (binary-expr <
+                (simple-var-ref v1)
+                (simple-var-ref j)))))
+          (expression-stmt
+            (invocation io println (
+              (binary-expr >
+                (simple-var-ref v1)
+                (simple-var-ref j)))))) (
+        (block-stmt
+          (expression-stmt
+            (invocation io println (
+              (literal else))))))))))

--- a/corpus/ast/08-comparable/order4-v.txt
+++ b/corpus/ast/08-comparable/order4-v.txt
@@ -1,0 +1,39 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable n1 (type
+          (array-type
+            (value-type null) dimensions: 1 ([]))) (expr
+          (list-constructor-expr))))
+      (var-def
+        (variable n2 (type
+          (array-type
+            (value-type null) dimensions: 2 ([][]))) (expr
+          (list-constructor-expr))))
+      (var-def
+        (variable n3 (type
+          (array-type
+            (union-type
+              (array-type
+                (value-type null) dimensions: 1 ([]))
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref n1)
+            (simple-var-ref n2)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref n3)
+            (simple-var-ref n2)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref n1)
+            (simple-var-ref n3))))))))

--- a/corpus/ast/08-comparable/order5-v.txt
+++ b/corpus/ast/08-comparable/order5-v.txt
@@ -1,0 +1,124 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable b1 (type
+          (array-type
+            (value-type boolean) dimensions: 2 ([][]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (literal true))))))
+      (var-def
+        (variable b2 (type
+          (array-type
+            (value-type boolean) dimensions: 2 ([][]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (literal true))
+            (list-constructor-expr)))))
+      (var-def
+        (variable b3 (type
+          (array-type
+            (union-type
+              (array-type
+                (value-type boolean) dimensions: 1 ([]))
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (literal true))
+            (literal <nil>)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b1)
+            (simple-var-ref b2)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b2)
+            (simple-var-ref b3)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b2)
+            (simple-var-ref b3)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b3)
+            (simple-var-ref b1)))))
+      (var-def
+        (variable s1 (type
+          (array-type
+            (value-type string) dimensions: 2 ([][]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (literal a))))))
+      (var-def
+        (variable s2 (type
+          (array-type
+            (value-type string) dimensions: 2 ([][]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (literal a))
+            (list-constructor-expr)))))
+      (var-def
+        (variable s3 (type
+          (array-type
+            (union-type
+              (array-type
+                (value-type string) dimensions: 1 ([]))
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (literal a))
+            (literal <nil>)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref s2)
+            (simple-var-ref s1)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref s2)
+            (simple-var-ref s3)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref s2)
+            (simple-var-ref s3)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref s1)
+            (simple-var-ref s3)))))
+      (var-def
+        (variable f1 (type
+          (array-type
+            (value-type float) dimensions: 2 ([][]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (literal 80.0))))))
+      (var-def
+        (variable f2 (type
+          (array-type
+            (value-type float) dimensions: 2 ([][]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (binary-expr /
+                (literal 0.0)
+                (literal 0.0)))))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref f1)
+            (simple-var-ref f2)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref f2)
+            (simple-var-ref f2))))))))

--- a/corpus/ast/08-comparable/relational4-v.txt
+++ b/corpus/ast/08-comparable/relational4-v.txt
@@ -1,0 +1,78 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable x (type
+          (array-type
+            (value-type decimal) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 1.5d)))))
+      (var-def
+        (variable y (type
+          (array-type
+            (value-type decimal) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 3d)))))
+      (var-def
+        (variable z (type
+          (array-type
+            (value-type decimal) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 3d)))))
+      (var-def
+        (variable a1 (type
+          (array-type
+            (value-type decimal) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 1d)
+            (literal 2.5d)))))
+      (var-def
+        (variable a2 (type
+          (array-type
+            (value-type decimal) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 2d)
+            (literal 3d)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref x)
+            (simple-var-ref y)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref x)
+            (simple-var-ref y)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref y)
+            (simple-var-ref x)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref y)
+            (simple-var-ref x)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref y)
+            (simple-var-ref z)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref y)
+            (simple-var-ref z)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a1)
+            (simple-var-ref a2)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a1)
+            (simple-var-ref a2))))))))

--- a/corpus/ast/08-comparable/relational5-v.txt
+++ b/corpus/ast/08-comparable/relational5-v.txt
@@ -1,0 +1,94 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable d1 (type
+          (value-type decimal)) (expr
+          (literal 1d))))
+      (var-def
+        (variable d2 (type
+          (value-type decimal)) (expr
+          (literal 2d))))
+      (var-def
+        (variable d3 (type
+          (value-type decimal)) (expr
+          (literal 3d))))
+      (var-def
+        (variable d15 (type
+          (value-type decimal)) (expr
+          (literal 1.5d))))
+      (var-def
+        (variable x (type
+          (array-type
+            (value-type decimal) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (simple-var-ref d15)))))
+      (var-def
+        (variable y (type
+          (array-type
+            (value-type decimal) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (simple-var-ref d3)))))
+      (var-def
+        (variable z (type
+          (array-type
+            (value-type decimal) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 3d)))))
+      (var-def
+        (variable a1 (type
+          (array-type
+            (value-type decimal) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (simple-var-ref d1)
+            (simple-var-ref d2)))))
+      (var-def
+        (variable a2 (type
+          (array-type
+            (value-type decimal) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (simple-var-ref d2)
+            (simple-var-ref d3)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref x)
+            (simple-var-ref y)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref x)
+            (simple-var-ref y)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref y)
+            (simple-var-ref x)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref y)
+            (simple-var-ref x)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref y)
+            (simple-var-ref z)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref y)
+            (simple-var-ref z)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a1)
+            (simple-var-ref a2)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a1)
+            (simple-var-ref a2))))))))

--- a/corpus/ast/08-comparable/stringsubtypecompare-v.txt
+++ b/corpus/ast/08-comparable/stringsubtypecompare-v.txt
@@ -1,0 +1,66 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (type-definition A
+    (union-type
+      (finite-type
+        (literal a))
+      (finite-type
+        (literal aa))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (array-type
+            (user-defined-type A) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal a)
+            (literal aa)))))
+      (var-def
+        (variable b (type
+          (array-type
+            (value-type string) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal b)
+            (literal bb)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref a))))))))

--- a/corpus/bal/08-comparable/5-v.bal
+++ b/corpus/bal/08-comparable/5-v.bal
@@ -1,0 +1,24 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/io;
+public function main() {
+    any a = [1, 2] < [3, 1];
+    io:println(a); // @output true
+    io:println([1, 2] < [1, 2]); // @output false
+    boolean b = [1, 2] > [3];
+    io:println(b); // @output false
+    io:println([10, -1, -1] > [0]); // @output true
+}

--- a/corpus/bal/08-comparable/arr1-v.bal
+++ b/corpus/bal/08-comparable/arr1-v.bal
@@ -1,0 +1,47 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/io;
+
+public function main() {
+	int[] a = [1,2,3];
+	int?[] b = [1,(),3];
+	int?[] c = [1,(),4];
+
+	io:println(b < b); // @output false
+	io:println(b <= b); // @output true
+	io:println(b > b); // @output false
+	io:println(b >= b); // @output true
+
+	io:println(a < b); // @output false
+	io:println(a <= b); // @output false
+	io:println(a > b); // @output false
+	io:println(a >= b); // @output false
+
+	io:println(b < a); // @output false
+	io:println(b <= a); // @output false
+	io:println(b > a); // @output false
+	io:println(b >= a); // @output false
+
+	io:println(b < c); // @output true
+	io:println(b <= c); // @output true
+	io:println(b > c); // @output false
+	io:println(b >= c); // @output false
+
+	io:println(c < b); // @output false
+	io:println(c <= b); // @output false
+	io:println(c > b); // @output true
+	io:println(c >= b); // @output true
+}

--- a/corpus/bal/08-comparable/arr2-v.bal
+++ b/corpus/bal/08-comparable/arr2-v.bal
@@ -1,0 +1,47 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/io;
+
+public function main() {
+	float[] a = [0.1,2,3.5];
+	float?[] b = [0.1,(),3.5];
+	float?[] c = [0.1,(),4.7];
+
+	io:println(b < b); // @output false
+	io:println(b <= b); // @output true
+	io:println(b > b); // @output false
+	io:println(b >= b); // @output true
+
+	io:println(a < b); // @output false
+	io:println(a <= b); // @output false
+	io:println(a > b); // @output false
+	io:println(a >= b); // @output false
+
+	io:println(b < a); // @output false
+	io:println(b <= a); // @output false
+	io:println(b > a); // @output false
+	io:println(b >= a); // @output false
+
+	io:println(b < c); // @output true
+	io:println(b <= c); // @output true
+	io:println(b > c); // @output false
+	io:println(b >= c); // @output false
+
+	io:println(c < b); // @output false
+	io:println(c <= b); // @output false
+	io:println(c > b); // @output true
+	io:println(c >= b); // @output true
+}

--- a/corpus/bal/08-comparable/arr3-v.bal
+++ b/corpus/bal/08-comparable/arr3-v.bal
@@ -1,0 +1,47 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/io;
+
+public function main() {
+	string[] a = ["abc","abd","abcd"];
+	string?[] b = ["abc",(),"abcd"];
+	string?[] c = ["abc",(),"xyz"];
+
+	io:println(b < b); // @output false
+	io:println(b <= b); // @output true
+	io:println(b > b); // @output false
+	io:println(b >= b); // @output true
+
+	io:println(a < b); // @output false
+	io:println(a <= b); // @output false
+	io:println(a > b); // @output false
+	io:println(a >= b); // @output false
+
+	io:println(b < a); // @output false
+	io:println(b <= a); // @output false
+	io:println(b > a); // @output false
+	io:println(b >= a); // @output false
+
+	io:println(b < c); // @output true
+	io:println(b <= c); // @output true
+	io:println(b > c); // @output false
+	io:println(b >= c); // @output false
+
+	io:println(c < b); // @output false
+	io:println(c <= b); // @output false
+	io:println(c > b); // @output true
+	io:println(c >= b); // @output true
+}

--- a/corpus/bal/08-comparable/arr4-v.bal
+++ b/corpus/bal/08-comparable/arr4-v.bal
@@ -1,0 +1,47 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/io;
+
+public function main() {
+	boolean[] a = [false,true,false];
+	boolean?[] b = [false,(),false];
+	boolean?[] c = [false,(),true];
+
+	io:println(b < b); // @output false
+	io:println(b <= b); // @output true
+	io:println(b > b); // @output false
+	io:println(b >= b); // @output true
+
+	io:println(a < b); // @output false
+	io:println(a <= b); // @output false
+	io:println(a > b); // @output false
+	io:println(a >= b); // @output false
+
+	io:println(b < a); // @output false
+	io:println(b <= a); // @output false
+	io:println(b > a); // @output false
+	io:println(b >= a); // @output false
+
+	io:println(b < c); // @output true
+	io:println(b <= c); // @output true
+	io:println(b > c); // @output false
+	io:println(b >= c); // @output false
+
+	io:println(c < b); // @output false
+	io:println(c <= b); // @output false
+	io:println(c > b); // @output true
+	io:println(c >= b); // @output true
+}

--- a/corpus/bal/08-comparable/booleansubtypecompare-v.bal
+++ b/corpus/bal/08-comparable/booleansubtypecompare-v.bal
@@ -1,0 +1,32 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/io;
+
+type A false;
+public function main() {
+    A[] a = [false, false];
+    boolean[] b = [true, true];
+    io:println(a < b); //@output true
+    io:println(a <= b); //@output true
+    io:println(a > b); //@output false
+    io:println(a >= b); //@output false
+
+    io:println(b < a); //@output false
+    io:println(b <= a); //@output false
+    io:println(b > a); //@output true
+    io:println(b >= a); //@output true
+}
+

--- a/corpus/bal/08-comparable/comp1-v.bal
+++ b/corpus/bal/08-comparable/comp1-v.bal
@@ -1,0 +1,44 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/io;
+
+type INTSTR [int, string];
+public function main() {
+    INTSTR a = [0, "b"];
+    INTSTR b = [1, "a"];
+    INTSTR c = [0, "a"];
+
+    io:println(a < b); //@output true
+    io:println(a <= b); //@output true
+    io:println(a > b); //@output false
+    io:println(a >= b); //@output false
+
+    io:println(b < a); //@output false
+    io:println(b <= a); //@output false
+    io:println(b > a); //@output true
+    io:println(b >= a); //@output true
+
+
+    io:println(a < c); //@output false
+    io:println(a <= c); //@output false
+    io:println(a > c); //@output true
+    io:println(a >= c); //@output true
+
+    io:println(c < a); //@output true
+    io:println(c <= a); //@output true
+    io:println(c > a); //@output false
+    io:println(c >= a); //@output false
+}

--- a/corpus/bal/08-comparable/comp10-v.bal
+++ b/corpus/bal/08-comparable/comp10-v.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/io;
+type A [int, int];
+type B [int, byte];
+
+public function main() {
+    A a = [0, 500];
+    B b = [0, 5];
+
+    io:println(a < b); //@output false
+    io:println(a <= b); //@output false
+    io:println(a > b); //@output true
+    io:println(a >= b); //@output true
+
+    io:println(b < a); //@output true
+    io:println(b <= a); //@output true
+    io:println(b > a); //@output false
+    io:println(b >= a); //@output false
+}

--- a/corpus/bal/08-comparable/comp11-v.bal
+++ b/corpus/bal/08-comparable/comp11-v.bal
@@ -1,0 +1,45 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/io;
+type A [int, float, decimal, int...];
+type B [byte];
+type C [byte, int...];
+
+public function main() {
+    A a = [1, 6.4, 100, 10, 11];
+    B b = [5];
+    C c = [0, 4, 10];
+
+    io:println(a < b); //@output true
+    io:println(a <= b); //@output true
+    io:println(a > b); //@output false
+    io:println(a >= b); //@output false
+
+    io:println(b < a); //@output false
+    io:println(b <= a); //@output false
+    io:println(b > a); //@output true
+    io:println(b >= a); //@output true
+
+    io:println(b < c); //@output false
+    io:println(b <= c); //@output false
+    io:println(b > c); //@output true
+    io:println(b >= c); //@output true
+
+    io:println(c < b); //@output true
+    io:println(c <= b); //@output true
+    io:println(c > b); //@output false
+    io:println(c >= b); //@output false
+}

--- a/corpus/bal/08-comparable/comp2-v.bal
+++ b/corpus/bal/08-comparable/comp2-v.bal
@@ -1,0 +1,44 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/io;
+
+type T [int, int, int];
+public function main() {
+    T a = [0, 1, 2];
+    T b = [1, 0, 3];
+    T c = [0, 1, 0];
+
+    io:println(a < b); //@output true
+    io:println(a <= b); //@output true
+    io:println(a > b); //@output false
+    io:println(a >= b); //@output false
+
+    io:println(b < a); //@output false
+    io:println(b <= a); //@output false
+    io:println(b > a); //@output true
+    io:println(b >= a); //@output true
+
+
+    io:println(a < c); //@output false
+    io:println(a <= c); //@output false
+    io:println(a > c); //@output true
+    io:println(a >= c); //@output true
+
+    io:println(c < a); //@output true
+    io:println(c <= a); //@output true
+    io:println(c > a); //@output false
+    io:println(c >= a); //@output false
+}

--- a/corpus/bal/08-comparable/comp3-v.bal
+++ b/corpus/bal/08-comparable/comp3-v.bal
@@ -1,0 +1,44 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/io;
+type T1 [int, int];
+type T2 [int];
+
+public function main() {
+    T1 a = [0 , 5];
+    T2 b = [2];
+    T2 c = [-1];
+
+    io:println(a < b); //@output true
+    io:println(a <= b); //@output true
+    io:println(a > b); //@output false
+    io:println(a >= b); //@output false
+
+    io:println(b < a); //@output false
+    io:println(b <= a); //@output false
+    io:println(b > a); //@output true
+    io:println(b >= a); //@output true
+
+    io:println(a < c); //@output false
+    io:println(a <= c); //@output false
+    io:println(a > c); //@output true
+    io:println(a >= c); //@output true
+
+    io:println(c < a); //@output true
+    io:println(c <= a); //@output true
+    io:println(c > a); //@output false
+    io:println(c >= a); //@output false
+}

--- a/corpus/bal/08-comparable/comp5-v.bal
+++ b/corpus/bal/08-comparable/comp5-v.bal
@@ -1,0 +1,32 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/io;
+type A [int, [int, int]];
+
+public function main() {
+    A arr1 = [5, [1, 2]];
+    A arr2 = [5, [0, 2]];
+    A arr3 = [5, [2, 2]];
+    A arr4 = [3, [1, 2]];
+
+    io:println(arr1 < arr2); // @output false
+    io:println(arr1 < arr3); // @output true
+    io:println(arr1 < arr4); // @output false
+
+    io:println(arr1 > arr2); // @output true
+    io:println(arr1 > arr3); // @output false
+    io:println(arr1 > arr4); // @output true
+}

--- a/corpus/bal/08-comparable/comp7-v.bal
+++ b/corpus/bal/08-comparable/comp7-v.bal
@@ -1,0 +1,44 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/io;
+type T1 [int, float, int];
+type T2 [int, float, int, int];
+
+public function main() {
+    T1 a = [0 , 5.0, 1];
+    T2 b = [0 , 5.0, 1, 2];
+    T2 c = [0 , 5.0, 1, -1];
+
+    io:println(a < b); //@output true
+    io:println(a <= b); //@output true
+    io:println(a > b); //@output false
+    io:println(a >= b); //@output false
+
+    io:println(b < a); //@output false
+    io:println(b <= a); //@output false
+    io:println(b > a); //@output true
+    io:println(b >= a); //@output true
+
+    io:println(a < c); //@output true
+    io:println(a <= c); //@output true
+    io:println(a > c); //@output false
+    io:println(a >= c); //@output false
+
+    io:println(c < a); //@output false
+    io:println(c <= a); //@output false
+    io:println(c > a); //@output true
+    io:println(c >= a); //@output true
+}

--- a/corpus/bal/08-comparable/floatsubtypecompare-v.bal
+++ b/corpus/bal/08-comparable/floatsubtypecompare-v.bal
@@ -1,0 +1,31 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/io;
+
+type A 1.0|2.0|3.0;
+public function main() {
+    A[] a = [1.0, 2.0, 3.0];
+    float[] b = [4.0, 5.0, 6.0];
+    io:println(a < b); //@output true
+    io:println(a <= b); //@output true
+    io:println(a > b); //@output false
+    io:println(a >= b); //@output false
+
+    io:println(b < a); //@output false
+    io:println(b <= a); //@output false
+    io:println(b > a); //@output true
+    io:println(b >= a); //@output true
+}

--- a/corpus/bal/08-comparable/intsubtypecompare-v.bal
+++ b/corpus/bal/08-comparable/intsubtypecompare-v.bal
@@ -1,0 +1,24 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/io;
+
+type A 1|2|3;
+public function main() {
+    A[] a = [1, 2, 3];
+    int[] b = [4, 5, 6];
+    io:println(a < b); //@output true
+    io:println(a <= b); //@output true
+}

--- a/corpus/bal/08-comparable/order1-v.bal
+++ b/corpus/bal/08-comparable/order1-v.bal
@@ -1,0 +1,34 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/io;
+
+public function main() {
+    int[][] a = [[1], [2]];
+    int[][] b = [[1], [3]];
+    io:println(a < b); // @output true
+    io:println(a > b); // @output false
+
+    int[]?[] c = [[0], [-1]];
+    int[][] d = [[0], [-2]];
+    io:println(c < d); // @output false
+    io:println(c > d); // @output true
+
+    int[]?[] e = [(), [1]];
+    int[][] f = [[0], [1]];
+    io:println(e == f); // @output false
+    io:println(e < f); // @output false
+    io:println(e > f); // @output false
+}

--- a/corpus/bal/08-comparable/order2-v.bal
+++ b/corpus/bal/08-comparable/order2-v.bal
@@ -1,0 +1,58 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/io;
+
+public function main() {
+    io:println(1 < ()); // @output false
+    io:println(() < ()); // @output false
+    io:println(() <= ()); // @output true
+
+    int[]? a = [1];
+    io:println(a < ()); // @output false
+    io:println(() < a); // @output false
+
+    int[]?[] b = [[1]];
+    io:println(b < ()); // @output false
+    io:println(() < b); // @output false
+
+    int[]?[] c = [()];
+    io:println(b < c); // @output false
+
+    int?[] d = [1];
+    io:println(d < ()); // @output false
+
+    int?[] e = [()];
+    io:println(d < e); // @output false
+    io:println(e < d); // @output false
+
+    int[] f = [1, 2, 3];
+    ()[] g = [(), (), ()];
+    io:println(f < g); // @output false
+    io:println(g < f); // @output false
+
+    int?[] h = [1, 2, 3];
+    ()[] i = [(), (), (), ()];
+    io:println(h > i); // @output false
+    io:println(i > h); // @output false
+
+    io:println(g < i); // @output true
+    io:println(i < g); // @output false
+
+    ()[][] j = [[()], [(), ()]];
+    ()[][] k = [[()], [(), (), ()]];
+    io:println(j < k); // @output true
+    io:println(k < j); // @output false
+}

--- a/corpus/bal/08-comparable/order3-v.bal
+++ b/corpus/bal/08-comparable/order3-v.bal
@@ -1,0 +1,28 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/io;
+
+public function main() {
+    int[] v1 = [];
+    if v1 is string[] {
+        string[] j = [];
+        io:println(v1 < j);
+        io:println(v1 > j);
+    }
+    else {
+        io:println("else"); // @output else
+    }
+}

--- a/corpus/bal/08-comparable/order4-v.bal
+++ b/corpus/bal/08-comparable/order4-v.bal
@@ -1,0 +1,25 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/io;
+
+public function main() {
+    ()[] n1 = [];
+    ()[][] n2 = [];
+    ()[]?[] n3 = [];
+    io:println(n1 < n2); // @output false
+    io:println(n3 < n2); // @output false
+    io:println(n1 < n3); // @output false
+}

--- a/corpus/bal/08-comparable/order5-v.bal
+++ b/corpus/bal/08-comparable/order5-v.bal
@@ -1,0 +1,42 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/io;
+
+public function main() {
+    boolean[][] b1 = [[true]];
+    boolean[][] b2 = [[true], []];
+    boolean[]?[] b3 = [[true], ()];
+
+    io:println(b1 < b2); // @output true
+    io:println(b2 < b3); // @output false
+    io:println(b2 > b3); // @output false
+    io:println(b3 > b1); // @output true
+
+    string[][] s1 = [["a"]];
+    string[][] s2 = [["a"], []];
+    string[]?[] s3 = [["a"], ()];
+
+    io:println(s2 > s1); // @output true
+    io:println(s2 < s3); // @output false
+    io:println(s2 > s3); // @output false
+    io:println(s1 < s3); // @output true
+
+    float[][] f1 = [[80.0]];
+    float[][] f2 = [[0.0 / 0.0]];
+
+    io:println(f1 > f2); // @output false
+    io:println(f2 > f2); // @output false
+}

--- a/corpus/bal/08-comparable/relational4-v.bal
+++ b/corpus/bal/08-comparable/relational4-v.bal
@@ -1,0 +1,31 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/io;
+public function main() {
+    decimal[] x = [1.5d];
+    decimal[] y = [3d];
+    decimal[] z = [3d];
+    decimal[] a1 = [1d, 2.5d];
+    decimal[] a2 = [2d, 3d];
+    io:println(x < y); // @output true
+    io:println(x > y); // @output false
+    io:println(y <= x); // @output false
+    io:println(y >= x); // @output true
+    io:println(y >= z); // @output true
+    io:println(y <= z); // @output true
+    io:println(a1 < a2); // @output true
+    io:println(a1 >= a2); // @output false
+}

--- a/corpus/bal/08-comparable/relational5-v.bal
+++ b/corpus/bal/08-comparable/relational5-v.bal
@@ -1,0 +1,35 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/io;
+public function main() {
+    decimal d1 = 1d;
+    decimal d2 = 2d;
+    decimal d3 = 3d;
+    decimal d15 = 1.5d;
+    decimal[] x = [d15];
+    decimal[] y = [d3];
+    decimal[] z = [3d];
+    decimal[] a1 = [d1, d2];
+    decimal[] a2 = [d2, d3];
+    io:println(x < y); // @output true
+    io:println(x > y); // @output false
+    io:println(y <= x); // @output false
+    io:println(y >= x); // @output true
+    io:println(y >= z); // @output true
+    io:println(y <= z); // @output true
+    io:println(a1 < a2); // @output true
+    io:println(a1 >= a2); // @output false
+}

--- a/corpus/bal/08-comparable/stringsubtypecompare-v.bal
+++ b/corpus/bal/08-comparable/stringsubtypecompare-v.bal
@@ -1,0 +1,31 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/io;
+
+type A "a"|"aa";
+public function main() {
+    A[] a = ["a", "aa"];
+    string[] b = ["b", "bb"];
+    io:println(a < b); //@output true
+    io:println(a <= b); //@output true
+    io:println(a > b); //@output false
+    io:println(a >= b); //@output false
+
+    io:println(b < a); //@output false
+    io:println(b <= a); //@output false
+    io:println(b > a); //@output true
+    io:println(b >= a); //@output true
+}

--- a/corpus/bir/08-comparable/5-v.txt
+++ b/corpus/bir/08-comparable/5-v.txt
@@ -1,0 +1,61 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %2 = ConstantLoad 1
+    %3 = ConstantLoad 2
+    %4 = ConstantLoad 2
+    %5 = newArray [int, int, never...][%4]{%2, %3}
+    %6 = ConstantLoad 3
+    %7 = ConstantLoad 1
+    %8 = ConstantLoad 2
+    %9 = newArray [int, int, never...][%8]{%6, %7}
+    %1 = < %5 %9;
+    a = %1;
+    %11 = println(a) -> bb1;
+  }
+  bb1 {
+    %13 = ConstantLoad 1
+    %14 = ConstantLoad 2
+    %15 = ConstantLoad 2
+    %16 = newArray [int, int, never...][%15]{%13, %14}
+    %17 = ConstantLoad 1
+    %18 = ConstantLoad 2
+    %19 = ConstantLoad 2
+    %20 = newArray [int, int, never...][%19]{%17, %18}
+    %12 = < %16 %20;
+    %21 = %12;
+    %22 = println(%21) -> bb2;
+  }
+  bb2 {
+    %24 = ConstantLoad 1
+    %25 = ConstantLoad 2
+    %26 = ConstantLoad 2
+    %27 = newArray [int, int, never...][%26]{%24, %25}
+    %28 = ConstantLoad 3
+    %29 = ConstantLoad 1
+    %30 = newArray [int, never...][%29]{%28}
+    %23 = > %27 %30;
+    b = %23;
+    %32 = b;
+    %33 = println(%32) -> bb3;
+  }
+  bb3 {
+    %35 = ConstantLoad 10
+    %36 = ConstantLoad 1
+    %37 = unknown %36;
+    %38 = ConstantLoad 1
+    %39 = unknown %38;
+    %40 = ConstantLoad 3
+    %41 = newArray [int, int, int, never...][%40]{%35, %37, %39}
+    %42 = ConstantLoad 0
+    %43 = ConstantLoad 1
+    %44 = newArray [int, never...][%43]{%42}
+    %34 = > %41 %44;
+    %45 = %34;
+    %46 = println(%45) -> bb4;
+  }
+  bb4 {
+    return;
+  }
+}

--- a/corpus/bir/08-comparable/arr1-v.txt
+++ b/corpus/bir/08-comparable/arr1-v.txt
@@ -1,0 +1,125 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad 1
+    %2 = ConstantLoad 2
+    %3 = ConstantLoad 3
+    %4 = ConstantLoad 3
+    %5 = newArray [int...][%4]{%1, %2, %3}
+    a = %5;
+    %7 = ConstantLoad 1
+    %8 = ConstantLoad <nil>
+    %9 = ConstantLoad 3
+    %10 = ConstantLoad 3
+    %11 = newArray [nil|int...][%10]{%7, %8, %9}
+    b = %11;
+    %13 = ConstantLoad 1
+    %14 = ConstantLoad <nil>
+    %15 = ConstantLoad 4
+    %16 = ConstantLoad 3
+    %17 = newArray [nil|int...][%16]{%13, %14, %15}
+    c = %17;
+    %19 = < b b;
+    %20 = %19;
+    %21 = println(%20) -> bb1;
+  }
+  bb1 {
+    %22 = <= b b;
+    %23 = %22;
+    %24 = println(%23) -> bb2;
+  }
+  bb2 {
+    %25 = > b b;
+    %26 = %25;
+    %27 = println(%26) -> bb3;
+  }
+  bb3 {
+    %28 = >= b b;
+    %29 = %28;
+    %30 = println(%29) -> bb4;
+  }
+  bb4 {
+    %31 = < a b;
+    %32 = %31;
+    %33 = println(%32) -> bb5;
+  }
+  bb5 {
+    %34 = <= a b;
+    %35 = %34;
+    %36 = println(%35) -> bb6;
+  }
+  bb6 {
+    %37 = > a b;
+    %38 = %37;
+    %39 = println(%38) -> bb7;
+  }
+  bb7 {
+    %40 = >= a b;
+    %41 = %40;
+    %42 = println(%41) -> bb8;
+  }
+  bb8 {
+    %43 = < b a;
+    %44 = %43;
+    %45 = println(%44) -> bb9;
+  }
+  bb9 {
+    %46 = <= b a;
+    %47 = %46;
+    %48 = println(%47) -> bb10;
+  }
+  bb10 {
+    %49 = > b a;
+    %50 = %49;
+    %51 = println(%50) -> bb11;
+  }
+  bb11 {
+    %52 = >= b a;
+    %53 = %52;
+    %54 = println(%53) -> bb12;
+  }
+  bb12 {
+    %55 = < b c;
+    %56 = %55;
+    %57 = println(%56) -> bb13;
+  }
+  bb13 {
+    %58 = <= b c;
+    %59 = %58;
+    %60 = println(%59) -> bb14;
+  }
+  bb14 {
+    %61 = > b c;
+    %62 = %61;
+    %63 = println(%62) -> bb15;
+  }
+  bb15 {
+    %64 = >= b c;
+    %65 = %64;
+    %66 = println(%65) -> bb16;
+  }
+  bb16 {
+    %67 = < c b;
+    %68 = %67;
+    %69 = println(%68) -> bb17;
+  }
+  bb17 {
+    %70 = <= c b;
+    %71 = %70;
+    %72 = println(%71) -> bb18;
+  }
+  bb18 {
+    %73 = > c b;
+    %74 = %73;
+    %75 = println(%74) -> bb19;
+  }
+  bb19 {
+    %76 = >= c b;
+    %77 = %76;
+    %78 = println(%77) -> bb20;
+  }
+  bb20 {
+    return;
+  }
+}

--- a/corpus/bir/08-comparable/arr2-v.txt
+++ b/corpus/bir/08-comparable/arr2-v.txt
@@ -1,0 +1,125 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad 0.1
+    %2 = ConstantLoad 2
+    %3 = ConstantLoad 3.5
+    %4 = ConstantLoad 3
+    %5 = newArray [float...][%4]{%1, %2, %3}
+    a = %5;
+    %7 = ConstantLoad 0.1
+    %8 = ConstantLoad <nil>
+    %9 = ConstantLoad 3.5
+    %10 = ConstantLoad 3
+    %11 = newArray [nil|float...][%10]{%7, %8, %9}
+    b = %11;
+    %13 = ConstantLoad 0.1
+    %14 = ConstantLoad <nil>
+    %15 = ConstantLoad 4.7
+    %16 = ConstantLoad 3
+    %17 = newArray [nil|float...][%16]{%13, %14, %15}
+    c = %17;
+    %19 = < b b;
+    %20 = %19;
+    %21 = println(%20) -> bb1;
+  }
+  bb1 {
+    %22 = <= b b;
+    %23 = %22;
+    %24 = println(%23) -> bb2;
+  }
+  bb2 {
+    %25 = > b b;
+    %26 = %25;
+    %27 = println(%26) -> bb3;
+  }
+  bb3 {
+    %28 = >= b b;
+    %29 = %28;
+    %30 = println(%29) -> bb4;
+  }
+  bb4 {
+    %31 = < a b;
+    %32 = %31;
+    %33 = println(%32) -> bb5;
+  }
+  bb5 {
+    %34 = <= a b;
+    %35 = %34;
+    %36 = println(%35) -> bb6;
+  }
+  bb6 {
+    %37 = > a b;
+    %38 = %37;
+    %39 = println(%38) -> bb7;
+  }
+  bb7 {
+    %40 = >= a b;
+    %41 = %40;
+    %42 = println(%41) -> bb8;
+  }
+  bb8 {
+    %43 = < b a;
+    %44 = %43;
+    %45 = println(%44) -> bb9;
+  }
+  bb9 {
+    %46 = <= b a;
+    %47 = %46;
+    %48 = println(%47) -> bb10;
+  }
+  bb10 {
+    %49 = > b a;
+    %50 = %49;
+    %51 = println(%50) -> bb11;
+  }
+  bb11 {
+    %52 = >= b a;
+    %53 = %52;
+    %54 = println(%53) -> bb12;
+  }
+  bb12 {
+    %55 = < b c;
+    %56 = %55;
+    %57 = println(%56) -> bb13;
+  }
+  bb13 {
+    %58 = <= b c;
+    %59 = %58;
+    %60 = println(%59) -> bb14;
+  }
+  bb14 {
+    %61 = > b c;
+    %62 = %61;
+    %63 = println(%62) -> bb15;
+  }
+  bb15 {
+    %64 = >= b c;
+    %65 = %64;
+    %66 = println(%65) -> bb16;
+  }
+  bb16 {
+    %67 = < c b;
+    %68 = %67;
+    %69 = println(%68) -> bb17;
+  }
+  bb17 {
+    %70 = <= c b;
+    %71 = %70;
+    %72 = println(%71) -> bb18;
+  }
+  bb18 {
+    %73 = > c b;
+    %74 = %73;
+    %75 = println(%74) -> bb19;
+  }
+  bb19 {
+    %76 = >= c b;
+    %77 = %76;
+    %78 = println(%77) -> bb20;
+  }
+  bb20 {
+    return;
+  }
+}

--- a/corpus/bir/08-comparable/arr3-v.txt
+++ b/corpus/bir/08-comparable/arr3-v.txt
@@ -1,0 +1,125 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad abc
+    %2 = ConstantLoad abd
+    %3 = ConstantLoad abcd
+    %4 = ConstantLoad 3
+    %5 = newArray [string...][%4]{%1, %2, %3}
+    a = %5;
+    %7 = ConstantLoad abc
+    %8 = ConstantLoad <nil>
+    %9 = ConstantLoad abcd
+    %10 = ConstantLoad 3
+    %11 = newArray [nil|string...][%10]{%7, %8, %9}
+    b = %11;
+    %13 = ConstantLoad abc
+    %14 = ConstantLoad <nil>
+    %15 = ConstantLoad xyz
+    %16 = ConstantLoad 3
+    %17 = newArray [nil|string...][%16]{%13, %14, %15}
+    c = %17;
+    %19 = < b b;
+    %20 = %19;
+    %21 = println(%20) -> bb1;
+  }
+  bb1 {
+    %22 = <= b b;
+    %23 = %22;
+    %24 = println(%23) -> bb2;
+  }
+  bb2 {
+    %25 = > b b;
+    %26 = %25;
+    %27 = println(%26) -> bb3;
+  }
+  bb3 {
+    %28 = >= b b;
+    %29 = %28;
+    %30 = println(%29) -> bb4;
+  }
+  bb4 {
+    %31 = < a b;
+    %32 = %31;
+    %33 = println(%32) -> bb5;
+  }
+  bb5 {
+    %34 = <= a b;
+    %35 = %34;
+    %36 = println(%35) -> bb6;
+  }
+  bb6 {
+    %37 = > a b;
+    %38 = %37;
+    %39 = println(%38) -> bb7;
+  }
+  bb7 {
+    %40 = >= a b;
+    %41 = %40;
+    %42 = println(%41) -> bb8;
+  }
+  bb8 {
+    %43 = < b a;
+    %44 = %43;
+    %45 = println(%44) -> bb9;
+  }
+  bb9 {
+    %46 = <= b a;
+    %47 = %46;
+    %48 = println(%47) -> bb10;
+  }
+  bb10 {
+    %49 = > b a;
+    %50 = %49;
+    %51 = println(%50) -> bb11;
+  }
+  bb11 {
+    %52 = >= b a;
+    %53 = %52;
+    %54 = println(%53) -> bb12;
+  }
+  bb12 {
+    %55 = < b c;
+    %56 = %55;
+    %57 = println(%56) -> bb13;
+  }
+  bb13 {
+    %58 = <= b c;
+    %59 = %58;
+    %60 = println(%59) -> bb14;
+  }
+  bb14 {
+    %61 = > b c;
+    %62 = %61;
+    %63 = println(%62) -> bb15;
+  }
+  bb15 {
+    %64 = >= b c;
+    %65 = %64;
+    %66 = println(%65) -> bb16;
+  }
+  bb16 {
+    %67 = < c b;
+    %68 = %67;
+    %69 = println(%68) -> bb17;
+  }
+  bb17 {
+    %70 = <= c b;
+    %71 = %70;
+    %72 = println(%71) -> bb18;
+  }
+  bb18 {
+    %73 = > c b;
+    %74 = %73;
+    %75 = println(%74) -> bb19;
+  }
+  bb19 {
+    %76 = >= c b;
+    %77 = %76;
+    %78 = println(%77) -> bb20;
+  }
+  bb20 {
+    return;
+  }
+}

--- a/corpus/bir/08-comparable/arr4-v.txt
+++ b/corpus/bir/08-comparable/arr4-v.txt
@@ -1,0 +1,125 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad false
+    %2 = ConstantLoad true
+    %3 = ConstantLoad false
+    %4 = ConstantLoad 3
+    %5 = newArray [boolean...][%4]{%1, %2, %3}
+    a = %5;
+    %7 = ConstantLoad false
+    %8 = ConstantLoad <nil>
+    %9 = ConstantLoad false
+    %10 = ConstantLoad 3
+    %11 = newArray [nil|boolean...][%10]{%7, %8, %9}
+    b = %11;
+    %13 = ConstantLoad false
+    %14 = ConstantLoad <nil>
+    %15 = ConstantLoad true
+    %16 = ConstantLoad 3
+    %17 = newArray [nil|boolean...][%16]{%13, %14, %15}
+    c = %17;
+    %19 = < b b;
+    %20 = %19;
+    %21 = println(%20) -> bb1;
+  }
+  bb1 {
+    %22 = <= b b;
+    %23 = %22;
+    %24 = println(%23) -> bb2;
+  }
+  bb2 {
+    %25 = > b b;
+    %26 = %25;
+    %27 = println(%26) -> bb3;
+  }
+  bb3 {
+    %28 = >= b b;
+    %29 = %28;
+    %30 = println(%29) -> bb4;
+  }
+  bb4 {
+    %31 = < a b;
+    %32 = %31;
+    %33 = println(%32) -> bb5;
+  }
+  bb5 {
+    %34 = <= a b;
+    %35 = %34;
+    %36 = println(%35) -> bb6;
+  }
+  bb6 {
+    %37 = > a b;
+    %38 = %37;
+    %39 = println(%38) -> bb7;
+  }
+  bb7 {
+    %40 = >= a b;
+    %41 = %40;
+    %42 = println(%41) -> bb8;
+  }
+  bb8 {
+    %43 = < b a;
+    %44 = %43;
+    %45 = println(%44) -> bb9;
+  }
+  bb9 {
+    %46 = <= b a;
+    %47 = %46;
+    %48 = println(%47) -> bb10;
+  }
+  bb10 {
+    %49 = > b a;
+    %50 = %49;
+    %51 = println(%50) -> bb11;
+  }
+  bb11 {
+    %52 = >= b a;
+    %53 = %52;
+    %54 = println(%53) -> bb12;
+  }
+  bb12 {
+    %55 = < b c;
+    %56 = %55;
+    %57 = println(%56) -> bb13;
+  }
+  bb13 {
+    %58 = <= b c;
+    %59 = %58;
+    %60 = println(%59) -> bb14;
+  }
+  bb14 {
+    %61 = > b c;
+    %62 = %61;
+    %63 = println(%62) -> bb15;
+  }
+  bb15 {
+    %64 = >= b c;
+    %65 = %64;
+    %66 = println(%65) -> bb16;
+  }
+  bb16 {
+    %67 = < c b;
+    %68 = %67;
+    %69 = println(%68) -> bb17;
+  }
+  bb17 {
+    %70 = <= c b;
+    %71 = %70;
+    %72 = println(%71) -> bb18;
+  }
+  bb18 {
+    %73 = > c b;
+    %74 = %73;
+    %75 = println(%74) -> bb19;
+  }
+  bb19 {
+    %76 = >= c b;
+    %77 = %76;
+    %78 = println(%77) -> bb20;
+  }
+  bb20 {
+    return;
+  }
+}

--- a/corpus/bir/08-comparable/booleansubtypecompare-v.txt
+++ b/corpus/bir/08-comparable/booleansubtypecompare-v.txt
@@ -1,0 +1,57 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad false
+    %2 = ConstantLoad false
+    %3 = ConstantLoad 2
+    %4 = newArray [false...][%3]{%1, %2}
+    a = %4;
+    %6 = ConstantLoad true
+    %7 = ConstantLoad true
+    %8 = ConstantLoad 2
+    %9 = newArray [boolean...][%8]{%6, %7}
+    b = %9;
+    %11 = < a b;
+    %12 = %11;
+    %13 = println(%12) -> bb1;
+  }
+  bb1 {
+    %14 = <= a b;
+    %15 = %14;
+    %16 = println(%15) -> bb2;
+  }
+  bb2 {
+    %17 = > a b;
+    %18 = %17;
+    %19 = println(%18) -> bb3;
+  }
+  bb3 {
+    %20 = >= a b;
+    %21 = %20;
+    %22 = println(%21) -> bb4;
+  }
+  bb4 {
+    %23 = < b a;
+    %24 = %23;
+    %25 = println(%24) -> bb5;
+  }
+  bb5 {
+    %26 = <= b a;
+    %27 = %26;
+    %28 = println(%27) -> bb6;
+  }
+  bb6 {
+    %29 = > b a;
+    %30 = %29;
+    %31 = println(%30) -> bb7;
+  }
+  bb7 {
+    %32 = >= b a;
+    %33 = %32;
+    %34 = println(%33) -> bb8;
+  }
+  bb8 {
+    return;
+  }
+}

--- a/corpus/bir/08-comparable/comp1-v.txt
+++ b/corpus/bir/08-comparable/comp1-v.txt
@@ -1,0 +1,102 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad 0
+    %2 = ConstantLoad b
+    %3 = ConstantLoad 2
+    %4 = newArray [int, string, never...][%3]{%1, %2}
+    a = %4;
+    %6 = ConstantLoad 1
+    %7 = ConstantLoad a
+    %8 = ConstantLoad 2
+    %9 = newArray [int, string, never...][%8]{%6, %7}
+    b = %9;
+    %11 = ConstantLoad 0
+    %12 = ConstantLoad a
+    %13 = ConstantLoad 2
+    %14 = newArray [int, string, never...][%13]{%11, %12}
+    c = %14;
+    %16 = < a b;
+    %17 = %16;
+    %18 = println(%17) -> bb1;
+  }
+  bb1 {
+    %19 = <= a b;
+    %20 = %19;
+    %21 = println(%20) -> bb2;
+  }
+  bb2 {
+    %22 = > a b;
+    %23 = %22;
+    %24 = println(%23) -> bb3;
+  }
+  bb3 {
+    %25 = >= a b;
+    %26 = %25;
+    %27 = println(%26) -> bb4;
+  }
+  bb4 {
+    %28 = < b a;
+    %29 = %28;
+    %30 = println(%29) -> bb5;
+  }
+  bb5 {
+    %31 = <= b a;
+    %32 = %31;
+    %33 = println(%32) -> bb6;
+  }
+  bb6 {
+    %34 = > b a;
+    %35 = %34;
+    %36 = println(%35) -> bb7;
+  }
+  bb7 {
+    %37 = >= b a;
+    %38 = %37;
+    %39 = println(%38) -> bb8;
+  }
+  bb8 {
+    %40 = < a c;
+    %41 = %40;
+    %42 = println(%41) -> bb9;
+  }
+  bb9 {
+    %43 = <= a c;
+    %44 = %43;
+    %45 = println(%44) -> bb10;
+  }
+  bb10 {
+    %46 = > a c;
+    %47 = %46;
+    %48 = println(%47) -> bb11;
+  }
+  bb11 {
+    %49 = >= a c;
+    %50 = %49;
+    %51 = println(%50) -> bb12;
+  }
+  bb12 {
+    %52 = < c a;
+    %53 = %52;
+    %54 = println(%53) -> bb13;
+  }
+  bb13 {
+    %55 = <= c a;
+    %56 = %55;
+    %57 = println(%56) -> bb14;
+  }
+  bb14 {
+    %58 = > c a;
+    %59 = %58;
+    %60 = println(%59) -> bb15;
+  }
+  bb15 {
+    %61 = >= c a;
+    %62 = %61;
+    %63 = println(%62) -> bb16;
+  }
+  bb16 {
+    return;
+  }
+}

--- a/corpus/bir/08-comparable/comp10-v.txt
+++ b/corpus/bir/08-comparable/comp10-v.txt
@@ -1,0 +1,57 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad 0
+    %2 = ConstantLoad 500
+    %3 = ConstantLoad 2
+    %4 = newArray [int, int, never...][%3]{%1, %2}
+    a = %4;
+    %6 = ConstantLoad 0
+    %7 = ConstantLoad 5
+    %8 = ConstantLoad 2
+    %9 = newArray [int, int:Unsigned8, never...][%8]{%6, %7}
+    b = %9;
+    %11 = < a b;
+    %12 = %11;
+    %13 = println(%12) -> bb1;
+  }
+  bb1 {
+    %14 = <= a b;
+    %15 = %14;
+    %16 = println(%15) -> bb2;
+  }
+  bb2 {
+    %17 = > a b;
+    %18 = %17;
+    %19 = println(%18) -> bb3;
+  }
+  bb3 {
+    %20 = >= a b;
+    %21 = %20;
+    %22 = println(%21) -> bb4;
+  }
+  bb4 {
+    %23 = < b a;
+    %24 = %23;
+    %25 = println(%24) -> bb5;
+  }
+  bb5 {
+    %26 = <= b a;
+    %27 = %26;
+    %28 = println(%27) -> bb6;
+  }
+  bb6 {
+    %29 = > b a;
+    %30 = %29;
+    %31 = println(%30) -> bb7;
+  }
+  bb7 {
+    %32 = >= b a;
+    %33 = %32;
+    %34 = println(%33) -> bb8;
+  }
+  bb8 {
+    return;
+  }
+}

--- a/corpus/bir/08-comparable/comp11-v.txt
+++ b/corpus/bir/08-comparable/comp11-v.txt
@@ -1,0 +1,105 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad 1
+    %2 = ConstantLoad 6.4
+    %3 = ConstantLoad 100/1
+    %4 = ConstantLoad 10
+    %5 = ConstantLoad 11
+    %6 = ConstantLoad 5
+    %7 = newArray [int, float, decimal, int...][%6]{%1, %2, %3, %4, %5}
+    a = %7;
+    %9 = ConstantLoad 5
+    %10 = ConstantLoad 1
+    %11 = newArray [int:Unsigned8, never...][%10]{%9}
+    b = %11;
+    %13 = ConstantLoad 0
+    %14 = ConstantLoad 4
+    %15 = ConstantLoad 10
+    %16 = ConstantLoad 3
+    %17 = newArray [int:Unsigned8, int...][%16]{%13, %14, %15}
+    c = %17;
+    %19 = < a b;
+    %20 = %19;
+    %21 = println(%20) -> bb1;
+  }
+  bb1 {
+    %22 = <= a b;
+    %23 = %22;
+    %24 = println(%23) -> bb2;
+  }
+  bb2 {
+    %25 = > a b;
+    %26 = %25;
+    %27 = println(%26) -> bb3;
+  }
+  bb3 {
+    %28 = >= a b;
+    %29 = %28;
+    %30 = println(%29) -> bb4;
+  }
+  bb4 {
+    %31 = < b a;
+    %32 = %31;
+    %33 = println(%32) -> bb5;
+  }
+  bb5 {
+    %34 = <= b a;
+    %35 = %34;
+    %36 = println(%35) -> bb6;
+  }
+  bb6 {
+    %37 = > b a;
+    %38 = %37;
+    %39 = println(%38) -> bb7;
+  }
+  bb7 {
+    %40 = >= b a;
+    %41 = %40;
+    %42 = println(%41) -> bb8;
+  }
+  bb8 {
+    %43 = < b c;
+    %44 = %43;
+    %45 = println(%44) -> bb9;
+  }
+  bb9 {
+    %46 = <= b c;
+    %47 = %46;
+    %48 = println(%47) -> bb10;
+  }
+  bb10 {
+    %49 = > b c;
+    %50 = %49;
+    %51 = println(%50) -> bb11;
+  }
+  bb11 {
+    %52 = >= b c;
+    %53 = %52;
+    %54 = println(%53) -> bb12;
+  }
+  bb12 {
+    %55 = < c b;
+    %56 = %55;
+    %57 = println(%56) -> bb13;
+  }
+  bb13 {
+    %58 = <= c b;
+    %59 = %58;
+    %60 = println(%59) -> bb14;
+  }
+  bb14 {
+    %61 = > c b;
+    %62 = %61;
+    %63 = println(%62) -> bb15;
+  }
+  bb15 {
+    %64 = >= c b;
+    %65 = %64;
+    %66 = println(%65) -> bb16;
+  }
+  bb16 {
+    return;
+  }
+}

--- a/corpus/bir/08-comparable/comp2-v.txt
+++ b/corpus/bir/08-comparable/comp2-v.txt
@@ -1,0 +1,105 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad 0
+    %2 = ConstantLoad 1
+    %3 = ConstantLoad 2
+    %4 = ConstantLoad 3
+    %5 = newArray [int, int, int, never...][%4]{%1, %2, %3}
+    a = %5;
+    %7 = ConstantLoad 1
+    %8 = ConstantLoad 0
+    %9 = ConstantLoad 3
+    %10 = ConstantLoad 3
+    %11 = newArray [int, int, int, never...][%10]{%7, %8, %9}
+    b = %11;
+    %13 = ConstantLoad 0
+    %14 = ConstantLoad 1
+    %15 = ConstantLoad 0
+    %16 = ConstantLoad 3
+    %17 = newArray [int, int, int, never...][%16]{%13, %14, %15}
+    c = %17;
+    %19 = < a b;
+    %20 = %19;
+    %21 = println(%20) -> bb1;
+  }
+  bb1 {
+    %22 = <= a b;
+    %23 = %22;
+    %24 = println(%23) -> bb2;
+  }
+  bb2 {
+    %25 = > a b;
+    %26 = %25;
+    %27 = println(%26) -> bb3;
+  }
+  bb3 {
+    %28 = >= a b;
+    %29 = %28;
+    %30 = println(%29) -> bb4;
+  }
+  bb4 {
+    %31 = < b a;
+    %32 = %31;
+    %33 = println(%32) -> bb5;
+  }
+  bb5 {
+    %34 = <= b a;
+    %35 = %34;
+    %36 = println(%35) -> bb6;
+  }
+  bb6 {
+    %37 = > b a;
+    %38 = %37;
+    %39 = println(%38) -> bb7;
+  }
+  bb7 {
+    %40 = >= b a;
+    %41 = %40;
+    %42 = println(%41) -> bb8;
+  }
+  bb8 {
+    %43 = < a c;
+    %44 = %43;
+    %45 = println(%44) -> bb9;
+  }
+  bb9 {
+    %46 = <= a c;
+    %47 = %46;
+    %48 = println(%47) -> bb10;
+  }
+  bb10 {
+    %49 = > a c;
+    %50 = %49;
+    %51 = println(%50) -> bb11;
+  }
+  bb11 {
+    %52 = >= a c;
+    %53 = %52;
+    %54 = println(%53) -> bb12;
+  }
+  bb12 {
+    %55 = < c a;
+    %56 = %55;
+    %57 = println(%56) -> bb13;
+  }
+  bb13 {
+    %58 = <= c a;
+    %59 = %58;
+    %60 = println(%59) -> bb14;
+  }
+  bb14 {
+    %61 = > c a;
+    %62 = %61;
+    %63 = println(%62) -> bb15;
+  }
+  bb15 {
+    %64 = >= c a;
+    %65 = %64;
+    %66 = println(%65) -> bb16;
+  }
+  bb16 {
+    return;
+  }
+}

--- a/corpus/bir/08-comparable/comp3-v.txt
+++ b/corpus/bir/08-comparable/comp3-v.txt
@@ -1,0 +1,101 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad 0
+    %2 = ConstantLoad 5
+    %3 = ConstantLoad 2
+    %4 = newArray [int, int, never...][%3]{%1, %2}
+    a = %4;
+    %6 = ConstantLoad 2
+    %7 = ConstantLoad 1
+    %8 = newArray [int, never...][%7]{%6}
+    b = %8;
+    %10 = ConstantLoad 1
+    %11 = unknown %10;
+    %12 = ConstantLoad 1
+    %13 = newArray [int, never...][%12]{%11}
+    c = %13;
+    %15 = < a b;
+    %16 = %15;
+    %17 = println(%16) -> bb1;
+  }
+  bb1 {
+    %18 = <= a b;
+    %19 = %18;
+    %20 = println(%19) -> bb2;
+  }
+  bb2 {
+    %21 = > a b;
+    %22 = %21;
+    %23 = println(%22) -> bb3;
+  }
+  bb3 {
+    %24 = >= a b;
+    %25 = %24;
+    %26 = println(%25) -> bb4;
+  }
+  bb4 {
+    %27 = < b a;
+    %28 = %27;
+    %29 = println(%28) -> bb5;
+  }
+  bb5 {
+    %30 = <= b a;
+    %31 = %30;
+    %32 = println(%31) -> bb6;
+  }
+  bb6 {
+    %33 = > b a;
+    %34 = %33;
+    %35 = println(%34) -> bb7;
+  }
+  bb7 {
+    %36 = >= b a;
+    %37 = %36;
+    %38 = println(%37) -> bb8;
+  }
+  bb8 {
+    %39 = < a c;
+    %40 = %39;
+    %41 = println(%40) -> bb9;
+  }
+  bb9 {
+    %42 = <= a c;
+    %43 = %42;
+    %44 = println(%43) -> bb10;
+  }
+  bb10 {
+    %45 = > a c;
+    %46 = %45;
+    %47 = println(%46) -> bb11;
+  }
+  bb11 {
+    %48 = >= a c;
+    %49 = %48;
+    %50 = println(%49) -> bb12;
+  }
+  bb12 {
+    %51 = < c a;
+    %52 = %51;
+    %53 = println(%52) -> bb13;
+  }
+  bb13 {
+    %54 = <= c a;
+    %55 = %54;
+    %56 = println(%55) -> bb14;
+  }
+  bb14 {
+    %57 = > c a;
+    %58 = %57;
+    %59 = println(%58) -> bb15;
+  }
+  bb15 {
+    %60 = >= c a;
+    %61 = %60;
+    %62 = println(%61) -> bb16;
+  }
+  bb16 {
+    return;
+  }
+}

--- a/corpus/bir/08-comparable/comp5-v.txt
+++ b/corpus/bir/08-comparable/comp5-v.txt
@@ -1,0 +1,69 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad 5
+    %2 = ConstantLoad 1
+    %3 = ConstantLoad 2
+    %4 = ConstantLoad 2
+    %5 = newArray [int, int, never...][%4]{%2, %3}
+    %6 = ConstantLoad 2
+    %7 = newArray [int, [int, int, never...], never...][%6]{%1, %5}
+    arr1 = %7;
+    %9 = ConstantLoad 5
+    %10 = ConstantLoad 0
+    %11 = ConstantLoad 2
+    %12 = ConstantLoad 2
+    %13 = newArray [int, int, never...][%12]{%10, %11}
+    %14 = ConstantLoad 2
+    %15 = newArray [int, [int, int, never...], never...][%14]{%9, %13}
+    arr2 = %15;
+    %17 = ConstantLoad 5
+    %18 = ConstantLoad 2
+    %19 = ConstantLoad 2
+    %20 = ConstantLoad 2
+    %21 = newArray [int, int, never...][%20]{%18, %19}
+    %22 = ConstantLoad 2
+    %23 = newArray [int, [int, int, never...], never...][%22]{%17, %21}
+    arr3 = %23;
+    %25 = ConstantLoad 3
+    %26 = ConstantLoad 1
+    %27 = ConstantLoad 2
+    %28 = ConstantLoad 2
+    %29 = newArray [int, int, never...][%28]{%26, %27}
+    %30 = ConstantLoad 2
+    %31 = newArray [int, [int, int, never...], never...][%30]{%25, %29}
+    arr4 = %31;
+    %33 = < arr1 arr2;
+    %34 = %33;
+    %35 = println(%34) -> bb1;
+  }
+  bb1 {
+    %36 = < arr1 arr3;
+    %37 = %36;
+    %38 = println(%37) -> bb2;
+  }
+  bb2 {
+    %39 = < arr1 arr4;
+    %40 = %39;
+    %41 = println(%40) -> bb3;
+  }
+  bb3 {
+    %42 = > arr1 arr2;
+    %43 = %42;
+    %44 = println(%43) -> bb4;
+  }
+  bb4 {
+    %45 = > arr1 arr3;
+    %46 = %45;
+    %47 = println(%46) -> bb5;
+  }
+  bb5 {
+    %48 = > arr1 arr4;
+    %49 = %48;
+    %50 = println(%49) -> bb6;
+  }
+  bb6 {
+    return;
+  }
+}

--- a/corpus/bir/08-comparable/comp7-v.txt
+++ b/corpus/bir/08-comparable/comp7-v.txt
@@ -1,0 +1,108 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad 0
+    %2 = ConstantLoad 5
+    %3 = ConstantLoad 1
+    %4 = ConstantLoad 3
+    %5 = newArray [int, float, int, never...][%4]{%1, %2, %3}
+    a = %5;
+    %7 = ConstantLoad 0
+    %8 = ConstantLoad 5
+    %9 = ConstantLoad 1
+    %10 = ConstantLoad 2
+    %11 = ConstantLoad 4
+    %12 = newArray [int, float, int, int, never...][%11]{%7, %8, %9, %10}
+    b = %12;
+    %14 = ConstantLoad 0
+    %15 = ConstantLoad 5
+    %16 = ConstantLoad 1
+    %17 = ConstantLoad 1
+    %18 = unknown %17;
+    %19 = ConstantLoad 4
+    %20 = newArray [int, float, int, int, never...][%19]{%14, %15, %16, %18}
+    c = %20;
+    %22 = < a b;
+    %23 = %22;
+    %24 = println(%23) -> bb1;
+  }
+  bb1 {
+    %25 = <= a b;
+    %26 = %25;
+    %27 = println(%26) -> bb2;
+  }
+  bb2 {
+    %28 = > a b;
+    %29 = %28;
+    %30 = println(%29) -> bb3;
+  }
+  bb3 {
+    %31 = >= a b;
+    %32 = %31;
+    %33 = println(%32) -> bb4;
+  }
+  bb4 {
+    %34 = < b a;
+    %35 = %34;
+    %36 = println(%35) -> bb5;
+  }
+  bb5 {
+    %37 = <= b a;
+    %38 = %37;
+    %39 = println(%38) -> bb6;
+  }
+  bb6 {
+    %40 = > b a;
+    %41 = %40;
+    %42 = println(%41) -> bb7;
+  }
+  bb7 {
+    %43 = >= b a;
+    %44 = %43;
+    %45 = println(%44) -> bb8;
+  }
+  bb8 {
+    %46 = < a c;
+    %47 = %46;
+    %48 = println(%47) -> bb9;
+  }
+  bb9 {
+    %49 = <= a c;
+    %50 = %49;
+    %51 = println(%50) -> bb10;
+  }
+  bb10 {
+    %52 = > a c;
+    %53 = %52;
+    %54 = println(%53) -> bb11;
+  }
+  bb11 {
+    %55 = >= a c;
+    %56 = %55;
+    %57 = println(%56) -> bb12;
+  }
+  bb12 {
+    %58 = < c a;
+    %59 = %58;
+    %60 = println(%59) -> bb13;
+  }
+  bb13 {
+    %61 = <= c a;
+    %62 = %61;
+    %63 = println(%62) -> bb14;
+  }
+  bb14 {
+    %64 = > c a;
+    %65 = %64;
+    %66 = println(%65) -> bb15;
+  }
+  bb15 {
+    %67 = >= c a;
+    %68 = %67;
+    %69 = println(%68) -> bb16;
+  }
+  bb16 {
+    return;
+  }
+}

--- a/corpus/bir/08-comparable/floatsubtypecompare-v.txt
+++ b/corpus/bir/08-comparable/floatsubtypecompare-v.txt
@@ -1,0 +1,59 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad 1
+    %2 = ConstantLoad 2
+    %3 = ConstantLoad 3
+    %4 = ConstantLoad 3
+    %5 = newArray [1|2|3...][%4]{%1, %2, %3}
+    a = %5;
+    %7 = ConstantLoad 4
+    %8 = ConstantLoad 5
+    %9 = ConstantLoad 6
+    %10 = ConstantLoad 3
+    %11 = newArray [float...][%10]{%7, %8, %9}
+    b = %11;
+    %13 = < a b;
+    %14 = %13;
+    %15 = println(%14) -> bb1;
+  }
+  bb1 {
+    %16 = <= a b;
+    %17 = %16;
+    %18 = println(%17) -> bb2;
+  }
+  bb2 {
+    %19 = > a b;
+    %20 = %19;
+    %21 = println(%20) -> bb3;
+  }
+  bb3 {
+    %22 = >= a b;
+    %23 = %22;
+    %24 = println(%23) -> bb4;
+  }
+  bb4 {
+    %25 = < b a;
+    %26 = %25;
+    %27 = println(%26) -> bb5;
+  }
+  bb5 {
+    %28 = <= b a;
+    %29 = %28;
+    %30 = println(%29) -> bb6;
+  }
+  bb6 {
+    %31 = > b a;
+    %32 = %31;
+    %33 = println(%32) -> bb7;
+  }
+  bb7 {
+    %34 = >= b a;
+    %35 = %34;
+    %36 = println(%35) -> bb8;
+  }
+  bb8 {
+    return;
+  }
+}

--- a/corpus/bir/08-comparable/intsubtypecompare-v.txt
+++ b/corpus/bir/08-comparable/intsubtypecompare-v.txt
@@ -1,0 +1,29 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad 1
+    %2 = ConstantLoad 2
+    %3 = ConstantLoad 3
+    %4 = ConstantLoad 3
+    %5 = newArray [1|2|3...][%4]{%1, %2, %3}
+    a = %5;
+    %7 = ConstantLoad 4
+    %8 = ConstantLoad 5
+    %9 = ConstantLoad 6
+    %10 = ConstantLoad 3
+    %11 = newArray [int...][%10]{%7, %8, %9}
+    b = %11;
+    %13 = < a b;
+    %14 = %13;
+    %15 = println(%14) -> bb1;
+  }
+  bb1 {
+    %16 = <= a b;
+    %17 = %16;
+    %18 = println(%17) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}

--- a/corpus/bir/08-comparable/order1-v.txt
+++ b/corpus/bir/08-comparable/order1-v.txt
@@ -1,0 +1,96 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad 1
+    %2 = ConstantLoad 1
+    %3 = newArray [int...][%2]{%1}
+    %4 = ConstantLoad 2
+    %5 = ConstantLoad 1
+    %6 = newArray [int...][%5]{%4}
+    %7 = ConstantLoad 2
+    %8 = newArray [[int...]...][%7]{%3, %6}
+    a = %8;
+    %10 = ConstantLoad 1
+    %11 = ConstantLoad 1
+    %12 = newArray [int...][%11]{%10}
+    %13 = ConstantLoad 3
+    %14 = ConstantLoad 1
+    %15 = newArray [int...][%14]{%13}
+    %16 = ConstantLoad 2
+    %17 = newArray [[int...]...][%16]{%12, %15}
+    b = %17;
+    %19 = < a b;
+    %20 = %19;
+    %21 = println(%20) -> bb1;
+  }
+  bb1 {
+    %22 = > a b;
+    %23 = %22;
+    %24 = println(%23) -> bb2;
+  }
+  bb2 {
+    %25 = ConstantLoad 0
+    %26 = ConstantLoad 1
+    %27 = newArray [int...][%26]{%25}
+    %28 = ConstantLoad 1
+    %29 = unknown %28;
+    %30 = ConstantLoad 1
+    %31 = newArray [int...][%30]{%29}
+    %32 = ConstantLoad 2
+    %33 = newArray [nil|[int...]...][%32]{%27, %31}
+    c = %33;
+    %35 = ConstantLoad 0
+    %36 = ConstantLoad 1
+    %37 = newArray [int...][%36]{%35}
+    %38 = ConstantLoad 2
+    %39 = unknown %38;
+    %40 = ConstantLoad 1
+    %41 = newArray [int...][%40]{%39}
+    %42 = ConstantLoad 2
+    %43 = newArray [[int...]...][%42]{%37, %41}
+    d = %43;
+    %45 = < c d;
+    %46 = %45;
+    %47 = println(%46) -> bb3;
+  }
+  bb3 {
+    %48 = > c d;
+    %49 = %48;
+    %50 = println(%49) -> bb4;
+  }
+  bb4 {
+    %51 = ConstantLoad <nil>
+    %52 = ConstantLoad 1
+    %53 = ConstantLoad 1
+    %54 = newArray [int...][%53]{%52}
+    %55 = ConstantLoad 2
+    %56 = newArray [nil|[int...]...][%55]{%51, %54}
+    e = %56;
+    %58 = ConstantLoad 0
+    %59 = ConstantLoad 1
+    %60 = newArray [int...][%59]{%58}
+    %61 = ConstantLoad 1
+    %62 = ConstantLoad 1
+    %63 = newArray [int...][%62]{%61}
+    %64 = ConstantLoad 2
+    %65 = newArray [[int...]...][%64]{%60, %63}
+    f = %65;
+    %67 = == e f;
+    %68 = %67;
+    %69 = println(%68) -> bb5;
+  }
+  bb5 {
+    %70 = < e f;
+    %71 = %70;
+    %72 = println(%71) -> bb6;
+  }
+  bb6 {
+    %73 = > e f;
+    %74 = %73;
+    %75 = println(%74) -> bb7;
+  }
+  bb7 {
+    return;
+  }
+}

--- a/corpus/bir/08-comparable/order2-v.txt
+++ b/corpus/bir/08-comparable/order2-v.txt
@@ -1,0 +1,192 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %2 = ConstantLoad 1
+    %3 = %2;
+    %4 = ConstantLoad <nil>
+    %5 = %4;
+    %1 = < %3 %5;
+    %6 = %1;
+    %7 = println(%6) -> bb1;
+  }
+  bb1 {
+    %9 = ConstantLoad <nil>
+    %10 = %9;
+    %11 = ConstantLoad <nil>
+    %12 = %11;
+    %8 = < %10 %12;
+    %13 = %8;
+    %14 = println(%13) -> bb2;
+  }
+  bb2 {
+    %16 = ConstantLoad <nil>
+    %17 = %16;
+    %18 = ConstantLoad <nil>
+    %19 = %18;
+    %15 = <= %17 %19;
+    %20 = %15;
+    %21 = println(%20) -> bb3;
+  }
+  bb3 {
+    %22 = ConstantLoad 1
+    %23 = ConstantLoad 1
+    %24 = newArray [int...][%23]{%22}
+    a = %24;
+    %27 = ConstantLoad <nil>
+    %28 = %27;
+    %26 = < a %28;
+    %29 = %26;
+    %30 = println(%29) -> bb4;
+  }
+  bb4 {
+    %32 = ConstantLoad <nil>
+    %33 = %32;
+    %31 = < %33 a;
+    %34 = %31;
+    %35 = println(%34) -> bb5;
+  }
+  bb5 {
+    %36 = ConstantLoad 1
+    %37 = ConstantLoad 1
+    %38 = newArray [int...][%37]{%36}
+    %39 = ConstantLoad 1
+    %40 = newArray [nil|[int...]...][%39]{%38}
+    b = %40;
+    %43 = ConstantLoad <nil>
+    %44 = %43;
+    %42 = < b %44;
+    %45 = %42;
+    %46 = println(%45) -> bb6;
+  }
+  bb6 {
+    %48 = ConstantLoad <nil>
+    %49 = %48;
+    %47 = < %49 b;
+    %50 = %47;
+    %51 = println(%50) -> bb7;
+  }
+  bb7 {
+    %52 = ConstantLoad <nil>
+    %53 = ConstantLoad 1
+    %54 = newArray [nil|[int...]...][%53]{%52}
+    c = %54;
+    %56 = < b c;
+    %57 = %56;
+    %58 = println(%57) -> bb8;
+  }
+  bb8 {
+    %59 = ConstantLoad 1
+    %60 = ConstantLoad 1
+    %61 = newArray [nil|int...][%60]{%59}
+    d = %61;
+    %64 = ConstantLoad <nil>
+    %65 = %64;
+    %63 = < d %65;
+    %66 = %63;
+    %67 = println(%66) -> bb9;
+  }
+  bb9 {
+    %68 = ConstantLoad <nil>
+    %69 = ConstantLoad 1
+    %70 = newArray [nil|int...][%69]{%68}
+    e = %70;
+    %72 = < d e;
+    %73 = %72;
+    %74 = println(%73) -> bb10;
+  }
+  bb10 {
+    %75 = < e d;
+    %76 = %75;
+    %77 = println(%76) -> bb11;
+  }
+  bb11 {
+    %78 = ConstantLoad 1
+    %79 = ConstantLoad 2
+    %80 = ConstantLoad 3
+    %81 = ConstantLoad 3
+    %82 = newArray [int...][%81]{%78, %79, %80}
+    f = %82;
+    %84 = ConstantLoad <nil>
+    %85 = ConstantLoad <nil>
+    %86 = ConstantLoad <nil>
+    %87 = ConstantLoad 3
+    %88 = newArray [nil...][%87]{%84, %85, %86}
+    g = %88;
+    %90 = < f g;
+    %91 = %90;
+    %92 = println(%91) -> bb12;
+  }
+  bb12 {
+    %93 = < g f;
+    %94 = %93;
+    %95 = println(%94) -> bb13;
+  }
+  bb13 {
+    %96 = ConstantLoad 1
+    %97 = ConstantLoad 2
+    %98 = ConstantLoad 3
+    %99 = ConstantLoad 3
+    %100 = newArray [nil|int...][%99]{%96, %97, %98}
+    h = %100;
+    %102 = ConstantLoad <nil>
+    %103 = ConstantLoad <nil>
+    %104 = ConstantLoad <nil>
+    %105 = ConstantLoad <nil>
+    %106 = ConstantLoad 4
+    %107 = newArray [nil...][%106]{%102, %103, %104, %105}
+    i = %107;
+    %109 = > h i;
+    %110 = %109;
+    %111 = println(%110) -> bb14;
+  }
+  bb14 {
+    %112 = > i h;
+    %113 = %112;
+    %114 = println(%113) -> bb15;
+  }
+  bb15 {
+    %115 = < g i;
+    %116 = %115;
+    %117 = println(%116) -> bb16;
+  }
+  bb16 {
+    %118 = < i g;
+    %119 = %118;
+    %120 = println(%119) -> bb17;
+  }
+  bb17 {
+    %121 = ConstantLoad <nil>
+    %122 = ConstantLoad 1
+    %123 = newArray [nil...][%122]{%121}
+    %124 = ConstantLoad <nil>
+    %125 = ConstantLoad <nil>
+    %126 = ConstantLoad 2
+    %127 = newArray [nil...][%126]{%124, %125}
+    %128 = ConstantLoad 2
+    %129 = newArray [[nil...]...][%128]{%123, %127}
+    j = %129;
+    %131 = ConstantLoad <nil>
+    %132 = ConstantLoad 1
+    %133 = newArray [nil...][%132]{%131}
+    %134 = ConstantLoad <nil>
+    %135 = ConstantLoad <nil>
+    %136 = ConstantLoad <nil>
+    %137 = ConstantLoad 3
+    %138 = newArray [nil...][%137]{%134, %135, %136}
+    %139 = ConstantLoad 2
+    %140 = newArray [[nil...]...][%139]{%133, %138}
+    k = %140;
+    %142 = < j k;
+    %143 = %142;
+    %144 = println(%143) -> bb18;
+  }
+  bb18 {
+    %145 = < k j;
+    %146 = %145;
+    %147 = println(%146) -> bb19;
+  }
+  bb19 {
+    return;
+  }
+}

--- a/corpus/bir/08-comparable/order3-v.txt
+++ b/corpus/bir/08-comparable/order3-v.txt
@@ -1,0 +1,37 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad 0
+    %2 = newArray [int...][%1]{}
+    v1 = %2;
+    %4 = v1 is [string...]
+    %4 ? bb1 : bb4;
+  }
+  bb1 {
+    %5 = ConstantLoad 0
+    %6 = newArray [string...][%5]{}
+    j = %6;
+    %8 = < v1 j;
+    %9 = %8;
+    %10 = println(%9) -> bb2;
+  }
+  bb2 {
+    %11 = > v1 j;
+    %12 = %11;
+    %13 = println(%12) -> bb3;
+  }
+  bb3 {
+    GOTO bb6;
+  }
+  bb4 {
+    %14 = ConstantLoad else
+    %15 = println(%14) -> bb5;
+  }
+  bb5 {
+    GOTO bb6;
+  }
+  bb6 {
+    return;
+  }
+}

--- a/corpus/bir/08-comparable/order4-v.txt
+++ b/corpus/bir/08-comparable/order4-v.txt
@@ -1,0 +1,31 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad 0
+    %2 = newArray [nil...][%1]{}
+    n1 = %2;
+    %4 = ConstantLoad 0
+    %5 = newArray [[nil...]...][%4]{}
+    n2 = %5;
+    %7 = ConstantLoad 0
+    %8 = newArray [nil|[nil...]...][%7]{}
+    n3 = %8;
+    %10 = < n1 n2;
+    %11 = %10;
+    %12 = println(%11) -> bb1;
+  }
+  bb1 {
+    %13 = < n3 n2;
+    %14 = %13;
+    %15 = println(%14) -> bb2;
+  }
+  bb2 {
+    %16 = < n1 n3;
+    %17 = %16;
+    %18 = println(%17) -> bb3;
+  }
+  bb3 {
+    return;
+  }
+}

--- a/corpus/bir/08-comparable/order5-v.txt
+++ b/corpus/bir/08-comparable/order5-v.txt
@@ -1,0 +1,115 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad true
+    %2 = ConstantLoad 1
+    %3 = newArray [boolean...][%2]{%1}
+    %4 = ConstantLoad 1
+    %5 = newArray [[boolean...]...][%4]{%3}
+    b1 = %5;
+    %7 = ConstantLoad true
+    %8 = ConstantLoad 1
+    %9 = newArray [boolean...][%8]{%7}
+    %10 = ConstantLoad 0
+    %11 = newArray [boolean...][%10]{}
+    %12 = ConstantLoad 2
+    %13 = newArray [[boolean...]...][%12]{%9, %11}
+    b2 = %13;
+    %15 = ConstantLoad true
+    %16 = ConstantLoad 1
+    %17 = newArray [boolean...][%16]{%15}
+    %18 = ConstantLoad <nil>
+    %19 = ConstantLoad 2
+    %20 = newArray [nil|[boolean...]...][%19]{%17, %18}
+    b3 = %20;
+    %22 = < b1 b2;
+    %23 = %22;
+    %24 = println(%23) -> bb1;
+  }
+  bb1 {
+    %25 = < b2 b3;
+    %26 = %25;
+    %27 = println(%26) -> bb2;
+  }
+  bb2 {
+    %28 = > b2 b3;
+    %29 = %28;
+    %30 = println(%29) -> bb3;
+  }
+  bb3 {
+    %31 = > b3 b1;
+    %32 = %31;
+    %33 = println(%32) -> bb4;
+  }
+  bb4 {
+    %34 = ConstantLoad a
+    %35 = ConstantLoad 1
+    %36 = newArray [string...][%35]{%34}
+    %37 = ConstantLoad 1
+    %38 = newArray [[string...]...][%37]{%36}
+    s1 = %38;
+    %40 = ConstantLoad a
+    %41 = ConstantLoad 1
+    %42 = newArray [string...][%41]{%40}
+    %43 = ConstantLoad 0
+    %44 = newArray [string...][%43]{}
+    %45 = ConstantLoad 2
+    %46 = newArray [[string...]...][%45]{%42, %44}
+    s2 = %46;
+    %48 = ConstantLoad a
+    %49 = ConstantLoad 1
+    %50 = newArray [string...][%49]{%48}
+    %51 = ConstantLoad <nil>
+    %52 = ConstantLoad 2
+    %53 = newArray [nil|[string...]...][%52]{%50, %51}
+    s3 = %53;
+    %55 = > s2 s1;
+    %56 = %55;
+    %57 = println(%56) -> bb5;
+  }
+  bb5 {
+    %58 = < s2 s3;
+    %59 = %58;
+    %60 = println(%59) -> bb6;
+  }
+  bb6 {
+    %61 = > s2 s3;
+    %62 = %61;
+    %63 = println(%62) -> bb7;
+  }
+  bb7 {
+    %64 = < s1 s3;
+    %65 = %64;
+    %66 = println(%65) -> bb8;
+  }
+  bb8 {
+    %67 = ConstantLoad 80
+    %68 = ConstantLoad 1
+    %69 = newArray [float...][%68]{%67}
+    %70 = ConstantLoad 1
+    %71 = newArray [[float...]...][%70]{%69}
+    f1 = %71;
+    %74 = ConstantLoad 0
+    %75 = %74;
+    %76 = ConstantLoad 0
+    %77 = %76;
+    %73 = / %75 %77;
+    %78 = ConstantLoad 1
+    %79 = newArray [float...][%78]{%73}
+    %80 = ConstantLoad 1
+    %81 = newArray [[float...]...][%80]{%79}
+    f2 = %81;
+    %83 = > f1 f2;
+    %84 = %83;
+    %85 = println(%84) -> bb9;
+  }
+  bb9 {
+    %86 = > f2 f2;
+    %87 = %86;
+    %88 = println(%87) -> bb10;
+  }
+  bb10 {
+    return;
+  }
+}

--- a/corpus/bir/08-comparable/relational4-v.txt
+++ b/corpus/bir/08-comparable/relational4-v.txt
@@ -1,0 +1,69 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad 3/2
+    %2 = ConstantLoad 1
+    %3 = newArray [decimal...][%2]{%1}
+    x = %3;
+    %5 = ConstantLoad 3/1
+    %6 = ConstantLoad 1
+    %7 = newArray [decimal...][%6]{%5}
+    y = %7;
+    %9 = ConstantLoad 3/1
+    %10 = ConstantLoad 1
+    %11 = newArray [decimal...][%10]{%9}
+    z = %11;
+    %13 = ConstantLoad 1/1
+    %14 = ConstantLoad 5/2
+    %15 = ConstantLoad 2
+    %16 = newArray [decimal...][%15]{%13, %14}
+    a1 = %16;
+    %18 = ConstantLoad 2/1
+    %19 = ConstantLoad 3/1
+    %20 = ConstantLoad 2
+    %21 = newArray [decimal...][%20]{%18, %19}
+    a2 = %21;
+    %23 = < x y;
+    %24 = %23;
+    %25 = println(%24) -> bb1;
+  }
+  bb1 {
+    %26 = > x y;
+    %27 = %26;
+    %28 = println(%27) -> bb2;
+  }
+  bb2 {
+    %29 = <= y x;
+    %30 = %29;
+    %31 = println(%30) -> bb3;
+  }
+  bb3 {
+    %32 = >= y x;
+    %33 = %32;
+    %34 = println(%33) -> bb4;
+  }
+  bb4 {
+    %35 = >= y z;
+    %36 = %35;
+    %37 = println(%36) -> bb5;
+  }
+  bb5 {
+    %38 = <= y z;
+    %39 = %38;
+    %40 = println(%39) -> bb6;
+  }
+  bb6 {
+    %41 = < a1 a2;
+    %42 = %41;
+    %43 = println(%42) -> bb7;
+  }
+  bb7 {
+    %44 = >= a1 a2;
+    %45 = %44;
+    %46 = println(%45) -> bb8;
+  }
+  bb8 {
+    return;
+  }
+}

--- a/corpus/bir/08-comparable/relational5-v.txt
+++ b/corpus/bir/08-comparable/relational5-v.txt
@@ -1,0 +1,71 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad 1/1
+    d1 = %1;
+    %3 = ConstantLoad 2/1
+    d2 = %3;
+    %5 = ConstantLoad 3/1
+    d3 = %5;
+    %7 = ConstantLoad 3/2
+    d15 = %7;
+    %9 = ConstantLoad 1
+    %10 = newArray [decimal...][%9]{d15}
+    x = %10;
+    %12 = ConstantLoad 1
+    %13 = newArray [decimal...][%12]{d3}
+    y = %13;
+    %15 = ConstantLoad 3/1
+    %16 = ConstantLoad 1
+    %17 = newArray [decimal...][%16]{%15}
+    z = %17;
+    %19 = ConstantLoad 2
+    %20 = newArray [decimal...][%19]{d1, d2}
+    a1 = %20;
+    %22 = ConstantLoad 2
+    %23 = newArray [decimal...][%22]{d2, d3}
+    a2 = %23;
+    %25 = < x y;
+    %26 = %25;
+    %27 = println(%26) -> bb1;
+  }
+  bb1 {
+    %28 = > x y;
+    %29 = %28;
+    %30 = println(%29) -> bb2;
+  }
+  bb2 {
+    %31 = <= y x;
+    %32 = %31;
+    %33 = println(%32) -> bb3;
+  }
+  bb3 {
+    %34 = >= y x;
+    %35 = %34;
+    %36 = println(%35) -> bb4;
+  }
+  bb4 {
+    %37 = >= y z;
+    %38 = %37;
+    %39 = println(%38) -> bb5;
+  }
+  bb5 {
+    %40 = <= y z;
+    %41 = %40;
+    %42 = println(%41) -> bb6;
+  }
+  bb6 {
+    %43 = < a1 a2;
+    %44 = %43;
+    %45 = println(%44) -> bb7;
+  }
+  bb7 {
+    %46 = >= a1 a2;
+    %47 = %46;
+    %48 = println(%47) -> bb8;
+  }
+  bb8 {
+    return;
+  }
+}

--- a/corpus/bir/08-comparable/stringsubtypecompare-v.txt
+++ b/corpus/bir/08-comparable/stringsubtypecompare-v.txt
@@ -1,0 +1,57 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad a
+    %2 = ConstantLoad aa
+    %3 = ConstantLoad 2
+    %4 = newArray ["a"|"aa"...][%3]{%1, %2}
+    a = %4;
+    %6 = ConstantLoad b
+    %7 = ConstantLoad bb
+    %8 = ConstantLoad 2
+    %9 = newArray [string...][%8]{%6, %7}
+    b = %9;
+    %11 = < a b;
+    %12 = %11;
+    %13 = println(%12) -> bb1;
+  }
+  bb1 {
+    %14 = <= a b;
+    %15 = %14;
+    %16 = println(%15) -> bb2;
+  }
+  bb2 {
+    %17 = > a b;
+    %18 = %17;
+    %19 = println(%18) -> bb3;
+  }
+  bb3 {
+    %20 = >= a b;
+    %21 = %20;
+    %22 = println(%21) -> bb4;
+  }
+  bb4 {
+    %23 = < b a;
+    %24 = %23;
+    %25 = println(%24) -> bb5;
+  }
+  bb5 {
+    %26 = <= b a;
+    %27 = %26;
+    %28 = println(%27) -> bb6;
+  }
+  bb6 {
+    %29 = > b a;
+    %30 = %29;
+    %31 = println(%30) -> bb7;
+  }
+  bb7 {
+    %32 = >= b a;
+    %33 = %32;
+    %34 = println(%33) -> bb8;
+  }
+  bb8 {
+    return;
+  }
+}

--- a/corpus/cfg/08-comparable/5-v.txt
+++ b/corpus/cfg/08-comparable/5-v.txt
@@ -1,0 +1,49 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable a (type
+        (value-type any)) (expr
+        (binary-expr <
+          (list-constructor-expr
+            (literal 1)
+            (literal 2))
+          (list-constructor-expr
+            (literal 3)
+            (literal 1))))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref a))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (list-constructor-expr
+            (literal 1)
+            (literal 2))
+          (list-constructor-expr
+            (literal 1)
+            (literal 2))))))
+    (var-def
+      (variable b (type
+        (value-type boolean)) (expr
+        (binary-expr >
+          (list-constructor-expr
+            (literal 1)
+            (literal 2))
+          (list-constructor-expr
+            (literal 3))))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref b))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (list-constructor-expr
+            (literal 10)
+            (unary-expr -
+              (literal 1))
+            (unary-expr -
+              (literal 1)))
+          (list-constructor-expr
+            (literal 0))))))
+  )
+)

--- a/corpus/cfg/08-comparable/arr1-v.txt
+++ b/corpus/cfg/08-comparable/arr1-v.txt
@@ -1,0 +1,132 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable a (type
+        (array-type
+          (value-type int) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal 1)
+          (literal 2)
+          (literal 3)))))
+    (var-def
+      (variable b (type
+        (array-type
+          (union-type
+            (value-type int)
+            (value-type null)) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal 1)
+          (literal <nil>)
+          (literal 3)))))
+    (var-def
+      (variable c (type
+        (array-type
+          (union-type
+            (value-type int)
+            (value-type null)) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal 1)
+          (literal <nil>)
+          (literal 4)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref b)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref b)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref b)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref b)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref b)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref b)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref b)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref b)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref c)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref c)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref c)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref c)
+          (simple-var-ref b)))))
+  )
+)

--- a/corpus/cfg/08-comparable/arr2-v.txt
+++ b/corpus/cfg/08-comparable/arr2-v.txt
@@ -1,0 +1,132 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable a (type
+        (array-type
+          (value-type float) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal 0.1)
+          (literal 2)
+          (literal 3.5)))))
+    (var-def
+      (variable b (type
+        (array-type
+          (union-type
+            (value-type float)
+            (value-type null)) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal 0.1)
+          (literal <nil>)
+          (literal 3.5)))))
+    (var-def
+      (variable c (type
+        (array-type
+          (union-type
+            (value-type float)
+            (value-type null)) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal 0.1)
+          (literal <nil>)
+          (literal 4.7)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref b)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref b)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref b)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref b)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref b)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref b)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref b)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref b)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref c)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref c)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref c)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref c)
+          (simple-var-ref b)))))
+  )
+)

--- a/corpus/cfg/08-comparable/arr3-v.txt
+++ b/corpus/cfg/08-comparable/arr3-v.txt
@@ -1,0 +1,132 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable a (type
+        (array-type
+          (value-type string) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal abc)
+          (literal abd)
+          (literal abcd)))))
+    (var-def
+      (variable b (type
+        (array-type
+          (union-type
+            (value-type string)
+            (value-type null)) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal abc)
+          (literal <nil>)
+          (literal abcd)))))
+    (var-def
+      (variable c (type
+        (array-type
+          (union-type
+            (value-type string)
+            (value-type null)) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal abc)
+          (literal <nil>)
+          (literal xyz)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref b)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref b)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref b)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref b)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref b)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref b)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref b)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref b)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref c)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref c)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref c)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref c)
+          (simple-var-ref b)))))
+  )
+)

--- a/corpus/cfg/08-comparable/arr4-v.txt
+++ b/corpus/cfg/08-comparable/arr4-v.txt
@@ -1,0 +1,132 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable a (type
+        (array-type
+          (value-type boolean) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal false)
+          (literal true)
+          (literal false)))))
+    (var-def
+      (variable b (type
+        (array-type
+          (union-type
+            (value-type boolean)
+            (value-type null)) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal false)
+          (literal <nil>)
+          (literal false)))))
+    (var-def
+      (variable c (type
+        (array-type
+          (union-type
+            (value-type boolean)
+            (value-type null)) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal false)
+          (literal <nil>)
+          (literal true)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref b)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref b)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref b)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref b)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref b)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref b)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref b)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref b)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref c)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref c)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref c)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref c)
+          (simple-var-ref b)))))
+  )
+)

--- a/corpus/cfg/08-comparable/booleansubtypecompare-v.txt
+++ b/corpus/cfg/08-comparable/booleansubtypecompare-v.txt
@@ -1,0 +1,58 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable a (type
+        (array-type
+          (user-defined-type A) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal false)
+          (literal false)))))
+    (var-def
+      (variable b (type
+        (array-type
+          (value-type boolean) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal true)
+          (literal true)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+  )
+)

--- a/corpus/cfg/08-comparable/comp1-v.txt
+++ b/corpus/cfg/08-comparable/comp1-v.txt
@@ -1,0 +1,102 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable a (type
+        (user-defined-type INTSTR)) (expr
+        (list-constructor-expr
+          (literal 0)
+          (literal b)))))
+    (var-def
+      (variable b (type
+        (user-defined-type INTSTR)) (expr
+        (list-constructor-expr
+          (literal 1)
+          (literal a)))))
+    (var-def
+      (variable c (type
+        (user-defined-type INTSTR)) (expr
+        (list-constructor-expr
+          (literal 0)
+          (literal a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref a)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref a)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref a)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref a)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref c)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref c)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref c)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref c)
+          (simple-var-ref a)))))
+  )
+)

--- a/corpus/cfg/08-comparable/comp10-v.txt
+++ b/corpus/cfg/08-comparable/comp10-v.txt
@@ -1,0 +1,56 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable a (type
+        (user-defined-type A)) (expr
+        (list-constructor-expr
+          (literal 0)
+          (literal 500)))))
+    (var-def
+      (variable b (type
+        (user-defined-type B)) (expr
+        (list-constructor-expr
+          (literal 0)
+          (literal 5)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+  )
+)

--- a/corpus/cfg/08-comparable/comp11-v.txt
+++ b/corpus/cfg/08-comparable/comp11-v.txt
@@ -1,0 +1,105 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable a (type
+        (user-defined-type A)) (expr
+        (list-constructor-expr
+          (literal 1)
+          (literal 6.4)
+          (literal 100/1)
+          (literal 10)
+          (literal 11)))))
+    (var-def
+      (variable b (type
+        (user-defined-type B)) (expr
+        (list-constructor-expr
+          (literal 5)))))
+    (var-def
+      (variable c (type
+        (user-defined-type C)) (expr
+        (list-constructor-expr
+          (literal 0)
+          (literal 4)
+          (literal 10)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref b)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref b)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref b)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref b)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref c)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref c)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref c)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref c)
+          (simple-var-ref b)))))
+  )
+)

--- a/corpus/cfg/08-comparable/comp2-v.txt
+++ b/corpus/cfg/08-comparable/comp2-v.txt
@@ -1,0 +1,105 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable a (type
+        (user-defined-type T)) (expr
+        (list-constructor-expr
+          (literal 0)
+          (literal 1)
+          (literal 2)))))
+    (var-def
+      (variable b (type
+        (user-defined-type T)) (expr
+        (list-constructor-expr
+          (literal 1)
+          (literal 0)
+          (literal 3)))))
+    (var-def
+      (variable c (type
+        (user-defined-type T)) (expr
+        (list-constructor-expr
+          (literal 0)
+          (literal 1)
+          (literal 0)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref a)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref a)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref a)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref a)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref c)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref c)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref c)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref c)
+          (simple-var-ref a)))))
+  )
+)

--- a/corpus/cfg/08-comparable/comp3-v.txt
+++ b/corpus/cfg/08-comparable/comp3-v.txt
@@ -1,0 +1,101 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable a (type
+        (user-defined-type T1)) (expr
+        (list-constructor-expr
+          (literal 0)
+          (literal 5)))))
+    (var-def
+      (variable b (type
+        (user-defined-type T2)) (expr
+        (list-constructor-expr
+          (literal 2)))))
+    (var-def
+      (variable c (type
+        (user-defined-type T2)) (expr
+        (list-constructor-expr
+          (unary-expr -
+            (literal 1))))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref a)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref a)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref a)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref a)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref c)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref c)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref c)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref c)
+          (simple-var-ref a)))))
+  )
+)

--- a/corpus/cfg/08-comparable/comp5-v.txt
+++ b/corpus/cfg/08-comparable/comp5-v.txt
@@ -1,0 +1,66 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable arr1 (type
+        (user-defined-type A)) (expr
+        (list-constructor-expr
+          (literal 5)
+          (list-constructor-expr
+            (literal 1)
+            (literal 2))))))
+    (var-def
+      (variable arr2 (type
+        (user-defined-type A)) (expr
+        (list-constructor-expr
+          (literal 5)
+          (list-constructor-expr
+            (literal 0)
+            (literal 2))))))
+    (var-def
+      (variable arr3 (type
+        (user-defined-type A)) (expr
+        (list-constructor-expr
+          (literal 5)
+          (list-constructor-expr
+            (literal 2)
+            (literal 2))))))
+    (var-def
+      (variable arr4 (type
+        (user-defined-type A)) (expr
+        (list-constructor-expr
+          (literal 3)
+          (list-constructor-expr
+            (literal 1)
+            (literal 2))))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref arr1)
+          (simple-var-ref arr2)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref arr1)
+          (simple-var-ref arr3)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref arr1)
+          (simple-var-ref arr4)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref arr1)
+          (simple-var-ref arr2)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref arr1)
+          (simple-var-ref arr3)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref arr1)
+          (simple-var-ref arr4)))))
+  )
+)

--- a/corpus/cfg/08-comparable/comp7-v.txt
+++ b/corpus/cfg/08-comparable/comp7-v.txt
@@ -1,0 +1,108 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable a (type
+        (user-defined-type T1)) (expr
+        (list-constructor-expr
+          (literal 0)
+          (literal 5)
+          (literal 1)))))
+    (var-def
+      (variable b (type
+        (user-defined-type T2)) (expr
+        (list-constructor-expr
+          (literal 0)
+          (literal 5)
+          (literal 1)
+          (literal 2)))))
+    (var-def
+      (variable c (type
+        (user-defined-type T2)) (expr
+        (list-constructor-expr
+          (literal 0)
+          (literal 5)
+          (literal 1)
+          (unary-expr -
+            (literal 1))))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref a)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref a)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref a)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref a)
+          (simple-var-ref c)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref c)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref c)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref c)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref c)
+          (simple-var-ref a)))))
+  )
+)

--- a/corpus/cfg/08-comparable/floatsubtypecompare-v.txt
+++ b/corpus/cfg/08-comparable/floatsubtypecompare-v.txt
@@ -1,0 +1,60 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable a (type
+        (array-type
+          (user-defined-type A) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal 1)
+          (literal 2)
+          (literal 3)))))
+    (var-def
+      (variable b (type
+        (array-type
+          (value-type float) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal 4)
+          (literal 5)
+          (literal 6)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+  )
+)

--- a/corpus/cfg/08-comparable/intsubtypecompare-v.txt
+++ b/corpus/cfg/08-comparable/intsubtypecompare-v.txt
@@ -1,0 +1,30 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable a (type
+        (array-type
+          (user-defined-type A) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal 1)
+          (literal 2)
+          (literal 3)))))
+    (var-def
+      (variable b (type
+        (array-type
+          (value-type int) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal 4)
+          (literal 5)
+          (literal 6)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+  )
+)

--- a/corpus/cfg/08-comparable/order1-v.txt
+++ b/corpus/cfg/08-comparable/order1-v.txt
@@ -1,0 +1,100 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable a (type
+        (array-type
+          (value-type int) dimensions: 2 ([][]))) (expr
+        (list-constructor-expr
+          (list-constructor-expr
+            (literal 1))
+          (list-constructor-expr
+            (literal 2))))))
+    (var-def
+      (variable b (type
+        (array-type
+          (value-type int) dimensions: 2 ([][]))) (expr
+        (list-constructor-expr
+          (list-constructor-expr
+            (literal 1))
+          (list-constructor-expr
+            (literal 3))))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (var-def
+      (variable c (type
+        (array-type
+          (union-type
+            (array-type
+              (value-type int) dimensions: 1 ([]))
+            (value-type null)) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (list-constructor-expr
+            (literal 0))
+          (list-constructor-expr
+            (unary-expr -
+              (literal 1)))))))
+    (var-def
+      (variable d (type
+        (array-type
+          (value-type int) dimensions: 2 ([][]))) (expr
+        (list-constructor-expr
+          (list-constructor-expr
+            (literal 0))
+          (list-constructor-expr
+            (unary-expr -
+              (literal 2)))))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref c)
+          (simple-var-ref d)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref c)
+          (simple-var-ref d)))))
+    (var-def
+      (variable e (type
+        (array-type
+          (union-type
+            (array-type
+              (value-type int) dimensions: 1 ([]))
+            (value-type null)) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal <nil>)
+          (list-constructor-expr
+            (literal 1))))))
+    (var-def
+      (variable f (type
+        (array-type
+          (value-type int) dimensions: 2 ([][]))) (expr
+        (list-constructor-expr
+          (list-constructor-expr
+            (literal 0))
+          (list-constructor-expr
+            (literal 1))))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr ==
+          (simple-var-ref e)
+          (simple-var-ref f)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref e)
+          (simple-var-ref f)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref e)
+          (simple-var-ref f)))))
+  )
+)

--- a/corpus/cfg/08-comparable/order2-v.txt
+++ b/corpus/cfg/08-comparable/order2-v.txt
@@ -1,0 +1,198 @@
+(main
+  (bb0 () ()
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (literal 1)
+          (literal <nil>)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (literal <nil>)
+          (literal <nil>)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (literal <nil>)
+          (literal <nil>)))))
+    (var-def
+      (variable a (type
+        (union-type
+          (array-type
+            (value-type int) dimensions: 1 ([]))
+          (value-type null))) (expr
+        (list-constructor-expr
+          (literal 1)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref a)
+          (literal <nil>)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (literal <nil>)
+          (simple-var-ref a)))))
+    (var-def
+      (variable b (type
+        (array-type
+          (union-type
+            (array-type
+              (value-type int) dimensions: 1 ([]))
+            (value-type null)) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (list-constructor-expr
+            (literal 1))))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref b)
+          (literal <nil>)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (literal <nil>)
+          (simple-var-ref b)))))
+    (var-def
+      (variable c (type
+        (array-type
+          (union-type
+            (array-type
+              (value-type int) dimensions: 1 ([]))
+            (value-type null)) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal <nil>)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref b)
+          (simple-var-ref c)))))
+    (var-def
+      (variable d (type
+        (array-type
+          (union-type
+            (value-type int)
+            (value-type null)) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal 1)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref d)
+          (literal <nil>)))))
+    (var-def
+      (variable e (type
+        (array-type
+          (union-type
+            (value-type int)
+            (value-type null)) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal <nil>)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref d)
+          (simple-var-ref e)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref e)
+          (simple-var-ref d)))))
+    (var-def
+      (variable f (type
+        (array-type
+          (value-type int) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal 1)
+          (literal 2)
+          (literal 3)))))
+    (var-def
+      (variable g (type
+        (array-type
+          (value-type null) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal <nil>)
+          (literal <nil>)
+          (literal <nil>)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref f)
+          (simple-var-ref g)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref g)
+          (simple-var-ref f)))))
+    (var-def
+      (variable h (type
+        (array-type
+          (union-type
+            (value-type int)
+            (value-type null)) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal 1)
+          (literal 2)
+          (literal 3)))))
+    (var-def
+      (variable i (type
+        (array-type
+          (value-type null) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal <nil>)
+          (literal <nil>)
+          (literal <nil>)
+          (literal <nil>)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref h)
+          (simple-var-ref i)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref i)
+          (simple-var-ref h)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref g)
+          (simple-var-ref i)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref i)
+          (simple-var-ref g)))))
+    (var-def
+      (variable j (type
+        (array-type
+          (value-type null) dimensions: 2 ([][]))) (expr
+        (list-constructor-expr
+          (list-constructor-expr
+            (literal <nil>))
+          (list-constructor-expr
+            (literal <nil>)
+            (literal <nil>))))))
+    (var-def
+      (variable k (type
+        (array-type
+          (value-type null) dimensions: 2 ([][]))) (expr
+        (list-constructor-expr
+          (list-constructor-expr
+            (literal <nil>))
+          (list-constructor-expr
+            (literal <nil>)
+            (literal <nil>)
+            (literal <nil>))))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref j)
+          (simple-var-ref k)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref k)
+          (simple-var-ref j)))))
+  )
+)

--- a/corpus/cfg/08-comparable/order3-v.txt
+++ b/corpus/cfg/08-comparable/order3-v.txt
@@ -1,0 +1,36 @@
+(main
+  (bb0 () (bb1 bb3)
+    (var-def
+      (variable v1 (type
+        (array-type
+          (value-type int) dimensions: 1 ([]))) (expr
+        (list-constructor-expr))))
+    (type-test-expr is
+      (simple-var-ref v1)
+      (array-type
+        (value-type string) dimensions: 1 ([])))
+  )
+  (bb1 (bb0) (bb2)
+    (var-def
+      (variable j (type
+        (array-type
+          (value-type string) dimensions: 1 ([]))) (expr
+        (list-constructor-expr))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref v1)
+          (simple-var-ref j)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref v1)
+          (simple-var-ref j)))))
+  )
+  (bb2 (bb1 bb3) ())
+  (bb3 (bb0) (bb2)
+    (expression-stmt
+      (invocation io println (
+        (literal else))))
+  )
+)

--- a/corpus/cfg/08-comparable/order4-v.txt
+++ b/corpus/cfg/08-comparable/order4-v.txt
@@ -1,0 +1,37 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable n1 (type
+        (array-type
+          (value-type null) dimensions: 1 ([]))) (expr
+        (list-constructor-expr))))
+    (var-def
+      (variable n2 (type
+        (array-type
+          (value-type null) dimensions: 2 ([][]))) (expr
+        (list-constructor-expr))))
+    (var-def
+      (variable n3 (type
+        (array-type
+          (union-type
+            (array-type
+              (value-type null) dimensions: 1 ([]))
+            (value-type null)) dimensions: 1 ([]))) (expr
+        (list-constructor-expr))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref n1)
+          (simple-var-ref n2)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref n3)
+          (simple-var-ref n2)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref n1)
+          (simple-var-ref n3)))))
+  )
+)

--- a/corpus/cfg/08-comparable/order5-v.txt
+++ b/corpus/cfg/08-comparable/order5-v.txt
@@ -1,0 +1,122 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable b1 (type
+        (array-type
+          (value-type boolean) dimensions: 2 ([][]))) (expr
+        (list-constructor-expr
+          (list-constructor-expr
+            (literal true))))))
+    (var-def
+      (variable b2 (type
+        (array-type
+          (value-type boolean) dimensions: 2 ([][]))) (expr
+        (list-constructor-expr
+          (list-constructor-expr
+            (literal true))
+          (list-constructor-expr)))))
+    (var-def
+      (variable b3 (type
+        (array-type
+          (union-type
+            (array-type
+              (value-type boolean) dimensions: 1 ([]))
+            (value-type null)) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (list-constructor-expr
+            (literal true))
+          (literal <nil>)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref b1)
+          (simple-var-ref b2)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref b2)
+          (simple-var-ref b3)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref b2)
+          (simple-var-ref b3)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref b3)
+          (simple-var-ref b1)))))
+    (var-def
+      (variable s1 (type
+        (array-type
+          (value-type string) dimensions: 2 ([][]))) (expr
+        (list-constructor-expr
+          (list-constructor-expr
+            (literal a))))))
+    (var-def
+      (variable s2 (type
+        (array-type
+          (value-type string) dimensions: 2 ([][]))) (expr
+        (list-constructor-expr
+          (list-constructor-expr
+            (literal a))
+          (list-constructor-expr)))))
+    (var-def
+      (variable s3 (type
+        (array-type
+          (union-type
+            (array-type
+              (value-type string) dimensions: 1 ([]))
+            (value-type null)) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (list-constructor-expr
+            (literal a))
+          (literal <nil>)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref s2)
+          (simple-var-ref s1)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref s2)
+          (simple-var-ref s3)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref s2)
+          (simple-var-ref s3)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref s1)
+          (simple-var-ref s3)))))
+    (var-def
+      (variable f1 (type
+        (array-type
+          (value-type float) dimensions: 2 ([][]))) (expr
+        (list-constructor-expr
+          (list-constructor-expr
+            (literal 80))))))
+    (var-def
+      (variable f2 (type
+        (array-type
+          (value-type float) dimensions: 2 ([][]))) (expr
+        (list-constructor-expr
+          (list-constructor-expr
+            (binary-expr /
+              (literal 0)
+              (literal 0)))))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref f1)
+          (simple-var-ref f2)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref f2)
+          (simple-var-ref f2)))))
+  )
+)

--- a/corpus/cfg/08-comparable/relational4-v.txt
+++ b/corpus/cfg/08-comparable/relational4-v.txt
@@ -1,0 +1,76 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable x (type
+        (array-type
+          (value-type decimal) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal 3/2)))))
+    (var-def
+      (variable y (type
+        (array-type
+          (value-type decimal) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal 3/1)))))
+    (var-def
+      (variable z (type
+        (array-type
+          (value-type decimal) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal 3/1)))))
+    (var-def
+      (variable a1 (type
+        (array-type
+          (value-type decimal) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal 1/1)
+          (literal 5/2)))))
+    (var-def
+      (variable a2 (type
+        (array-type
+          (value-type decimal) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal 2/1)
+          (literal 3/1)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref x)
+          (simple-var-ref y)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref x)
+          (simple-var-ref y)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref y)
+          (simple-var-ref x)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref y)
+          (simple-var-ref x)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref y)
+          (simple-var-ref z)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref y)
+          (simple-var-ref z)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref a1)
+          (simple-var-ref a2)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref a1)
+          (simple-var-ref a2)))))
+  )
+)

--- a/corpus/cfg/08-comparable/relational5-v.txt
+++ b/corpus/cfg/08-comparable/relational5-v.txt
@@ -1,0 +1,92 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable d1 (type
+        (value-type decimal)) (expr
+        (literal 1/1))))
+    (var-def
+      (variable d2 (type
+        (value-type decimal)) (expr
+        (literal 2/1))))
+    (var-def
+      (variable d3 (type
+        (value-type decimal)) (expr
+        (literal 3/1))))
+    (var-def
+      (variable d15 (type
+        (value-type decimal)) (expr
+        (literal 3/2))))
+    (var-def
+      (variable x (type
+        (array-type
+          (value-type decimal) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (simple-var-ref d15)))))
+    (var-def
+      (variable y (type
+        (array-type
+          (value-type decimal) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (simple-var-ref d3)))))
+    (var-def
+      (variable z (type
+        (array-type
+          (value-type decimal) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal 3/1)))))
+    (var-def
+      (variable a1 (type
+        (array-type
+          (value-type decimal) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (simple-var-ref d1)
+          (simple-var-ref d2)))))
+    (var-def
+      (variable a2 (type
+        (array-type
+          (value-type decimal) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (simple-var-ref d2)
+          (simple-var-ref d3)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref x)
+          (simple-var-ref y)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref x)
+          (simple-var-ref y)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref y)
+          (simple-var-ref x)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref y)
+          (simple-var-ref x)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref y)
+          (simple-var-ref z)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref y)
+          (simple-var-ref z)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref a1)
+          (simple-var-ref a2)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref a1)
+          (simple-var-ref a2)))))
+  )
+)

--- a/corpus/cfg/08-comparable/stringsubtypecompare-v.txt
+++ b/corpus/cfg/08-comparable/stringsubtypecompare-v.txt
@@ -1,0 +1,58 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable a (type
+        (array-type
+          (user-defined-type A) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal a)
+          (literal aa)))))
+    (var-def
+      (variable b (type
+        (array-type
+          (value-type string) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal b)
+          (literal bb)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref a)
+          (simple-var-ref b)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr <=
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr >=
+          (simple-var-ref b)
+          (simple-var-ref a)))))
+  )
+)

--- a/corpus/desugared/08-comparable/5-v.txt
+++ b/corpus/desugared/08-comparable/5-v.txt
@@ -1,0 +1,50 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (value-type any)) (expr
+          (binary-expr <
+            (list-constructor-expr
+              (literal 1)
+              (literal 2))
+            (list-constructor-expr
+              (literal 3)
+              (literal 1))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref a))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (list-constructor-expr
+              (literal 1)
+              (literal 2))
+            (list-constructor-expr
+              (literal 1)
+              (literal 2))))))
+      (var-def
+        (variable b (type
+          (value-type boolean)) (expr
+          (binary-expr >
+            (list-constructor-expr
+              (literal 1)
+              (literal 2))
+            (list-constructor-expr
+              (literal 3))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref b))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (list-constructor-expr
+              (literal 10)
+              (unary-expr -
+                (literal 1))
+              (unary-expr -
+                (literal 1)))
+            (list-constructor-expr
+              (literal 0)))))))))

--- a/corpus/desugared/08-comparable/arr1-v.txt
+++ b/corpus/desugared/08-comparable/arr1-v.txt
@@ -1,0 +1,133 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (array-type
+            (value-type int) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 1)
+            (literal 2)
+            (literal 3)))))
+      (var-def
+        (variable b (type
+          (array-type
+            (union-type
+              (value-type int)
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 1)
+            (literal <nil>)
+            (literal 3)))))
+      (var-def
+        (variable c (type
+          (array-type
+            (union-type
+              (value-type int)
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 1)
+            (literal <nil>)
+            (literal 4)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref c)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref c)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref c)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref c)
+            (simple-var-ref b))))))))

--- a/corpus/desugared/08-comparable/arr2-v.txt
+++ b/corpus/desugared/08-comparable/arr2-v.txt
@@ -1,0 +1,133 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (array-type
+            (value-type float) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 0.1)
+            (literal 2)
+            (literal 3.5)))))
+      (var-def
+        (variable b (type
+          (array-type
+            (union-type
+              (value-type float)
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 0.1)
+            (literal <nil>)
+            (literal 3.5)))))
+      (var-def
+        (variable c (type
+          (array-type
+            (union-type
+              (value-type float)
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 0.1)
+            (literal <nil>)
+            (literal 4.7)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref c)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref c)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref c)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref c)
+            (simple-var-ref b))))))))

--- a/corpus/desugared/08-comparable/arr3-v.txt
+++ b/corpus/desugared/08-comparable/arr3-v.txt
@@ -1,0 +1,133 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (array-type
+            (value-type string) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal abc)
+            (literal abd)
+            (literal abcd)))))
+      (var-def
+        (variable b (type
+          (array-type
+            (union-type
+              (value-type string)
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal abc)
+            (literal <nil>)
+            (literal abcd)))))
+      (var-def
+        (variable c (type
+          (array-type
+            (union-type
+              (value-type string)
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal abc)
+            (literal <nil>)
+            (literal xyz)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref c)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref c)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref c)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref c)
+            (simple-var-ref b))))))))

--- a/corpus/desugared/08-comparable/arr4-v.txt
+++ b/corpus/desugared/08-comparable/arr4-v.txt
@@ -1,0 +1,133 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (array-type
+            (value-type boolean) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal false)
+            (literal true)
+            (literal false)))))
+      (var-def
+        (variable b (type
+          (array-type
+            (union-type
+              (value-type boolean)
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal false)
+            (literal <nil>)
+            (literal false)))))
+      (var-def
+        (variable c (type
+          (array-type
+            (union-type
+              (value-type boolean)
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal false)
+            (literal <nil>)
+            (literal true)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref c)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref c)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref c)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref c)
+            (simple-var-ref b))))))))

--- a/corpus/desugared/08-comparable/booleansubtypecompare-v.txt
+++ b/corpus/desugared/08-comparable/booleansubtypecompare-v.txt
@@ -1,0 +1,62 @@
+(package
+  (import-package ballerina io (as io))
+  (type-definition A
+    (finite-type
+      (literal false)))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (array-type
+            (user-defined-type A) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal false)
+            (literal false)))))
+      (var-def
+        (variable b (type
+          (array-type
+            (value-type boolean) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal true)
+            (literal true)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref a))))))))

--- a/corpus/desugared/08-comparable/comp1-v.txt
+++ b/corpus/desugared/08-comparable/comp1-v.txt
@@ -1,0 +1,107 @@
+(package
+  (import-package ballerina io (as io))
+  (type-definition INTSTR
+    (tuple-type
+      (value-type int)
+      (value-type string)))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (user-defined-type INTSTR)) (expr
+          (list-constructor-expr
+            (literal 0)
+            (literal b)))))
+      (var-def
+        (variable b (type
+          (user-defined-type INTSTR)) (expr
+          (list-constructor-expr
+            (literal 1)
+            (literal a)))))
+      (var-def
+        (variable c (type
+          (user-defined-type INTSTR)) (expr
+          (list-constructor-expr
+            (literal 0)
+            (literal a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref c)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref c)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref c)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref c)
+            (simple-var-ref a))))))))

--- a/corpus/desugared/08-comparable/comp10-v.txt
+++ b/corpus/desugared/08-comparable/comp10-v.txt
@@ -1,0 +1,65 @@
+(package
+  (import-package ballerina io (as io))
+  (type-definition A
+    (tuple-type
+      (value-type int)
+      (value-type int)))
+  (type-definition B
+    (tuple-type
+      (value-type int)
+      (value-type byte)))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (user-defined-type A)) (expr
+          (list-constructor-expr
+            (literal 0)
+            (literal 500)))))
+      (var-def
+        (variable b (type
+          (user-defined-type B)) (expr
+          (list-constructor-expr
+            (literal 0)
+            (literal 5)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref a))))))))

--- a/corpus/desugared/08-comparable/comp11-v.txt
+++ b/corpus/desugared/08-comparable/comp11-v.txt
@@ -1,0 +1,119 @@
+(package
+  (import-package ballerina io (as io))
+  (type-definition A
+    (tuple-type
+      (value-type int)
+      (value-type float)
+      (value-type decimal) (rest
+        (value-type int))))
+  (type-definition B
+    (tuple-type
+      (value-type byte)))
+  (type-definition C
+    (tuple-type
+      (value-type byte) (rest
+        (value-type int))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (user-defined-type A)) (expr
+          (list-constructor-expr
+            (literal 1)
+            (literal 6.4)
+            (literal 100/1)
+            (literal 10)
+            (literal 11)))))
+      (var-def
+        (variable b (type
+          (user-defined-type B)) (expr
+          (list-constructor-expr
+            (literal 5)))))
+      (var-def
+        (variable c (type
+          (user-defined-type C)) (expr
+          (list-constructor-expr
+            (literal 0)
+            (literal 4)
+            (literal 10)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref c)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref c)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref c)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref c)
+            (simple-var-ref b))))))))

--- a/corpus/desugared/08-comparable/comp2-v.txt
+++ b/corpus/desugared/08-comparable/comp2-v.txt
@@ -1,0 +1,111 @@
+(package
+  (import-package ballerina io (as io))
+  (type-definition T
+    (tuple-type
+      (value-type int)
+      (value-type int)
+      (value-type int)))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (user-defined-type T)) (expr
+          (list-constructor-expr
+            (literal 0)
+            (literal 1)
+            (literal 2)))))
+      (var-def
+        (variable b (type
+          (user-defined-type T)) (expr
+          (list-constructor-expr
+            (literal 1)
+            (literal 0)
+            (literal 3)))))
+      (var-def
+        (variable c (type
+          (user-defined-type T)) (expr
+          (list-constructor-expr
+            (literal 0)
+            (literal 1)
+            (literal 0)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref c)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref c)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref c)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref c)
+            (simple-var-ref a))))))))

--- a/corpus/desugared/08-comparable/comp3-v.txt
+++ b/corpus/desugared/08-comparable/comp3-v.txt
@@ -1,0 +1,109 @@
+(package
+  (import-package ballerina io (as io))
+  (type-definition T1
+    (tuple-type
+      (value-type int)
+      (value-type int)))
+  (type-definition T2
+    (tuple-type
+      (value-type int)))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (user-defined-type T1)) (expr
+          (list-constructor-expr
+            (literal 0)
+            (literal 5)))))
+      (var-def
+        (variable b (type
+          (user-defined-type T2)) (expr
+          (list-constructor-expr
+            (literal 2)))))
+      (var-def
+        (variable c (type
+          (user-defined-type T2)) (expr
+          (list-constructor-expr
+            (unary-expr -
+              (literal 1))))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref c)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref c)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref c)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref c)
+            (simple-var-ref a))))))))

--- a/corpus/desugared/08-comparable/comp5-v.txt
+++ b/corpus/desugared/08-comparable/comp5-v.txt
@@ -1,0 +1,73 @@
+(package
+  (import-package ballerina io (as io))
+  (type-definition A
+    (tuple-type
+      (value-type int)
+      (tuple-type
+        (value-type int)
+        (value-type int))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable arr1 (type
+          (user-defined-type A)) (expr
+          (list-constructor-expr
+            (literal 5)
+            (list-constructor-expr
+              (literal 1)
+              (literal 2))))))
+      (var-def
+        (variable arr2 (type
+          (user-defined-type A)) (expr
+          (list-constructor-expr
+            (literal 5)
+            (list-constructor-expr
+              (literal 0)
+              (literal 2))))))
+      (var-def
+        (variable arr3 (type
+          (user-defined-type A)) (expr
+          (list-constructor-expr
+            (literal 5)
+            (list-constructor-expr
+              (literal 2)
+              (literal 2))))))
+      (var-def
+        (variable arr4 (type
+          (user-defined-type A)) (expr
+          (list-constructor-expr
+            (literal 3)
+            (list-constructor-expr
+              (literal 1)
+              (literal 2))))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref arr1)
+            (simple-var-ref arr2)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref arr1)
+            (simple-var-ref arr3)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref arr1)
+            (simple-var-ref arr4)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref arr1)
+            (simple-var-ref arr2)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref arr1)
+            (simple-var-ref arr3)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref arr1)
+            (simple-var-ref arr4))))))))

--- a/corpus/desugared/08-comparable/comp7-v.txt
+++ b/corpus/desugared/08-comparable/comp7-v.txt
@@ -1,0 +1,120 @@
+(package
+  (import-package ballerina io (as io))
+  (type-definition T1
+    (tuple-type
+      (value-type int)
+      (value-type float)
+      (value-type int)))
+  (type-definition T2
+    (tuple-type
+      (value-type int)
+      (value-type float)
+      (value-type int)
+      (value-type int)))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (user-defined-type T1)) (expr
+          (list-constructor-expr
+            (literal 0)
+            (literal 5)
+            (literal 1)))))
+      (var-def
+        (variable b (type
+          (user-defined-type T2)) (expr
+          (list-constructor-expr
+            (literal 0)
+            (literal 5)
+            (literal 1)
+            (literal 2)))))
+      (var-def
+        (variable c (type
+          (user-defined-type T2)) (expr
+          (list-constructor-expr
+            (literal 0)
+            (literal 5)
+            (literal 1)
+            (unary-expr -
+              (literal 1))))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref c)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref c)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref c)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref c)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref c)
+            (simple-var-ref a))))))))

--- a/corpus/desugared/08-comparable/floatsubtypecompare-v.txt
+++ b/corpus/desugared/08-comparable/floatsubtypecompare-v.txt
@@ -1,0 +1,70 @@
+(package
+  (import-package ballerina io (as io))
+  (type-definition A
+    (union-type
+      (union-type
+        (finite-type
+          (literal 1))
+        (finite-type
+          (literal 2)))
+      (finite-type
+        (literal 3))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (array-type
+            (user-defined-type A) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 1)
+            (literal 2)
+            (literal 3)))))
+      (var-def
+        (variable b (type
+          (array-type
+            (value-type float) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 4)
+            (literal 5)
+            (literal 6)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref a))))))))

--- a/corpus/desugared/08-comparable/intsubtypecompare-v.txt
+++ b/corpus/desugared/08-comparable/intsubtypecompare-v.txt
@@ -1,0 +1,40 @@
+(package
+  (import-package ballerina io (as io))
+  (type-definition A
+    (union-type
+      (union-type
+        (finite-type
+          (literal 1))
+        (finite-type
+          (literal 2)))
+      (finite-type
+        (literal 3))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (array-type
+            (user-defined-type A) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 1)
+            (literal 2)
+            (literal 3)))))
+      (var-def
+        (variable b (type
+          (array-type
+            (value-type int) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 4)
+            (literal 5)
+            (literal 6)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref b))))))))

--- a/corpus/desugared/08-comparable/order1-v.txt
+++ b/corpus/desugared/08-comparable/order1-v.txt
@@ -1,0 +1,101 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (array-type
+            (value-type int) dimensions: 2 ([][]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (literal 1))
+            (list-constructor-expr
+              (literal 2))))))
+      (var-def
+        (variable b (type
+          (array-type
+            (value-type int) dimensions: 2 ([][]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (literal 1))
+            (list-constructor-expr
+              (literal 3))))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (var-def
+        (variable c (type
+          (array-type
+            (union-type
+              (array-type
+                (value-type int) dimensions: 1 ([]))
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (literal 0))
+            (list-constructor-expr
+              (unary-expr -
+                (literal 1)))))))
+      (var-def
+        (variable d (type
+          (array-type
+            (value-type int) dimensions: 2 ([][]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (literal 0))
+            (list-constructor-expr
+              (unary-expr -
+                (literal 2)))))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref c)
+            (simple-var-ref d)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref c)
+            (simple-var-ref d)))))
+      (var-def
+        (variable e (type
+          (array-type
+            (union-type
+              (array-type
+                (value-type int) dimensions: 1 ([]))
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal <nil>)
+            (list-constructor-expr
+              (literal 1))))))
+      (var-def
+        (variable f (type
+          (array-type
+            (value-type int) dimensions: 2 ([][]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (literal 0))
+            (list-constructor-expr
+              (literal 1))))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr ==
+            (simple-var-ref e)
+            (simple-var-ref f)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref e)
+            (simple-var-ref f)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref e)
+            (simple-var-ref f))))))))

--- a/corpus/desugared/08-comparable/order2-v.txt
+++ b/corpus/desugared/08-comparable/order2-v.txt
@@ -1,0 +1,199 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (literal 1)
+            (literal <nil>)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (literal <nil>)
+            (literal <nil>)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (literal <nil>)
+            (literal <nil>)))))
+      (var-def
+        (variable a (type
+          (union-type
+            (array-type
+              (value-type int) dimensions: 1 ([]))
+            (value-type null))) (expr
+          (list-constructor-expr
+            (literal 1)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (literal <nil>)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (literal <nil>)
+            (simple-var-ref a)))))
+      (var-def
+        (variable b (type
+          (array-type
+            (union-type
+              (array-type
+                (value-type int) dimensions: 1 ([]))
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (literal 1))))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (literal <nil>)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (literal <nil>)
+            (simple-var-ref b)))))
+      (var-def
+        (variable c (type
+          (array-type
+            (union-type
+              (array-type
+                (value-type int) dimensions: 1 ([]))
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal <nil>)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref c)))))
+      (var-def
+        (variable d (type
+          (array-type
+            (union-type
+              (value-type int)
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 1)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref d)
+            (literal <nil>)))))
+      (var-def
+        (variable e (type
+          (array-type
+            (union-type
+              (value-type int)
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal <nil>)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref d)
+            (simple-var-ref e)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref e)
+            (simple-var-ref d)))))
+      (var-def
+        (variable f (type
+          (array-type
+            (value-type int) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 1)
+            (literal 2)
+            (literal 3)))))
+      (var-def
+        (variable g (type
+          (array-type
+            (value-type null) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal <nil>)
+            (literal <nil>)
+            (literal <nil>)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref f)
+            (simple-var-ref g)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref g)
+            (simple-var-ref f)))))
+      (var-def
+        (variable h (type
+          (array-type
+            (union-type
+              (value-type int)
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 1)
+            (literal 2)
+            (literal 3)))))
+      (var-def
+        (variable i (type
+          (array-type
+            (value-type null) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal <nil>)
+            (literal <nil>)
+            (literal <nil>)
+            (literal <nil>)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref h)
+            (simple-var-ref i)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref i)
+            (simple-var-ref h)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref g)
+            (simple-var-ref i)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref i)
+            (simple-var-ref g)))))
+      (var-def
+        (variable j (type
+          (array-type
+            (value-type null) dimensions: 2 ([][]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (literal <nil>))
+            (list-constructor-expr
+              (literal <nil>)
+              (literal <nil>))))))
+      (var-def
+        (variable k (type
+          (array-type
+            (value-type null) dimensions: 2 ([][]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (literal <nil>))
+            (list-constructor-expr
+              (literal <nil>)
+              (literal <nil>)
+              (literal <nil>))))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref j)
+            (simple-var-ref k)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref k)
+            (simple-var-ref j))))))))

--- a/corpus/desugared/08-comparable/order3-v.txt
+++ b/corpus/desugared/08-comparable/order3-v.txt
@@ -1,0 +1,35 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable v1 (type
+          (array-type
+            (value-type int) dimensions: 1 ([]))) (expr
+          (list-constructor-expr))))
+      (if
+        (type-test-expr is
+          (simple-var-ref v1)
+          (array-type
+            (value-type string) dimensions: 1 ([])))
+        (block-stmt
+          (var-def
+            (variable j (type
+              (array-type
+                (value-type string) dimensions: 1 ([]))) (expr
+              (list-constructor-expr))))
+          (expression-stmt
+            (invocation io println (
+              (binary-expr <
+                (simple-var-ref v1)
+                (simple-var-ref j)))))
+          (expression-stmt
+            (invocation io println (
+              (binary-expr >
+                (simple-var-ref v1)
+                (simple-var-ref j)))))) (
+        (block-stmt
+          (expression-stmt
+            (invocation io println (
+              (literal else))))))))))

--- a/corpus/desugared/08-comparable/order4-v.txt
+++ b/corpus/desugared/08-comparable/order4-v.txt
@@ -1,0 +1,38 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable n1 (type
+          (array-type
+            (value-type null) dimensions: 1 ([]))) (expr
+          (list-constructor-expr))))
+      (var-def
+        (variable n2 (type
+          (array-type
+            (value-type null) dimensions: 2 ([][]))) (expr
+          (list-constructor-expr))))
+      (var-def
+        (variable n3 (type
+          (array-type
+            (union-type
+              (array-type
+                (value-type null) dimensions: 1 ([]))
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref n1)
+            (simple-var-ref n2)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref n3)
+            (simple-var-ref n2)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref n1)
+            (simple-var-ref n3))))))))

--- a/corpus/desugared/08-comparable/order5-v.txt
+++ b/corpus/desugared/08-comparable/order5-v.txt
@@ -1,0 +1,123 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable b1 (type
+          (array-type
+            (value-type boolean) dimensions: 2 ([][]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (literal true))))))
+      (var-def
+        (variable b2 (type
+          (array-type
+            (value-type boolean) dimensions: 2 ([][]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (literal true))
+            (list-constructor-expr)))))
+      (var-def
+        (variable b3 (type
+          (array-type
+            (union-type
+              (array-type
+                (value-type boolean) dimensions: 1 ([]))
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (literal true))
+            (literal <nil>)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b1)
+            (simple-var-ref b2)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b2)
+            (simple-var-ref b3)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b2)
+            (simple-var-ref b3)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b3)
+            (simple-var-ref b1)))))
+      (var-def
+        (variable s1 (type
+          (array-type
+            (value-type string) dimensions: 2 ([][]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (literal a))))))
+      (var-def
+        (variable s2 (type
+          (array-type
+            (value-type string) dimensions: 2 ([][]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (literal a))
+            (list-constructor-expr)))))
+      (var-def
+        (variable s3 (type
+          (array-type
+            (union-type
+              (array-type
+                (value-type string) dimensions: 1 ([]))
+              (value-type null)) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (literal a))
+            (literal <nil>)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref s2)
+            (simple-var-ref s1)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref s2)
+            (simple-var-ref s3)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref s2)
+            (simple-var-ref s3)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref s1)
+            (simple-var-ref s3)))))
+      (var-def
+        (variable f1 (type
+          (array-type
+            (value-type float) dimensions: 2 ([][]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (literal 80))))))
+      (var-def
+        (variable f2 (type
+          (array-type
+            (value-type float) dimensions: 2 ([][]))) (expr
+          (list-constructor-expr
+            (list-constructor-expr
+              (binary-expr /
+                (literal 0)
+                (literal 0)))))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref f1)
+            (simple-var-ref f2)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref f2)
+            (simple-var-ref f2))))))))

--- a/corpus/desugared/08-comparable/relational4-v.txt
+++ b/corpus/desugared/08-comparable/relational4-v.txt
@@ -1,0 +1,77 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable x (type
+          (array-type
+            (value-type decimal) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 3/2)))))
+      (var-def
+        (variable y (type
+          (array-type
+            (value-type decimal) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 3/1)))))
+      (var-def
+        (variable z (type
+          (array-type
+            (value-type decimal) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 3/1)))))
+      (var-def
+        (variable a1 (type
+          (array-type
+            (value-type decimal) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 1/1)
+            (literal 5/2)))))
+      (var-def
+        (variable a2 (type
+          (array-type
+            (value-type decimal) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 2/1)
+            (literal 3/1)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref x)
+            (simple-var-ref y)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref x)
+            (simple-var-ref y)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref y)
+            (simple-var-ref x)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref y)
+            (simple-var-ref x)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref y)
+            (simple-var-ref z)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref y)
+            (simple-var-ref z)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a1)
+            (simple-var-ref a2)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a1)
+            (simple-var-ref a2))))))))

--- a/corpus/desugared/08-comparable/relational5-v.txt
+++ b/corpus/desugared/08-comparable/relational5-v.txt
@@ -1,0 +1,93 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable d1 (type
+          (value-type decimal)) (expr
+          (literal 1/1))))
+      (var-def
+        (variable d2 (type
+          (value-type decimal)) (expr
+          (literal 2/1))))
+      (var-def
+        (variable d3 (type
+          (value-type decimal)) (expr
+          (literal 3/1))))
+      (var-def
+        (variable d15 (type
+          (value-type decimal)) (expr
+          (literal 3/2))))
+      (var-def
+        (variable x (type
+          (array-type
+            (value-type decimal) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (simple-var-ref d15)))))
+      (var-def
+        (variable y (type
+          (array-type
+            (value-type decimal) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (simple-var-ref d3)))))
+      (var-def
+        (variable z (type
+          (array-type
+            (value-type decimal) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal 3/1)))))
+      (var-def
+        (variable a1 (type
+          (array-type
+            (value-type decimal) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (simple-var-ref d1)
+            (simple-var-ref d2)))))
+      (var-def
+        (variable a2 (type
+          (array-type
+            (value-type decimal) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (simple-var-ref d2)
+            (simple-var-ref d3)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref x)
+            (simple-var-ref y)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref x)
+            (simple-var-ref y)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref y)
+            (simple-var-ref x)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref y)
+            (simple-var-ref x)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref y)
+            (simple-var-ref z)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref y)
+            (simple-var-ref z)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a1)
+            (simple-var-ref a2)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a1)
+            (simple-var-ref a2))))))))

--- a/corpus/desugared/08-comparable/stringsubtypecompare-v.txt
+++ b/corpus/desugared/08-comparable/stringsubtypecompare-v.txt
@@ -1,0 +1,65 @@
+(package
+  (import-package ballerina io (as io))
+  (type-definition A
+    (union-type
+      (finite-type
+        (literal a))
+      (finite-type
+        (literal aa))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (array-type
+            (user-defined-type A) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal a)
+            (literal aa)))))
+      (var-def
+        (variable b (type
+          (array-type
+            (value-type string) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal b)
+            (literal bb)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref a)
+            (simple-var-ref b)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr <=
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (simple-var-ref b)
+            (simple-var-ref a)))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >=
+            (simple-var-ref b)
+            (simple-var-ref a))))))))

--- a/corpus/integration/08-comparable/5-v.txtar
+++ b/corpus/integration/08-comparable/5-v.txtar
@@ -1,0 +1,6 @@
+-- stdout --
+true
+false
+false
+true
+-- stderr --

--- a/corpus/integration/08-comparable/arr1-v.txtar
+++ b/corpus/integration/08-comparable/arr1-v.txtar
@@ -1,0 +1,22 @@
+-- stdout --
+false
+true
+false
+true
+false
+false
+false
+false
+false
+false
+false
+false
+true
+true
+false
+false
+false
+false
+true
+true
+-- stderr --

--- a/corpus/integration/08-comparable/arr2-v.txtar
+++ b/corpus/integration/08-comparable/arr2-v.txtar
@@ -1,0 +1,22 @@
+-- stdout --
+false
+true
+false
+true
+false
+false
+false
+false
+false
+false
+false
+false
+true
+true
+false
+false
+false
+false
+true
+true
+-- stderr --

--- a/corpus/integration/08-comparable/arr3-v.txtar
+++ b/corpus/integration/08-comparable/arr3-v.txtar
@@ -1,0 +1,22 @@
+-- stdout --
+false
+true
+false
+true
+false
+false
+false
+false
+false
+false
+false
+false
+true
+true
+false
+false
+false
+false
+true
+true
+-- stderr --

--- a/corpus/integration/08-comparable/arr4-v.txtar
+++ b/corpus/integration/08-comparable/arr4-v.txtar
@@ -1,0 +1,22 @@
+-- stdout --
+false
+true
+false
+true
+false
+false
+false
+false
+false
+false
+false
+false
+true
+true
+false
+false
+false
+false
+true
+true
+-- stderr --

--- a/corpus/integration/08-comparable/booleansubtypecompare-v.txtar
+++ b/corpus/integration/08-comparable/booleansubtypecompare-v.txtar
@@ -1,0 +1,10 @@
+-- stdout --
+true
+true
+false
+false
+false
+false
+true
+true
+-- stderr --

--- a/corpus/integration/08-comparable/comp1-v.txtar
+++ b/corpus/integration/08-comparable/comp1-v.txtar
@@ -1,0 +1,18 @@
+-- stdout --
+true
+true
+false
+false
+false
+false
+true
+true
+false
+false
+true
+true
+true
+true
+false
+false
+-- stderr --

--- a/corpus/integration/08-comparable/comp10-v.txtar
+++ b/corpus/integration/08-comparable/comp10-v.txtar
@@ -1,0 +1,10 @@
+-- stdout --
+false
+false
+true
+true
+true
+true
+false
+false
+-- stderr --

--- a/corpus/integration/08-comparable/comp11-v.txtar
+++ b/corpus/integration/08-comparable/comp11-v.txtar
@@ -1,0 +1,18 @@
+-- stdout --
+true
+true
+false
+false
+false
+false
+true
+true
+false
+false
+true
+true
+true
+true
+false
+false
+-- stderr --

--- a/corpus/integration/08-comparable/comp2-v.txtar
+++ b/corpus/integration/08-comparable/comp2-v.txtar
@@ -1,0 +1,18 @@
+-- stdout --
+true
+true
+false
+false
+false
+false
+true
+true
+false
+false
+true
+true
+true
+true
+false
+false
+-- stderr --

--- a/corpus/integration/08-comparable/comp3-v.txtar
+++ b/corpus/integration/08-comparable/comp3-v.txtar
@@ -1,0 +1,18 @@
+-- stdout --
+true
+true
+false
+false
+false
+false
+true
+true
+false
+false
+true
+true
+true
+true
+false
+false
+-- stderr --

--- a/corpus/integration/08-comparable/comp5-v.txtar
+++ b/corpus/integration/08-comparable/comp5-v.txtar
@@ -1,0 +1,8 @@
+-- stdout --
+false
+true
+false
+true
+false
+true
+-- stderr --

--- a/corpus/integration/08-comparable/comp7-v.txtar
+++ b/corpus/integration/08-comparable/comp7-v.txtar
@@ -1,0 +1,18 @@
+-- stdout --
+true
+true
+false
+false
+false
+false
+true
+true
+true
+true
+false
+false
+false
+false
+true
+true
+-- stderr --

--- a/corpus/integration/08-comparable/floatsubtypecompare-v.txtar
+++ b/corpus/integration/08-comparable/floatsubtypecompare-v.txtar
@@ -1,0 +1,10 @@
+-- stdout --
+true
+true
+false
+false
+false
+false
+true
+true
+-- stderr --

--- a/corpus/integration/08-comparable/intsubtypecompare-v.txtar
+++ b/corpus/integration/08-comparable/intsubtypecompare-v.txtar
@@ -1,0 +1,4 @@
+-- stdout --
+true
+true
+-- stderr --

--- a/corpus/integration/08-comparable/order1-v.txtar
+++ b/corpus/integration/08-comparable/order1-v.txtar
@@ -1,0 +1,9 @@
+-- stdout --
+true
+false
+false
+true
+false
+false
+false
+-- stderr --

--- a/corpus/integration/08-comparable/order2-v.txtar
+++ b/corpus/integration/08-comparable/order2-v.txtar
@@ -1,0 +1,21 @@
+-- stdout --
+false
+false
+true
+false
+false
+false
+false
+false
+false
+false
+false
+false
+false
+false
+false
+true
+false
+true
+false
+-- stderr --

--- a/corpus/integration/08-comparable/order3-v.txtar
+++ b/corpus/integration/08-comparable/order3-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+else
+-- stderr --

--- a/corpus/integration/08-comparable/order4-v.txtar
+++ b/corpus/integration/08-comparable/order4-v.txtar
@@ -1,0 +1,5 @@
+-- stdout --
+false
+false
+false
+-- stderr --

--- a/corpus/integration/08-comparable/relational4-v.txtar
+++ b/corpus/integration/08-comparable/relational4-v.txtar
@@ -1,0 +1,10 @@
+-- stdout --
+true
+false
+false
+true
+true
+true
+true
+false
+-- stderr --

--- a/corpus/integration/08-comparable/relational5-v.txtar
+++ b/corpus/integration/08-comparable/relational5-v.txtar
@@ -1,0 +1,10 @@
+-- stdout --
+true
+false
+false
+true
+true
+true
+true
+false
+-- stderr --

--- a/corpus/integration/08-comparable/stringsubtypecompare-v.txtar
+++ b/corpus/integration/08-comparable/stringsubtypecompare-v.txtar
@@ -1,0 +1,10 @@
+-- stdout --
+true
+true
+false
+false
+false
+false
+true
+true
+-- stderr --

--- a/corpus/integration_test.go
+++ b/corpus/integration_test.go
@@ -71,6 +71,30 @@ var (
 		"subset7/07-closure/equality4-v.bal",
 		"subset7/07-closure/typeCast1-v.bal",
 		"subset7/07-closure/typeCast2-p.bal",
+
+		// https://github.com/ballerina-platform/ballerina-lang-go/issues/358
+		"08-comparable/5-v.bal",
+		"08-comparable/arr1-v.bal",
+		"08-comparable/arr2-v.bal",
+		"08-comparable/arr3-v.bal",
+		"08-comparable/arr4-v.bal",
+		"08-comparable/booleansubtypecompare-v.bal",
+		"08-comparable/comp1-v.bal",
+		"08-comparable/comp2-v.bal",
+		"08-comparable/comp3-v.bal",
+		"08-comparable/comp5-v.bal",
+		"08-comparable/comp7-v.bal",
+		"08-comparable/comp10-v.bal",
+		"08-comparable/comp11-v.bal",
+		"08-comparable/floatsubtypecompare-v.bal",
+		"08-comparable/intsubtypecompare-v.bal",
+		"08-comparable/order1-v.bal",
+		"08-comparable/order2-v.bal",
+		"08-comparable/order4-v.bal",
+		"08-comparable/order5-v.bal",
+		"08-comparable/relational4-v.bal",
+		"08-comparable/relational5-v.bal",
+		"08-comparable/stringsubtypecompare-v.bal",
 	}
 )
 

--- a/corpus/integration_test.go
+++ b/corpus/integration_test.go
@@ -72,29 +72,8 @@ var (
 		"subset7/07-closure/typeCast1-v.bal",
 		"subset7/07-closure/typeCast2-p.bal",
 
-		// https://github.com/ballerina-platform/ballerina-lang-go/issues/358
-		"08-comparable/5-v.bal",
-		"08-comparable/arr1-v.bal",
-		"08-comparable/arr2-v.bal",
-		"08-comparable/arr3-v.bal",
-		"08-comparable/arr4-v.bal",
-		"08-comparable/booleansubtypecompare-v.bal",
-		"08-comparable/comp1-v.bal",
-		"08-comparable/comp2-v.bal",
-		"08-comparable/comp3-v.bal",
-		"08-comparable/comp5-v.bal",
-		"08-comparable/comp7-v.bal",
-		"08-comparable/comp10-v.bal",
-		"08-comparable/comp11-v.bal",
-		"08-comparable/floatsubtypecompare-v.bal",
-		"08-comparable/intsubtypecompare-v.bal",
-		"08-comparable/order1-v.bal",
-		"08-comparable/order2-v.bal",
-		"08-comparable/order4-v.bal",
+		// https://github.com/ballerina-platform/ballerina-lang-go/issues/364
 		"08-comparable/order5-v.bal",
-		"08-comparable/relational4-v.bal",
-		"08-comparable/relational5-v.bal",
-		"08-comparable/stringsubtypecompare-v.bal",
 	}
 )
 

--- a/runtime/internal/exec/binary.go
+++ b/runtime/internal/exec/binary.go
@@ -17,11 +17,12 @@
 package exec
 
 import (
+	"fmt"
+	"math"
+
 	"ballerina-lang-go/bir"
 	"ballerina-lang-go/runtime/internal/modules"
 	"ballerina-lang-go/values"
-	"fmt"
-	"math"
 )
 
 func execBinaryOpAdd(binaryOp *bir.BinaryOp, frame *Frame, reg *modules.Registry) {
@@ -192,39 +193,27 @@ func execBinaryOpNotEqual(binaryOp *bir.BinaryOp, frame *Frame, reg *modules.Reg
 }
 
 func execBinaryOpGT(binaryOp *bir.BinaryOp, frame *Frame, reg *modules.Registry) {
-	execBinaryOpCompare(binaryOp, frame, reg,
-		func(a, b int64) bool { return a > b },
-		func(a, b float64) bool { return a > b },
-		func(a, b bool) bool { return a && !b },
-		false,
-	)
+	op1, op2 := getBinaryRhsValues(binaryOp, frame, reg)
+	r := values.Compare(op1, op2)
+	setOperandValue(binaryOp.LhsOp, frame, reg, r == values.CmpGT)
 }
 
 func execBinaryOpGTE(binaryOp *bir.BinaryOp, frame *Frame, reg *modules.Registry) {
-	execBinaryOpCompare(binaryOp, frame, reg,
-		func(a, b int64) bool { return a >= b },
-		func(a, b float64) bool { return a >= b },
-		func(a, b bool) bool { return a || !b },
-		true,
-	)
+	op1, op2 := getBinaryRhsValues(binaryOp, frame, reg)
+	r := values.Compare(op1, op2)
+	setOperandValue(binaryOp.LhsOp, frame, reg, r == values.CmpGT || r == values.CmpEQ)
 }
 
 func execBinaryOpLT(binaryOp *bir.BinaryOp, frame *Frame, reg *modules.Registry) {
-	execBinaryOpCompare(binaryOp, frame, reg,
-		func(a, b int64) bool { return a < b },
-		func(a, b float64) bool { return a < b },
-		func(a, b bool) bool { return !a && b },
-		false,
-	)
+	op1, op2 := getBinaryRhsValues(binaryOp, frame, reg)
+	r := values.Compare(op1, op2)
+	setOperandValue(binaryOp.LhsOp, frame, reg, r == values.CmpLT)
 }
 
 func execBinaryOpLTE(binaryOp *bir.BinaryOp, frame *Frame, reg *modules.Registry) {
-	execBinaryOpCompare(binaryOp, frame, reg,
-		func(a, b int64) bool { return a <= b },
-		func(a, b float64) bool { return a <= b },
-		func(a, b bool) bool { return !a || b },
-		true,
-	)
+	op1, op2 := getBinaryRhsValues(binaryOp, frame, reg)
+	r := values.Compare(op1, op2)
+	setOperandValue(binaryOp.LhsOp, frame, reg, r == values.CmpLT || r == values.CmpEQ)
 }
 
 func execBinaryOpAnd(binaryOp *bir.BinaryOp, frame *Frame, reg *modules.Registry) {
@@ -330,32 +319,6 @@ func execBinaryOpBitwise(binaryOp *bir.BinaryOp, frame *Frame, reg *modules.Regi
 		validateShiftAmount(v2)
 	}
 	setOperandValue(binaryOp.LhsOp, frame, reg, bitOp(v1, v2))
-}
-
-func execBinaryOpCompare(binaryOp *bir.BinaryOp, frame *Frame, reg *modules.Registry,
-	intCmp func(a, b int64) bool, floatCmp func(a, b float64) bool,
-	boolCmp func(a, b bool) bool, nilEqualsNil bool,
-) {
-	op1, op2 := getBinaryRhsValues(binaryOp, frame, reg)
-	if op1 == nil || op2 == nil {
-		bothNil := op1 == nil && op2 == nil
-		setOperandValue(binaryOp.LhsOp, frame, reg, bothNil && nilEqualsNil)
-		return
-	}
-
-	switch v1 := op1.(type) {
-	case int64:
-		v2 := op2.(int64)
-		setOperandValue(binaryOp.LhsOp, frame, reg, intCmp(v1, v2))
-	case float64:
-		v2 := op2.(float64)
-		setOperandValue(binaryOp.LhsOp, frame, reg, floatCmp(v1, v2))
-	case bool:
-		v2 := op2.(bool)
-		setOperandValue(binaryOp.LhsOp, frame, reg, boolCmp(v1, v2))
-	default:
-		panic(values.NewErrorWithMessage(fmt.Sprintf("unsupported type: %T", op1)))
-	}
 }
 
 func getBinaryRhsValues(binaryOp *bir.BinaryOp, frame *Frame, reg *modules.Registry) (op1, op2 values.BalValue) {

--- a/semantics/type_resolver.go
+++ b/semantics/type_resolver.go
@@ -2480,39 +2480,265 @@ func negateNumericType(t typeResolver, expr *ast.BLangUnaryExpr, exprTy semtypes
 	}
 }
 
-func resolveBinaryExpr(t typeResolver, chain *binding, expr *ast.BLangBinaryExpr, expectedType semtypes.SemType) (semtypes.SemType, expressionEffect, bool) {
-	if isLogicalExpression(expr) {
-		return resolveLogicalExpr(t, chain, expr)
+func resolveAdditiveExpr(t typeResolver, chain *binding, expr *ast.BLangBinaryExpr, expectedType semtypes.SemType) (semtypes.SemType, expressionEffect, bool) {
+	operandExpectedType := semtypes.Union(semtypes.Union(semtypes.NUMBER, semtypes.STRING), semtypes.XML)
+	if expectedType != nil {
+		operandExpectedType = semtypes.Intersect(operandExpectedType, expectedType)
 	}
-	lhsTy, lhsEffect, ok := resolveExpression(t, chain, expr.LhsExpr, expectedType)
+	lhsTy, lhsEffect, ok := resolveExpression(t, chain, expr.LhsExpr, operandExpectedType)
 	if !ok {
 		return nil, expressionEffect{}, false
 	}
-	rhsTy, _, ok := resolveExpression(t, lhsEffect.ifTrue, expr.RhsExpr, expectedType)
+	rhsTy, _, ok := resolveExpression(t, lhsEffect.ifTrue, expr.RhsExpr, operandExpectedType)
+	if !ok {
+		return nil, expressionEffect{}, false
+	}
+	// TODO: handle singleton
+
+	lhsTy, rhsTy, nilLifted := nilLiftedUnderlyingType(lhsTy, rhsTy)
+
+	numLhsBits := semtypes.NBasicTypes(lhsTy)
+	numRhsBits := semtypes.NBasicTypes(rhsTy)
+
+	if numLhsBits > 1 || numRhsBits > 1 {
+		t.semanticError(fmt.Sprintf("union types not supported for %s", string(expr.GetOperatorKind())), expr.GetPosition())
+		return nil, expressionEffect{}, false
+	}
+
+	ctx := t.typeContext()
+
+	lhsBasicTy := semtypes.WidenToBasicTypes(lhsTy)
+	rhsBasicTy := semtypes.WidenToBasicTypes(rhsTy)
+	if !semtypes.IsSubtype(ctx, lhsBasicTy, additiveSupportedTypes) || !semtypes.IsSubtype(ctx, rhsBasicTy, additiveSupportedTypes) {
+		t.semanticError(fmt.Sprintf("expect numeric or string types for %s", string(expr.GetOperatorKind())), expr.GetPosition())
+		return nil, expressionEffect{}, false
+	} else if lhsBasicTy != rhsBasicTy {
+		t.semanticError("both operands must belong to same basic type", expr.GetPosition())
+		return nil, expressionEffect{}, false
+	}
+	var resultTy semtypes.SemType = lhsBasicTy
+	if nilLifted {
+		resultTy = semtypes.Union(semtypes.NIL, resultTy)
+	}
+	setExpectedType(expr, resultTy)
+	effect := defaultExpressionEffect(lhsEffect.ifTrue)
+	return resultTy, effect, true
+}
+
+func resolveRangeExpr(t typeResolver, chain *binding, expr *ast.BLangBinaryExpr) (semtypes.SemType, expressionEffect, bool) {
+	_, lhsEffect, ok := resolveExpression(t, chain, expr.LhsExpr, semtypes.INT)
+	if !ok {
+		return nil, expressionEffect{}, false
+	}
+	_, _, ok = resolveExpression(t, lhsEffect.ifTrue, expr.RhsExpr, semtypes.INT)
+	if !ok {
+		return nil, expressionEffect{}, false
+	}
+	resultTy := createIteratorType(t.typeEnv(), semtypes.INT, semtypes.NIL)
+	setExpectedType(expr, resultTy)
+	effect := defaultExpressionEffect(lhsEffect.ifTrue)
+	return resultTy, effect, true
+}
+
+func resolveShiftExpr(t typeResolver, chain *binding, expr *ast.BLangBinaryExpr) (semtypes.SemType, expressionEffect, bool) {
+	lhsTy, lhsEffect, ok := resolveExpression(t, chain, expr.LhsExpr, semtypes.INT)
+	if !ok {
+		return nil, expressionEffect{}, false
+	}
+	rhsTy, _, ok := resolveExpression(t, lhsEffect.ifTrue, expr.RhsExpr, semtypes.INT)
+	if !ok {
+		return nil, expressionEffect{}, false
+	}
+	lhsTy, rhsTy, nilLifted := nilLiftedUnderlyingType(lhsTy, rhsTy)
+	ctx := t.typeContext()
+	// TODO: handle singleton typing here
+
+	if !semtypes.IsSubtype(ctx, lhsTy, semtypes.INT) || !semtypes.IsSubtype(ctx, rhsTy, semtypes.INT) {
+		t.semanticError(fmt.Sprintf("expect integer types for %s", string(expr.GetOperatorKind())), expr.GetPosition())
+		return nil, expressionEffect{}, false
+	}
+	var resultTy semtypes.SemType = semtypes.INT
+	switch expr.GetOperatorKind() {
+	case model.OperatorKind_BITWISE_RIGHT_SHIFT, model.OperatorKind_BITWISE_UNSIGNED_RIGHT_SHIFT:
+		for _, ty := range bitWiseOpLookOrder {
+			if semtypes.IsSubtype(ctx, lhsTy, ty) {
+				resultTy = ty
+				break
+			}
+		}
+	}
+	if nilLifted {
+		resultTy = semtypes.Union(resultTy, semtypes.NIL)
+	}
+	setExpectedType(expr, resultTy)
+	effect := defaultExpressionEffect(lhsEffect.ifTrue)
+	return resultTy, effect, true
+}
+
+func nilLiftedUnderlyingType(lhsTy, rhsTy semtypes.SemType) (semtypes.SemType, semtypes.SemType, bool) {
+	nilLifted := false
+	if semtypes.ContainsBasicType(lhsTy, semtypes.NIL) {
+		nilLifted = true
+		lhsTy = semtypes.Diff(lhsTy, semtypes.NIL)
+	}
+	if semtypes.ContainsBasicType(rhsTy, semtypes.NIL) {
+		nilLifted = true
+		rhsTy = semtypes.Diff(rhsTy, semtypes.NIL)
+	}
+	return lhsTy, rhsTy, nilLifted
+}
+
+func resolveRelationalExpr(t typeResolver, chain *binding, expr *ast.BLangBinaryExpr) (semtypes.SemType, expressionEffect, bool) {
+	lhsTy, lhsEffect, ok := resolveExpression(t, chain, expr.LhsExpr, nil)
+	if !ok {
+		return nil, expressionEffect{}, false
+	}
+	rhsTy, _, ok := resolveExpression(t, lhsEffect.ifTrue, expr.RhsExpr, nil)
 	if !ok {
 		return nil, expressionEffect{}, false
 	}
 
+	if !semtypes.Comparable(t.typeContext(), lhsTy, rhsTy) {
+		t.semanticError("values are not comparable", expr.GetPosition())
+		return nil, expressionEffect{}, false
+	}
+	resultTy := semtypes.BOOLEAN
+	setExpectedType(expr, resultTy)
+	effect := defaultExpressionEffect(lhsEffect.ifTrue)
+	return resultTy, effect, true
+}
+
+func resolveMultiplicativeExpr(t typeResolver, chain *binding, expr *ast.BLangBinaryExpr, expectedType semtypes.SemType) (semtypes.SemType, expressionEffect, bool) {
+	var operandExpectedType semtypes.SemType = semtypes.NUMBER
+	if expectedType != nil {
+		operandExpectedType = semtypes.Intersect(expectedType, operandExpectedType)
+	}
+	lhsTy, lhsEffect, ok := resolveExpression(t, chain, expr.LhsExpr, operandExpectedType)
+	if !ok {
+		return nil, expressionEffect{}, false
+	}
+	rhsTy, _, ok := resolveExpression(t, lhsEffect.ifTrue, expr.RhsExpr, operandExpectedType)
+	if !ok {
+		return nil, expressionEffect{}, false
+	}
+	// TODO: handle singleton
+
+	lhsTy, rhsTy, nilLifted := nilLiftedUnderlyingType(lhsTy, rhsTy)
+
+	numLhsBits := semtypes.NBasicTypes(lhsTy)
+	numRhsBits := semtypes.NBasicTypes(rhsTy)
+
+	if numLhsBits > 1 || numRhsBits > 1 {
+		t.semanticError(fmt.Sprintf("union types not supported for %s", string(expr.GetOperatorKind())), expr.GetPosition())
+		return nil, expressionEffect{}, false
+	}
+
+	lhsBasicTy := semtypes.WidenToBasicTypes(lhsTy)
+	rhsBasicTy := semtypes.WidenToBasicTypes(rhsTy)
+	if !isNumericType(lhsBasicTy) || !isNumericType(rhsBasicTy) {
+		t.semanticError(fmt.Sprintf("expect numeric types for %s", string(expr.GetOperatorKind())), expr.GetPosition())
+		return nil, expressionEffect{}, false
+	}
 	var resultTy semtypes.SemType
-
-	if isEqualityExpr(expr) {
-		return resolveEqualityExpr(t, lhsEffect.ifTrue, expr)
-	} else if isRangeExpr(expr) {
-		resultTy = createIteratorType(t.typeEnv(), semtypes.INT, semtypes.NIL)
-	} else {
-		var nilLifted bool
-		resultTy, nilLifted = nilLiftingExprResultTy(t, lhsTy, rhsTy, expr)
-		if resultTy == nil {
+	if lhsBasicTy != rhsBasicTy {
+		ctx := t.typeContext()
+		if semtypes.IsSubtype(ctx, rhsBasicTy, semtypes.INT) {
+			resultTy = lhsBasicTy
+		} else if expr.GetOperatorKind() == model.OperatorKind_MUL && semtypes.IsSubtype(ctx, lhsBasicTy, semtypes.INT) {
+			resultTy = rhsBasicTy
+		} else {
+			t.semanticError("both operands must belong to same basic type", expr.GetPosition())
 			return nil, expressionEffect{}, false
 		}
-		if nilLifted {
-			resultTy = semtypes.Union(semtypes.NIL, resultTy)
+	} else {
+		resultTy = lhsBasicTy
+	}
+	if nilLifted {
+		resultTy = semtypes.Union(semtypes.NIL, resultTy)
+	}
+	setExpectedType(expr, resultTy)
+	effect := defaultExpressionEffect(lhsEffect.ifTrue)
+	return resultTy, effect, true
+}
+
+func resolveBitWiseExpr(t typeResolver, chain *binding, expr *ast.BLangBinaryExpr) (semtypes.SemType, expressionEffect, bool) {
+	lhsTy, lhsEffect, ok := resolveExpression(t, chain, expr.LhsExpr, semtypes.INT)
+	if !ok {
+		return nil, expressionEffect{}, false
+	}
+	rhsTy, _, ok := resolveExpression(t, lhsEffect.ifTrue, expr.RhsExpr, semtypes.INT)
+	if !ok {
+		return nil, expressionEffect{}, false
+	}
+	// TODO: handle singleton
+
+	lhsTy, rhsTy, nilLifted := nilLiftedUnderlyingType(lhsTy, rhsTy)
+
+	numLhsBits := semtypes.NBasicTypes(lhsTy)
+	numRhsBits := semtypes.NBasicTypes(rhsTy)
+
+	if numLhsBits > 1 || numRhsBits > 1 {
+		t.semanticError(fmt.Sprintf("union types not supported for %s", string(expr.GetOperatorKind())), expr.GetPosition())
+		return nil, expressionEffect{}, false
+	}
+
+	ctx := t.typeContext()
+	if !semtypes.IsSubtype(ctx, lhsTy, semtypes.INT) || !semtypes.IsSubtype(ctx, rhsTy, semtypes.INT) {
+		t.semanticError("expect integer types for bitwise operators", expr.GetPosition())
+		return nil, expressionEffect{}, false
+	}
+
+	var resultTy semtypes.SemType = semtypes.INT
+	switch expr.GetOperatorKind() {
+	case model.OperatorKind_BITWISE_AND:
+		for _, ty := range bitWiseOpLookOrder {
+			if semtypes.IsSubtype(ctx, lhsTy, ty) || semtypes.IsSubtype(ctx, rhsTy, ty) {
+				resultTy = ty
+				break
+			}
 		}
+	case model.OperatorKind_BITWISE_OR, model.OperatorKind_BITWISE_XOR:
+		for _, ty := range bitWiseOpLookOrder {
+			if semtypes.IsSubtype(ctx, lhsTy, ty) && semtypes.IsSubtype(ctx, rhsTy, ty) {
+				resultTy = ty
+				break
+			}
+		}
+	default:
+		t.unimplemented(fmt.Sprintf("unsupported bitwise operator: %s", string(expr.GetOperatorKind())), expr.GetPosition())
+		return nil, expressionEffect{}, false
+	}
+	if nilLifted {
+		resultTy = semtypes.Union(resultTy, semtypes.NIL)
 	}
 
 	setExpectedType(expr, resultTy)
 	effect := defaultExpressionEffect(lhsEffect.ifTrue)
 	return resultTy, effect, true
+}
+
+func resolveBinaryExpr(t typeResolver, chain *binding, expr *ast.BLangBinaryExpr, expectedType semtypes.SemType) (semtypes.SemType, expressionEffect, bool) {
+	switch expr.GetOperatorKind() {
+	case model.OperatorKind_ADD, model.OperatorKind_SUB:
+		return resolveAdditiveExpr(t, chain, expr, expectedType)
+	case model.OperatorKind_MUL, model.OperatorKind_DIV, model.OperatorKind_MOD:
+		return resolveMultiplicativeExpr(t, chain, expr, expectedType)
+	case model.OperatorKind_AND, model.OperatorKind_OR:
+		return resolveLogicalExpr(t, chain, expr)
+	case model.OperatorKind_EQUAL, model.OperatorKind_EQUALS, model.OperatorKind_NOT_EQUAL, model.OperatorKind_REF_EQUAL, model.OperatorKind_REF_NOT_EQUAL:
+		return resolveEqualityExpr(t, chain, expr)
+	case model.OperatorKind_CLOSED_RANGE, model.OperatorKind_HALF_OPEN_RANGE:
+		return resolveRangeExpr(t, chain, expr)
+	case model.OperatorKind_BITWISE_LEFT_SHIFT, model.OperatorKind_BITWISE_RIGHT_SHIFT, model.OperatorKind_BITWISE_UNSIGNED_RIGHT_SHIFT:
+		return resolveShiftExpr(t, chain, expr)
+	case model.OperatorKind_LESS_THAN, model.OperatorKind_LESS_EQUAL, model.OperatorKind_GREATER_THAN, model.OperatorKind_GREATER_EQUAL:
+		return resolveRelationalExpr(t, chain, expr)
+	case model.OperatorKind_BITWISE_AND, model.OperatorKind_BITWISE_OR, model.OperatorKind_BITWISE_XOR:
+		return resolveBitWiseExpr(t, chain, expr)
+	default:
+		t.internalError(fmt.Sprintf("Unexpected binary expr %s", expr.OpKind), expr.GetPosition())
+		return nil, expressionEffect{}, false
+	}
 }
 
 func isSingletonBool(ty semtypes.SemType, value bool) bool {
@@ -2525,7 +2751,16 @@ func isSingletonBool(ty semtypes.SemType, value bool) bool {
 }
 
 func resolveEqualityExpr(t typeResolver, chain *binding, expr *ast.BLangBinaryExpr) (semtypes.SemType, expressionEffect, bool) {
+	_, lhsEffect, ok := resolveExpression(t, chain, expr.LhsExpr, nil)
+	if !ok {
+		return nil, expressionEffect{}, false
+	}
+	_, _, ok = resolveExpression(t, lhsEffect.ifTrue, expr.RhsExpr, nil)
+	if !ok {
+		return nil, expressionEffect{}, false
+	}
 	var effect expressionEffect
+	// PR-TODO: pass in lhs and rhs types instead
 	if expr.OpKind == model.OperatorKind_EQUAL || expr.OpKind == model.OperatorKind_NOT_EQUAL {
 		effect = equalityNarrowingEffect(t, chain, expr)
 	} else {
@@ -2648,119 +2883,6 @@ func buildEqualityNarrowing(t typeResolver, chain *binding, ref model.SymbolRef,
 var additiveSupportedTypes = semtypes.Union(semtypes.NUMBER, semtypes.STRING)
 
 var bitWiseOpLookOrder = []semtypes.SemType{semtypes.UINT8, semtypes.UINT16, semtypes.UINT32}
-
-func nilLiftingExprResultTy(t typeResolver, lhsTy, rhsTy semtypes.SemType, expr *ast.BLangBinaryExpr) (semtypes.SemType, bool) {
-	nilLifted := false
-
-	if semtypes.ContainsBasicType(lhsTy, semtypes.NIL) || semtypes.ContainsBasicType(rhsTy, semtypes.NIL) {
-		nilLifted = true
-		lhsTy = semtypes.Diff(lhsTy, semtypes.NIL)
-		rhsTy = semtypes.Diff(rhsTy, semtypes.NIL)
-	}
-
-	lhsBasicTy := semtypes.WidenToBasicTypes(lhsTy)
-	rhsBasicTy := semtypes.WidenToBasicTypes(rhsTy)
-
-	numLhsBits := semtypes.NBasicTypes(lhsTy)
-	numRhsBits := semtypes.NBasicTypes(rhsTy)
-
-	if numLhsBits > 1 || numRhsBits > 1 {
-		t.semanticError(fmt.Sprintf("union types not supported for %s", string(expr.GetOperatorKind())), expr.GetPosition())
-		return nil, false
-	}
-
-	if isRelationalExpr(expr) {
-		if semtypes.Comparable(t.typeContext(), lhsBasicTy, rhsBasicTy) {
-			return semtypes.BOOLEAN, false
-		}
-		t.semanticError("values are not comparable", expr.GetPosition())
-		return nil, false
-	}
-
-	if isMultiplicativeExpr(expr) {
-		if !isNumericType(lhsBasicTy) || !isNumericType(rhsBasicTy) {
-			t.semanticError(fmt.Sprintf("expect numeric types for %s", string(expr.GetOperatorKind())), expr.GetPosition())
-			return nil, false
-		}
-		if lhsBasicTy == rhsBasicTy {
-			return lhsBasicTy, nilLifted
-		}
-		ctx := t.typeContext()
-		if semtypes.IsSubtype(ctx, rhsBasicTy, semtypes.INT) ||
-			(expr.GetOperatorKind() == model.OperatorKind_MUL && semtypes.IsSubtype(ctx, lhsBasicTy, semtypes.INT)) {
-			t.unimplemented("type coercion not supported", expr.GetPosition())
-			return nil, false
-		}
-		t.semanticError("both operands must belong to same basic type", expr.GetPosition())
-		return nil, false
-	}
-
-	if isAdditiveExpr(expr) {
-		ctx := t.typeContext()
-		if !semtypes.IsSubtype(ctx, lhsBasicTy, additiveSupportedTypes) || !semtypes.IsSubtype(ctx, rhsBasicTy, additiveSupportedTypes) {
-			t.semanticError(fmt.Sprintf("expect numeric or string types for %s", string(expr.GetOperatorKind())), expr.GetPosition())
-			return nil, false
-		}
-		if lhsBasicTy == rhsBasicTy {
-			return lhsBasicTy, nilLifted
-		}
-		t.semanticError("both operands must belong to same basic type", expr.GetPosition())
-		return nil, false
-	}
-
-	if isShiftExpr(expr) {
-		ctx := t.typeContext()
-		if !semtypes.IsSubtype(ctx, lhsTy, semtypes.INT) || !semtypes.IsSubtype(ctx, rhsTy, semtypes.INT) {
-			t.semanticError(fmt.Sprintf("expect integer types for %s", string(expr.GetOperatorKind())), expr.GetPosition())
-			return nil, false
-		}
-		var resultTy semtypes.SemType = semtypes.INT
-		switch expr.GetOperatorKind() {
-		case model.OperatorKind_BITWISE_RIGHT_SHIFT, model.OperatorKind_BITWISE_UNSIGNED_RIGHT_SHIFT:
-			for _, ty := range bitWiseOpLookOrder {
-				if semtypes.IsSubtype(ctx, lhsTy, ty) {
-					resultTy = ty
-					break
-				}
-			}
-		}
-		return resultTy, nilLifted
-	}
-
-	if isBitWiseExpr(expr) {
-		ctx := t.typeContext()
-		if !semtypes.IsSubtype(ctx, lhsTy, semtypes.INT) || !semtypes.IsSubtype(ctx, rhsTy, semtypes.INT) {
-			t.semanticError("expect integer types for bitwise operators", expr.GetPosition())
-			return nil, false
-		}
-
-		var resultTy semtypes.SemType = semtypes.INT
-		switch expr.GetOperatorKind() {
-		case model.OperatorKind_BITWISE_AND:
-			for _, ty := range bitWiseOpLookOrder {
-				if semtypes.IsSubtype(ctx, lhsTy, ty) || semtypes.IsSubtype(ctx, rhsTy, ty) {
-					resultTy = ty
-					break
-				}
-			}
-		case model.OperatorKind_BITWISE_OR, model.OperatorKind_BITWISE_XOR:
-			for _, ty := range bitWiseOpLookOrder {
-				if semtypes.IsSubtype(ctx, lhsTy, ty) && semtypes.IsSubtype(ctx, rhsTy, ty) {
-					resultTy = ty
-					break
-				}
-			}
-		default:
-			t.internalError(fmt.Sprintf("unsupported bitwise operator: %s", string(expr.GetOperatorKind())), expr.GetPosition())
-			return nil, false
-		}
-
-		return resultTy, nilLifted
-	}
-
-	t.internalError(fmt.Sprintf("unsupported binary operator: %s", string(expr.GetOperatorKind())), expr.GetPosition())
-	return nil, false
-}
 
 func createIteratorType(env semtypes.Env, t, c semtypes.SemType) semtypes.SemType {
 	od := semtypes.NewObjectDefinition()

--- a/values/compare.go
+++ b/values/compare.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package values
+
+import (
+	"fmt"
+	"math/big"
+)
+
+type CompareResult int8
+
+const (
+	CmpLT CompareResult = -1
+	CmpEQ CompareResult = 0
+	CmpGT CompareResult = 1
+	CmpUN CompareResult = 2
+)
+
+func Compare(x, y BalValue) CompareResult {
+	if x == nil && y == nil {
+		return CmpEQ
+	}
+	if x == nil || y == nil {
+		return CmpUN
+	}
+	switch v1 := x.(type) {
+	case int64:
+		v2 := y.(int64)
+		if v1 < v2 {
+			return CmpLT
+		}
+		if v1 > v2 {
+			return CmpGT
+		}
+		return CmpEQ
+	case float64:
+		v2 := y.(float64)
+		if v1 < v2 {
+			return CmpLT
+		}
+		if v1 > v2 {
+			return CmpGT
+		}
+		if v1 == v2 {
+			return CmpEQ
+		}
+		return CmpUN
+	case bool:
+		v2 := y.(bool)
+		if v1 == v2 {
+			return CmpEQ
+		}
+		if !v1 && v2 {
+			return CmpLT
+		}
+		return CmpGT
+	case string:
+		v2 := y.(string)
+		if v1 < v2 {
+			return CmpLT
+		}
+		if v1 > v2 {
+			return CmpGT
+		}
+		return CmpEQ
+	case *big.Rat:
+		v2 := y.(*big.Rat)
+		switch v1.Cmp(v2) {
+		case -1:
+			return CmpLT
+		case 0:
+			return CmpEQ
+		default:
+			return CmpGT
+		}
+	case *List:
+		v2 := y.(*List)
+		return compareList(v1, v2)
+	default:
+		panic(NewErrorWithMessage(fmt.Sprintf("unsupported type for comparison: %T", x)))
+	}
+}
+
+func compareList(x, y *List) CompareResult {
+	xLen := x.Len()
+	yLen := y.Len()
+	minLen := min(yLen, xLen)
+	for i := range minLen {
+		r := Compare(x.Get(i), y.Get(i))
+		if r != CmpEQ {
+			return r
+		}
+	}
+	if xLen < yLen {
+		return CmpLT
+	}
+	if xLen > yLen {
+		return CmpGT
+	}
+	return CmpEQ
+}


### PR DESCRIPTION
## Purpose
Fix #356 and #358
$subject


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added many new runnable comparison scenarios and expected-output fixtures covering arrays, tuples, nullable/missing elements, subtypes, NaN, and ordering edge cases.

* **Refactor**
  * Reworked binary-expression resolution into per-operator dispatch for clearer, more precise typing and diagnostics.

* **Bug Fixes**
  * Improved runtime comparison semantics for mixed and nullable values (including NaN and nil) to produce more consistent, predictable ordering results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->