### PR TITLE
Handle fatal diagnostics in CLI

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -196,7 +196,9 @@ func runBallerina(cmd *cobra.Command, args []string) error {
 	birPkgs := backend.BIRPackages()
 
 	if len(birPkgs) == 0 {
-		return fmt.Errorf("BIR generation failed: no BIR package produced")
+		err := fmt.Errorf("BIR generation failed: no BIR package produced")
+		printError(err, "", false)
+		return err
 	}
 
 	if runOpts.statsOneline {

--- a/cli/cmd/utils.go
+++ b/cli/cmd/utils.go
@@ -195,7 +195,7 @@ func printSourceSnippet(w io.Writer, s outputStyle, loc diagnosticLocation, fsys
 		var highlightLen int
 		startCol, _, highlightLen = computeTrimmedCaretSpan(lineContent, startCol, endCol)
 
-		_, _ = fmt.Fprintf(w, "%s%*s%s | %s\n", s.cyan, loc.numWidth, lineNumStr, s.reset, lineContent)
+		_, _ = fmt.Fprintf(w, "%s%*s | %s%s\n", s.cyan, loc.numWidth, lineNumStr, s.reset, lineContent)
 		pointer := buildPointer(lineContent, startCol, highlightLen)
 		_, _ = fmt.Fprintf(w, "%*s %s| %s%s%s\n", loc.numWidth, "", s.cyan, severityColor, pointer, s.reset)
 	}

--- a/projects/diagnostic_result.go
+++ b/projects/diagnostic_result.go
@@ -42,7 +42,7 @@ func NewDiagnosticResult(diags []diagnostics.Diagnostic) DiagnosticResult {
 	// Categorize by severity
 	for _, d := range diags {
 		switch d.DiagnosticInfo().Severity() {
-		case diagnostics.Error:
+		case diagnostics.Error, diagnostics.Fatal:
 			result.errors = append(result.errors, d)
 		case diagnostics.Warning:
 			result.warnings = append(result.warnings, d)

--- a/projects/package_compilation.go
+++ b/projects/package_compilation.go
@@ -114,9 +114,11 @@ func (c *PackageCompilation) compileModulesInternal() {
 		// Collect diagnostics from all modules
 		for _, moduleCtx := range c.packageResolution.topologicallySortedModuleList {
 			for _, diag := range moduleCtx.getDiagnostics() {
-				if c.getPackageContext().getProject().Kind() == ProjectKindBala &&
-					diag.DiagnosticInfo().Severity() != diagnostics.Error {
-					continue
+				severity := diag.DiagnosticInfo().Severity()
+				if c.getPackageContext().getProject().Kind() == ProjectKindBala {
+					if severity != diagnostics.Error && severity != diagnostics.Fatal {
+						continue
+					}
 				}
 				// TODO(P6): Determine isWorkspaceDep from dependency graph root comparison
 				isWorkspaceDep := false

--- a/tools/diagnostics/diagnostic_severity.go
+++ b/tools/diagnostics/diagnostic_severity.go
@@ -40,6 +40,8 @@ func (ds DiagnosticSeverity) String() string {
 		return "WARNING"
 	case Error:
 		return "ERROR"
+	case Fatal:
+		return "FATAL"
 	default:
 		return "UNKNOWN"
 	}


### PR DESCRIPTION
## Purpose
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Errors are now reliably printed when package generation yields no packages.
  * Source snippet styling adjusted so line highlight/reset renders consistently.
  * Diagnostic capture during compilation expanded to include fatal severities alongside errors.

* **New Features**
  * Fatal-level diagnostics are explicitly labeled as "FATAL" in outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->