### PR TITLE
Add to string support for object type

### DIFF
--- a/corpus/bir/subset6/06-object/init-error-return-v.txt
+++ b/corpus/bir/subset6/06-object/init-error-return-v.txt
@@ -56,7 +56,7 @@ main() -> nil{
   }
   bb4 {
     r1 = %4;
-    %7 = r1 is object
+    %7 = r1 is object { function getVal() returns int; function init(int) returns nil|error; int val }
     %7 ? bb5 : bb8;
   }
   bb5 {

--- a/corpus/bir/subset8/08-class/1-v.txt
+++ b/corpus/bir/subset8/08-class/1-v.txt
@@ -12,7 +12,7 @@ class Bar {
   }
 }
 class Foo {
-  bar object
+  bar object { function init(int) returns nil; int value }
 
   foo(int) -> int{
     bb0 {
@@ -28,7 +28,7 @@ class Foo {
     }
   }
 
-  init(object) -> nil{
+  init(object { function init(int) returns nil; int value }) -> nil{
     bb0 {
       %3 = ConstantLoad bar
       self[%3] = bar;

--- a/corpus/integration/subset6/06-object/init-type-check-2-e.txtar
+++ b/corpus/integration/subset6/06-object/init-type-check-2-e.txtar
@@ -1,6 +1,6 @@
 -- stdout --
 -- stderr --
-error[SEMANTIC_ERROR]: incompatible type: expected object, got error|object
+error[SEMANTIC_ERROR]: incompatible type: expected object { int bar; int baz; function foo(int, int) returns int; function init(int) returns nil|error }, got error|object { int bar; int baz; function foo(int, int) returns int; function init(int) returns nil|error }
   --> init-type-check-2-e.bal:31:13
    |
 31 |     Bar f = new (5); // @error

--- a/corpus/integration/subset6/06-object/init-type-check-3-e.txtar
+++ b/corpus/integration/subset6/06-object/init-type-check-3-e.txtar
@@ -1,6 +1,6 @@
 -- stdout --
 -- stderr --
-error[SEMANTIC_ERROR]: incompatible type: expected int|object, got error|object
+error[SEMANTIC_ERROR]: incompatible type: expected int|object { int bar; int baz; function foo(int, int) returns int; function init(int) returns nil|error }, got error|object { int bar; int baz; function foo(int, int) returns int; function init(int) returns nil|error }
   --> init-type-check-3-e.bal:31:17
    |
 31 |     int|Bar f = new (5); // @error

--- a/corpus/integration/subset6/06-object/type-check-e.txtar
+++ b/corpus/integration/subset6/06-object/type-check-e.txtar
@@ -1,6 +1,6 @@
 -- stdout --
 -- stderr --
-error[SEMANTIC_ERROR]: incompatible type: expected object, got object
+error[SEMANTIC_ERROR]: incompatible type: expected object { int bar; function baz(int, int) returns int; function foo(int, int) returns int }, got object { int bar; int baz; function foo(int, int) returns int; function init(int) returns nil }
   --> type-check-e.bal:39:13
    |
 39 |     Foo f = new Bar(5); // @error

--- a/semtypes/to_string.go
+++ b/semtypes/to_string.go
@@ -115,6 +115,8 @@ func (s *toStringState) subtypeToString(sub basicSubtype) string {
 			return s.bddErrorToString(st)
 		case BTFunction:
 			return s.bddFunctionToString(st)
+		case BTObject:
+			return s.bddObjectToString(st)
 		default:
 			name := strings.TrimPrefix(sub.BasicTypeCode.String(), "BT_")
 			return strings.ToLower(name)
@@ -305,6 +307,119 @@ func (s *toStringState) mappingAtomicTypeToString(atom atom) string {
 	restStr := s.semTypeToString(cellInnerVal(atomic.Rest))
 	parts = append(parts, restStr+"...")
 	return "{| " + strings.Join(parts, ", ") + " |}"
+}
+
+func (s *toStringState) bddObjectToString(bdd Bdd) string {
+	var formulas []string
+	bddEvery(s.cx, bdd, conjunctionNil, conjunctionNil, func(cx Context, pos conjunctionHandle, neg conjunctionHandle) bool {
+		var posParts []string
+		for c := pos; c != conjunctionNil; c = cx.conjunctionNext(c) {
+			posParts = append(posParts, s.objectAtomToString(cx.conjunctionAtom(c)))
+		}
+		for i, j := 0, len(posParts)-1; i < j; i, j = i+1, j-1 {
+			posParts[i], posParts[j] = posParts[j], posParts[i]
+		}
+		var negParts []string
+		for c := neg; c != conjunctionNil; c = cx.conjunctionNext(c) {
+			negParts = append(negParts, "¬"+s.objectAtomToString(cx.conjunctionAtom(c)))
+		}
+		for i, j := 0, len(negParts)-1; i < j; i, j = i+1, j-1 {
+			negParts[i], negParts[j] = negParts[j], negParts[i]
+		}
+		parts := append(posParts, negParts...)
+		formulas = append(formulas, strings.Join(parts, "&"))
+		return true
+	})
+	return strings.Join(formulas, "|")
+}
+
+func (s *toStringState) objectAtomToString(atom atom) string {
+	if recAtom, ok := atom.(*recAtom); ok && recAtom.index() == BDD_REC_ATOM_OBJECT_READONLY {
+		return "readonly"
+	}
+	key := atom.canonicalKey()
+	if s.visited[key] {
+		return "..."
+	}
+	s.visited[key] = true
+	defer delete(s.visited, key)
+	return s.objectAtomicTypeToString(atom)
+}
+
+func (s *toStringState) objectAtomicTypeToString(atom atom) string {
+	atomic := s.cx.MappingAtomType(atom)
+	var prefix []string
+	var members []string
+	for i, name := range atomic.Names {
+		if name == "$qualifiers" {
+			qualTy := cellInnerVal(&atomic.Types[i])
+			qualAtomic := ToMappingAtomicType(s.cx, qualTy)
+			if qualAtomic != nil {
+				isolatedTy := qualAtomic.FieldInnerVal("isolated")
+				if IsSameType(s.cx, isolatedTy, BooleanConst(true)) {
+					prefix = append(prefix, "isolated")
+				}
+				networkTy := qualAtomic.FieldInnerVal("network")
+				if IsSameType(s.cx, networkTy, StringConst("client")) {
+					prefix = append(prefix, "client")
+				} else if IsSameType(s.cx, networkTy, StringConst("service")) {
+					prefix = append(prefix, "service")
+				}
+			}
+			continue
+		}
+		memberTy := cellInnerVal(&atomic.Types[i])
+		memberAtomic := ToMappingAtomicType(s.cx, memberTy)
+		if memberAtomic == nil {
+			members = append(members, name+": "+s.semTypeToString(memberTy))
+			continue
+		}
+		kindTy := memberAtomic.FieldInnerVal("kind")
+		valueTy := memberAtomic.FieldInnerVal("value")
+		if IsSameType(s.cx, kindTy, StringConst("field")) {
+			members = append(members, s.semTypeToString(valueTy)+" "+name)
+		} else {
+			members = append(members, s.objectMethodToString(name, kindTy, valueTy))
+		}
+	}
+	prefix = append(prefix, "object")
+	result := strings.Join(prefix, " ")
+	if len(members) > 0 {
+		result += " { " + strings.Join(members, "; ") + " }"
+	}
+	return result
+}
+
+func (s *toStringState) objectMethodToString(name string, kindTy SemType, fnTy SemType) string {
+	var methodPrefix string
+	if IsSameType(s.cx, kindTy, StringConst("remote-method")) {
+		methodPrefix = "remote function "
+	} else if IsSameType(s.cx, kindTy, StringConst("resource-method")) {
+		methodPrefix = "resource function "
+	} else {
+		methodPrefix = "function "
+	}
+	cst, ok := fnTy.(*ComplexSemType)
+	if !ok {
+		return methodPrefix + name + "()"
+	}
+	for _, sub := range unpack(cst) {
+		if sub.BasicTypeCode == BTFunction {
+			bdd, ok := sub.SubtypeData.(Bdd)
+			if !ok {
+				continue
+			}
+			node, ok := bdd.(bddNode)
+			if !ok {
+				continue
+			}
+			atomic := s.cx.FunctionAtomType(node.atom())
+			paramsStr := s.functionParamsToString(atomic.ParamType)
+			retStr := s.semTypeToString(atomic.RetType)
+			return methodPrefix + name + "(" + paramsStr + ") returns " + retStr
+		}
+	}
+	return methodPrefix + name + "()"
 }
 
 func intSubtypeToString(st intSubtype) string {

--- a/semtypes/to_string_test.go
+++ b/semtypes/to_string_test.go
@@ -411,3 +411,215 @@ func TestFunctionTypeWithUnionParams(t *testing.T) {
 		t.Errorf("got %s expected %s", actual, expected)
 	}
 }
+
+func TestObjectSimpleFields(t *testing.T) {
+	env := CreateTypeEnv()
+	cx := ContextFrom(env)
+	od := NewObjectDefinition()
+	ty := od.Define(env, ObjectQualifiersDEFAULT, []Member{
+		{Name: "x", ValueTy: INT, Kind: MemberKindField, Visibility: VisibilityPublic},
+		{Name: "y", ValueTy: STRING, Kind: MemberKindField, Visibility: VisibilityPublic},
+	})
+	actual := ToString(cx, ty)
+	expected := "object { int x; string y }"
+	if actual != expected {
+		t.Errorf("got %q expected %q", actual, expected)
+	}
+}
+
+func TestObjectWithMethod(t *testing.T) {
+	env := CreateTypeEnv()
+	cx := ContextFrom(env)
+	od := NewObjectDefinition()
+	methodTy := funcHelper(env, createTupleType(env, INT, INT), INT)
+	ty := od.Define(env, ObjectQualifiersDEFAULT, []Member{
+		{Name: "foo", ValueTy: methodTy, Kind: MemberKindMethod, Visibility: VisibilityPublic, Immutable: true},
+	})
+	actual := ToString(cx, ty)
+	expected := "object { function foo(int, int) returns int }"
+	if actual != expected {
+		t.Errorf("got %q expected %q", actual, expected)
+	}
+}
+
+func TestObjectWithFieldsAndMethods(t *testing.T) {
+	env := CreateTypeEnv()
+	cx := ContextFrom(env)
+	od := NewObjectDefinition()
+	methodTy := funcHelper(env, createTupleType(env, INT, INT), INT)
+	ty := od.Define(env, ObjectQualifiersDEFAULT, []Member{
+		{Name: "bar", ValueTy: INT, Kind: MemberKindField, Visibility: VisibilityPublic},
+		{Name: "foo", ValueTy: methodTy, Kind: MemberKindMethod, Visibility: VisibilityPublic, Immutable: true},
+	})
+	actual := ToString(cx, ty)
+	expected := "object { int bar; function foo(int, int) returns int }"
+	if actual != expected {
+		t.Errorf("got %q expected %q", actual, expected)
+	}
+}
+
+func TestObjectIsolated(t *testing.T) {
+	env := CreateTypeEnv()
+	cx := ContextFrom(env)
+	od := NewObjectDefinition()
+	ty := od.Define(env, ObjectQualifiersFrom(true, false, NetworkQualifierNone), []Member{
+		{Name: "x", ValueTy: INT, Kind: MemberKindField, Visibility: VisibilityPublic},
+	})
+	actual := ToString(cx, ty)
+	expected := "isolated object { int x }"
+	if actual != expected {
+		t.Errorf("got %q expected %q", actual, expected)
+	}
+}
+
+func TestObjectClient(t *testing.T) {
+	env := CreateTypeEnv()
+	cx := ContextFrom(env)
+	od := NewObjectDefinition()
+	ty := od.Define(env, ObjectQualifiersFrom(false, false, NetworkQualifierClient), []Member{
+		{Name: "x", ValueTy: INT, Kind: MemberKindField, Visibility: VisibilityPublic},
+	})
+	actual := ToString(cx, ty)
+	expected := "client object { int x }"
+	if actual != expected {
+		t.Errorf("got %q expected %q", actual, expected)
+	}
+}
+
+func TestObjectService(t *testing.T) {
+	env := CreateTypeEnv()
+	cx := ContextFrom(env)
+	od := NewObjectDefinition()
+	ty := od.Define(env, ObjectQualifiersFrom(false, false, NetworkQualifierService), []Member{
+		{Name: "x", ValueTy: INT, Kind: MemberKindField, Visibility: VisibilityPublic},
+	})
+	actual := ToString(cx, ty)
+	expected := "service object { int x }"
+	if actual != expected {
+		t.Errorf("got %q expected %q", actual, expected)
+	}
+}
+
+func TestObjectIsolatedService(t *testing.T) {
+	env := CreateTypeEnv()
+	cx := ContextFrom(env)
+	od := NewObjectDefinition()
+	ty := od.Define(env, ObjectQualifiersFrom(true, false, NetworkQualifierService), []Member{
+		{Name: "x", ValueTy: INT, Kind: MemberKindField, Visibility: VisibilityPublic},
+	})
+	actual := ToString(cx, ty)
+	expected := "isolated service object { int x }"
+	if actual != expected {
+		t.Errorf("got %q expected %q", actual, expected)
+	}
+}
+
+func TestObjectRemoteMethod(t *testing.T) {
+	env := CreateTypeEnv()
+	cx := ContextFrom(env)
+	od := NewObjectDefinition()
+	methodTy := funcHelper(env, createTupleType(env, INT), STRING)
+	ty := od.Define(env, ObjectQualifiersFrom(false, false, NetworkQualifierClient), []Member{
+		{Name: "ping", ValueTy: methodTy, Kind: MemberKindRemoteMethod, Visibility: VisibilityPublic, Immutable: true},
+	})
+	actual := ToString(cx, ty)
+	expected := "client object { remote function ping(int) returns string }"
+	if actual != expected {
+		t.Errorf("got %q expected %q", actual, expected)
+	}
+}
+
+func TestObjectResourceMethod(t *testing.T) {
+	env := CreateTypeEnv()
+	cx := ContextFrom(env)
+	od := NewObjectDefinition()
+	methodTy := funcHelper(env, createTupleType(env), NIL)
+	ty := od.Define(env, ObjectQualifiersFrom(false, false, NetworkQualifierService), []Member{
+		{Name: "get", ValueTy: methodTy, Kind: MemberKindResourceMethod, Visibility: VisibilityPublic, Immutable: true},
+	})
+	actual := ToString(cx, ty)
+	expected := "service object { resource function get() returns nil }"
+	if actual != expected {
+		t.Errorf("got %q expected %q", actual, expected)
+	}
+}
+
+func TestObjectEmpty(t *testing.T) {
+	env := CreateTypeEnv()
+	cx := ContextFrom(env)
+	od := NewObjectDefinition()
+	ty := od.Define(env, ObjectQualifiersDEFAULT, nil)
+	actual := ToString(cx, ty)
+	expected := "object"
+	if actual != expected {
+		t.Errorf("got %q expected %q", actual, expected)
+	}
+}
+
+func TestObjectReadonlyIntersect(t *testing.T) {
+	env := CreateTypeEnv()
+	cx := ContextFrom(env)
+	od := NewObjectDefinition()
+	ty := od.Define(env, ObjectQualifiersDEFAULT, []Member{
+		{Name: "x", ValueTy: INT, Kind: MemberKindField, Visibility: VisibilityPublic},
+	})
+	actual := ToString(cx, Intersect(ty, VAL_READONLY))
+	expected := "readonly&object { int x }"
+	if actual != expected {
+		t.Errorf("got %q expected %q", actual, expected)
+	}
+}
+
+func TestObjectTypeUnion(t *testing.T) {
+	env := CreateTypeEnv()
+	cx := ContextFrom(env)
+	od1 := NewObjectDefinition()
+	ty1 := od1.Define(env, ObjectQualifiersDEFAULT, []Member{
+		{Name: "x", ValueTy: INT, Kind: MemberKindField, Visibility: VisibilityPublic},
+	})
+	od2 := NewObjectDefinition()
+	ty2 := od2.Define(env, ObjectQualifiersDEFAULT, []Member{
+		{Name: "y", ValueTy: STRING, Kind: MemberKindField, Visibility: VisibilityPublic},
+	})
+	actual := ToString(cx, Union(ty1, ty2))
+	expected := "object { int x }|object { string y }"
+	if actual != expected {
+		t.Errorf("got %q expected %q", actual, expected)
+	}
+}
+
+func TestObjectTypeIntersect(t *testing.T) {
+	env := CreateTypeEnv()
+	cx := ContextFrom(env)
+	od1 := NewObjectDefinition()
+	ty1 := od1.Define(env, ObjectQualifiersDEFAULT, []Member{
+		{Name: "x", ValueTy: INT, Kind: MemberKindField, Visibility: VisibilityPublic},
+	})
+	od2 := NewObjectDefinition()
+	ty2 := od2.Define(env, ObjectQualifiersDEFAULT, []Member{
+		{Name: "y", ValueTy: STRING, Kind: MemberKindField, Visibility: VisibilityPublic},
+	})
+	actual := ToString(cx, Intersect(ty1, ty2))
+	expected := "object { int x }&object { string y }"
+	if actual != expected {
+		t.Errorf("got %q expected %q", actual, expected)
+	}
+}
+
+func TestObjectTypeDiff(t *testing.T) {
+	env := CreateTypeEnv()
+	cx := ContextFrom(env)
+	od1 := NewObjectDefinition()
+	ty1 := od1.Define(env, ObjectQualifiersDEFAULT, []Member{
+		{Name: "x", ValueTy: INT, Kind: MemberKindField, Visibility: VisibilityPublic},
+	})
+	od2 := NewObjectDefinition()
+	ty2 := od2.Define(env, ObjectQualifiersDEFAULT, []Member{
+		{Name: "y", ValueTy: STRING, Kind: MemberKindField, Visibility: VisibilityPublic},
+	})
+	actual := ToString(cx, Diff(ty1, ty2))
+	expected := "object { int x }&¬object { string y }"
+	if actual != expected {
+		t.Errorf("got %q expected %q", actual, expected)
+	}
+}


### PR DESCRIPTION
## Purpose
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for object type mismatches—now display complete object structures including fields and method signatures for clearer debugging.
  * Enhanced error reporting for qualified objects (isolated, client, service, readonly) to show full structural details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->