### PR TITLE
Introduce PAL to runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,10 @@ This document defines how AI/code agents should work with this repository: codin
 
 - Each bal/go file should have the correct license header
 
+## PAL (Platform Adaptation Layer)
+
+- All platform interactions (e.g. io, http, fs) must go through PAL, not the underlying platform directly.
+
 ## Symbols
 
 - IMPORTANT: never store `model.Symbol` as the key in a map, always use a `model.SymbolRef`

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -226,7 +226,7 @@ func runBallerina(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	rt := runtime.NewRuntime()
+	rt := runtime.NewRuntime(runtime.NativePlatform())
 	for _, birPkg := range birPkgs {
 		if err := rt.Interpret(*birPkg); err != nil {
 			printRuntimeError(err)

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -226,7 +226,7 @@ func runBallerina(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	rt := runtime.NewRuntime(runtime.NativePlatform())
+	rt := runtime.NewRuntime(nativePal)
 	for _, birPkg := range birPkgs {
 		if err := rt.Interpret(*birPkg); err != nil {
 			printRuntimeError(err)

--- a/cli/cmd/utils.go
+++ b/cli/cmd/utils.go
@@ -23,12 +23,24 @@ import (
 	"os"
 	"strings"
 
+	"ballerina-lang-go/pal"
 	"ballerina-lang-go/projects"
 	"ballerina-lang-go/tools/diagnostics"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
+
+var nativePal = pal.Platform{
+	IO: pal.IO{
+		Stdout: func(p []byte) (n int, err error) {
+			return os.Stdout.Write(p)
+		},
+		Stderr: func(p []byte) (n int, err error) {
+			return os.Stderr.Write(p)
+		},
+	},
+}
 
 // printError prints an error message in the standard Ballerina CLI format to stderr.
 func printError(err error, usage string, showHelp bool) {

--- a/corpus/integration_test.go
+++ b/corpus/integration_test.go
@@ -40,7 +40,6 @@ import (
 	"ballerina-lang-go/semtypes"
 	"ballerina-lang-go/test_util"
 	"ballerina-lang-go/tools/text"
-	"ballerina-lang-go/values"
 
 	_ "ballerina-lang-go/lib/rt"
 )
@@ -256,25 +255,15 @@ func runInterpretPhase(birPkg *bir.BIRPackage, stdoutBuf, stderrBuf *bytes.Buffe
 	if birPkg == nil {
 		return
 	}
-	rt := runtime.NewRuntime()
-	runtime.RegisterExternFunction(rt, externOrgName, externModuleName, externFuncName, capturePrintlnOutput(stdoutBuf))
+
+	platform := runtime.NativePlatform()
+	platform.IO.Stdout = stdoutBuf
+	platform.IO.Stderr = stderrBuf
+
+	rt := runtime.NewRuntime(platform)
 	if err := rt.Interpret(*birPkg); err != nil {
 		// For now just write the error string to stderr to match corpus expectations
 		fmt.Fprintln(stderrBuf, err.Error())
-	}
-}
-
-func capturePrintlnOutput(stdoutBuf *bytes.Buffer) func(args []values.BalValue) (values.BalValue, error) {
-	return func(args []values.BalValue) (values.BalValue, error) {
-		var b strings.Builder
-		visited := make(map[uintptr]bool)
-		for _, arg := range args {
-			b.WriteString(values.String(arg, visited))
-		}
-		b.WriteByte('\n')
-		stdoutBuf.WriteString(b.String())
-
-		return nil, nil
 	}
 }
 
@@ -399,8 +388,12 @@ func runProjectInterpretPhase(birPkgs []*bir.BIRPackage, stdoutBuf, stderrBuf *b
 	if len(birPkgs) == 0 {
 		return
 	}
-	rt := runtime.NewRuntime()
-	runtime.RegisterExternFunction(rt, externOrgName, externModuleName, externFuncName, capturePrintlnOutput(stdoutBuf))
+
+	platform := runtime.NativePlatform()
+	platform.IO.Stdout = stdoutBuf
+	platform.IO.Stderr = stderrBuf
+
+	rt := runtime.NewRuntime(platform)
 	for _, birPkg := range birPkgs {
 		if err := rt.Interpret(*birPkg); err != nil {
 			fmt.Fprintln(stderrBuf, err.Error())

--- a/corpus/integration_test.go
+++ b/corpus/integration_test.go
@@ -256,11 +256,7 @@ func runInterpretPhase(birPkg *bir.BIRPackage, stdoutBuf, stderrBuf *bytes.Buffe
 		return
 	}
 
-	platform := runtime.NativePlatform()
-	platform.IO.Stdout = stdoutBuf
-	platform.IO.Stderr = stderrBuf
-
-	rt := runtime.NewRuntime(platform)
+	rt := runtime.NewRuntime(test_util.TestPal(stdoutBuf, stderrBuf))
 	if err := rt.Interpret(*birPkg); err != nil {
 		// For now just write the error string to stderr to match corpus expectations
 		fmt.Fprintln(stderrBuf, err.Error())
@@ -389,11 +385,7 @@ func runProjectInterpretPhase(birPkgs []*bir.BIRPackage, stdoutBuf, stderrBuf *b
 		return
 	}
 
-	platform := runtime.NativePlatform()
-	platform.IO.Stdout = stdoutBuf
-	platform.IO.Stderr = stderrBuf
-
-	rt := runtime.NewRuntime(platform)
+	rt := runtime.NewRuntime(test_util.TestPal(stdoutBuf, stderrBuf))
 	for _, birPkg := range birPkgs {
 		if err := rt.Interpret(*birPkg); err != nil {
 			fmt.Fprintln(stderrBuf, err.Error())

--- a/corpus/integration_test.go
+++ b/corpus/integration_test.go
@@ -48,10 +48,6 @@ const (
 	corpusProjectBaseDir            = "../corpus/project"
 	corpusProjectIntegrationBaseDir = "../corpus/integration/project"
 
-	externOrgName    = "ballerina"
-	externModuleName = "io"
-	externFuncName   = "println"
-
 	panicPrefix = "panic: "
 )
 

--- a/extern-test/extern_test.go
+++ b/extern-test/extern_test.go
@@ -64,20 +64,11 @@ func TestExternValid(t *testing.T) {
 	backend := projects.NewBallerinaBackend(compilation)
 	birPkg := backend.BIR()
 
-	var stdoutBuf bytes.Buffer
-	rt := runtime.NewRuntime()
+	stdoutBuf := &bytes.Buffer{}
 
-	// Register println to capture output
-	runtime.RegisterExternFunction(rt, "ballerina", "io", "println", func(args []values.BalValue) (values.BalValue, error) {
-		var b strings.Builder
-		visited := make(map[uintptr]bool)
-		for _, arg := range args {
-			b.WriteString(values.String(arg, visited))
-		}
-		b.WriteByte('\n')
-		stdoutBuf.WriteString(b.String())
-		return nil, nil
-	})
+	platform := runtime.NativePlatform()
+	platform.IO.Stdout = stdoutBuf
+	rt := runtime.NewRuntime(platform)
 
 	// Register foo() returns "$foo"
 	runtime.RegisterExternFunction(rt, "$anon", "1-v", "foo", func(args []values.BalValue) (values.BalValue, error) {
@@ -200,19 +191,11 @@ func TestExternHandle(t *testing.T) {
 	backend := projects.NewBallerinaBackend(compilation)
 	birPkg := backend.BIR()
 
-	var stdoutBuf bytes.Buffer
-	rt := runtime.NewRuntime()
+	stdoutBuf := &bytes.Buffer{}
 
-	runtime.RegisterExternFunction(rt, "ballerina", "io", "println", func(args []values.BalValue) (values.BalValue, error) {
-		var b strings.Builder
-		visited := make(map[uintptr]bool)
-		for _, arg := range args {
-			b.WriteString(values.String(arg, visited))
-		}
-		b.WriteByte('\n')
-		stdoutBuf.WriteString(b.String())
-		return nil, nil
-	})
+	platform := runtime.NativePlatform()
+	platform.IO.Stdout = stdoutBuf
+	rt := runtime.NewRuntime(platform)
 
 	type myHandle struct {
 		data string

--- a/extern-test/extern_test.go
+++ b/extern-test/extern_test.go
@@ -26,6 +26,7 @@ import (
 
 	"ballerina-lang-go/projects"
 	"ballerina-lang-go/runtime"
+	"ballerina-lang-go/test_util"
 	"ballerina-lang-go/values"
 
 	_ "ballerina-lang-go/lib/rt"
@@ -66,9 +67,7 @@ func TestExternValid(t *testing.T) {
 
 	stdoutBuf := &bytes.Buffer{}
 
-	platform := runtime.NativePlatform()
-	platform.IO.Stdout = stdoutBuf
-	rt := runtime.NewRuntime(platform)
+	rt := runtime.NewRuntime(test_util.TestPal(stdoutBuf, os.Stderr))
 
 	// Register foo() returns "$foo"
 	runtime.RegisterExternFunction(rt, "$anon", "1-v", "foo", func(args []values.BalValue) (values.BalValue, error) {
@@ -193,9 +192,7 @@ func TestExternHandle(t *testing.T) {
 
 	stdoutBuf := &bytes.Buffer{}
 
-	platform := runtime.NativePlatform()
-	platform.IO.Stdout = stdoutBuf
-	rt := runtime.NewRuntime(platform)
+	rt := runtime.NewRuntime(test_util.TestPal(stdoutBuf, os.Stderr))
 
 	type myHandle struct {
 		data string

--- a/lib/io/runtime/io.go
+++ b/lib/io/runtime/io.go
@@ -17,11 +17,11 @@
 package io
 
 import (
+	"fmt"
+	"strings"
+
 	"ballerina-lang-go/runtime"
 	"ballerina-lang-go/values"
-	"fmt"
-	"os"
-	"strings"
 )
 
 const (
@@ -30,22 +30,24 @@ const (
 	funcName   = "println"
 )
 
-func Println(vals ...values.BalValue) {
+func Println(rt *runtime.Runtime, vals ...values.BalValue) {
 	parts := make([]string, len(vals))
 	visited := make(map[uintptr]bool)
 	for i, v := range vals {
 		parts[i] = values.String(v, visited)
 	}
-	_, _ = fmt.Fprintln(os.Stdout, strings.Join(parts, ""))
+	_, _ = fmt.Fprintln(rt.Platform().IO.Stdout, strings.Join(parts, ""))
 }
 
-func printlnExtern(args []values.BalValue) (values.BalValue, error) {
-	Println(args...)
-	return nil, nil
+func printlnExtern(rt *runtime.Runtime) func(args []values.BalValue) (values.BalValue, error) {
+	return func(args []values.BalValue) (values.BalValue, error) {
+		Println(rt, args...)
+		return nil, nil
+	}
 }
 
 func initIOModule(rt *runtime.Runtime) {
-	runtime.RegisterExternFunction(rt, orgName, moduleName, funcName, printlnExtern)
+	runtime.RegisterExternFunction(rt, orgName, moduleName, funcName, printlnExtern(rt))
 }
 
 func init() {

--- a/lib/io/runtime/io.go
+++ b/lib/io/runtime/io.go
@@ -36,7 +36,7 @@ func Println(rt *runtime.Runtime, vals ...values.BalValue) {
 	for i, v := range vals {
 		parts[i] = values.String(v, visited)
 	}
-	_, _ = fmt.Fprintln(rt.Platform().IO.Stdout, strings.Join(parts, ""))
+	_, _ = rt.Platform().IO.Stdout(fmt.Appendln(nil, strings.Join(parts, "")))
 }
 
 func printlnExtern(rt *runtime.Runtime) func(args []values.BalValue) (values.BalValue, error) {

--- a/pal/platform.go
+++ b/pal/platform.go
@@ -14,6 +14,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// Package pal provides the Platform Adaptation Layer (PAL).
+//
+// PAL abstracts away interactions with the underlying platform such that the
+// runtime can be agnostic toward the underlying platform. All library functions
+// that interact with the underlying platform (e.g. io, http) should use PAL.
+// Each supported platform (e.g. native-cli, web-editor) should provide an
+// implementation of PAL to the runtime.
 package pal
 
 type (

--- a/pal/platform.go
+++ b/pal/platform.go
@@ -14,28 +14,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package runtime
-
-import (
-	"io"
-	"os"
-)
+package pal
 
 type (
 	Platform struct {
-		IO PlatformIO
+		IO IO
 	}
-	PlatformIO struct {
-		Stdout io.Writer
-		Stderr io.Writer
+	IO struct {
+		Stdout func(p []byte) (n int, err error)
+		Stderr func(p []byte) (n int, err error)
 	}
 )
-
-func NativePlatform() Platform {
-	return Platform{
-		IO: PlatformIO{
-			Stdout: os.Stdout,
-			Stderr: os.Stderr,
-		},
-	}
-}

--- a/runtime/platform.go
+++ b/runtime/platform.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package runtime
+
+import (
+	"io"
+	"os"
+)
+
+type (
+	Platform struct {
+		IO PlatformIO
+	}
+	PlatformIO struct {
+		Stdout io.Writer
+		Stderr io.Writer
+	}
+)
+
+func NativePlatform() Platform {
+	return Platform{
+		IO: PlatformIO{
+			Stdout: os.Stdout,
+			Stderr: os.Stderr,
+		},
+	}
+}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -28,6 +28,7 @@ import (
 // and is used as the execution context for interpreting BIR packages.
 type Runtime struct {
 	registry *modules.Registry
+	platform Platform
 }
 
 // ModuleInitializer is a function that can install modules (e.g. stdlibs) into
@@ -38,14 +39,20 @@ var moduleInitializers []ModuleInitializer
 
 // NewRuntime constructs a new runtime with an empty registry and runs all
 // registered module initializers.
-func NewRuntime() *Runtime {
+func NewRuntime(platform Platform) *Runtime {
 	rt := &Runtime{
 		registry: modules.NewRegistry(),
+		platform: platform,
 	}
 	for _, init := range moduleInitializers {
 		init(rt)
 	}
 	return rt
+}
+
+// Platform returns the platform configuration of this runtime instance.
+func (rt *Runtime) Platform() Platform {
+	return rt.platform
 }
 
 // Interpret interprets a BIR package using this runtime instance.

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -18,6 +18,7 @@ package runtime
 
 import (
 	"ballerina-lang-go/bir"
+	"ballerina-lang-go/pal"
 	"ballerina-lang-go/runtime/internal/exec"
 	"ballerina-lang-go/runtime/internal/modules"
 	"ballerina-lang-go/semtypes"
@@ -28,7 +29,7 @@ import (
 // and is used as the execution context for interpreting BIR packages.
 type Runtime struct {
 	registry *modules.Registry
-	platform Platform
+	platform pal.Platform
 }
 
 // ModuleInitializer is a function that can install modules (e.g. stdlibs) into
@@ -39,7 +40,7 @@ var moduleInitializers []ModuleInitializer
 
 // NewRuntime constructs a new runtime with an empty registry and runs all
 // registered module initializers.
-func NewRuntime(platform Platform) *Runtime {
+func NewRuntime(platform pal.Platform) *Runtime {
 	rt := &Runtime{
 		registry: modules.NewRegistry(),
 		platform: platform,
@@ -51,7 +52,7 @@ func NewRuntime(platform Platform) *Runtime {
 }
 
 // Platform returns the platform configuration of this runtime instance.
-func (rt *Runtime) Platform() Platform {
+func (rt *Runtime) Platform() pal.Platform {
 	return rt.platform
 }
 

--- a/test_util/test_util.go
+++ b/test_util/test_util.go
@@ -18,10 +18,13 @@
 package test_util
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"ballerina-lang-go/pal"
 )
 
 // TestKind represents the type of corpus test
@@ -160,4 +163,13 @@ func computeExpectedPath(inputPath, inputBaseDir, outputBaseDir, outputExt strin
 	relPath, _ := filepath.Rel(inputBaseDir, inputPath)
 	relPath = strings.TrimSuffix(relPath, ".bal") + outputExt
 	return filepath.Join(outputBaseDir, relPath)
+}
+
+func TestPal(stdout io.Writer, stderr io.Writer) pal.Platform {
+	return pal.Platform{
+		IO: pal.IO{
+			Stdout: stdout.Write,
+			Stderr: stderr.Write,
+		},
+	}
 }


### PR DESCRIPTION
## Purpose
Resolves #386 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Runtime and IO redesigned to use a platform abstraction for stdout/stderr, enabling configurable platform I/O at runtime.
* **Documentation**
  * Added guidance introducing the platform adaptation layer for handling platform-specific interactions.
* **Tests**
  * Test helpers updated to support injecting custom platform I/O, and tests adjusted to use the new platform-based I/O mechanism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->