### PR TITLE
Refactor semtype iterators to be stack allocated

### DIFF
--- a/semtypes/core.go
+++ b/semtypes/core.go
@@ -81,7 +81,9 @@ func Diff(t1, t2 SemType) SemType {
 		return basicTypeUnion(all)
 	}
 	var subtypes []basicSubtype
-	for pair := range newSubtypePairs(t1, t2, some) {
+	it := newSubtypePairs(t1, t2, some)
+	for it.hasNext() {
+		pair := it.next()
 		code := pair.BasicTypeCode
 		data1 := pair.SubtypeData1
 		data2 := pair.SubtypeData2
@@ -106,18 +108,6 @@ func Diff(t1, t2 SemType) SemType {
 	return createComplexSemType(all, subtypes...)
 }
 
-func getUnpackComplexSemType(t *ComplexSemType) []basicSubtype {
-	some := t.some()
-	subtypeDataList := t.subtypeDataList()
-	subtypes := make([]basicSubtype, len(subtypeDataList))
-	for i, data := range subtypeDataList {
-		code := basicTypeCodeFrom(bits.TrailingZeros(uint(some)))
-		subtypes[i] = basicSubtypeFrom(code, data)
-		some = some & ^(1 << code.Code())
-	}
-	return subtypes
-}
-
 func getComplexSubtypeData(t *ComplexSemType, code BasicTypeCode) SubtypeData {
 	c := BasicTypeBitSet(1 << code.Code())
 	if (t.all() & c) != 0 {
@@ -137,7 +127,6 @@ func getComplexSubtypeData(t *ComplexSemType, code BasicTypeCode) SubtypeData {
 }
 
 func Union(t1, t2 SemType) SemType {
-	common.Assert(t1 != nil && t2 != nil)
 	var all1, all2, some1, some2 BasicTypeBitSet
 	if b1, ok := t1.(BasicTypeBitSet); ok {
 		if b2, ok := t2.(BasicTypeBitSet); ok {
@@ -168,7 +157,9 @@ func Union(t1, t2 SemType) SemType {
 		return all
 	}
 	var subtypes []basicSubtype
-	for pair := range newSubtypePairs(t1, t2, some) {
+	it := newSubtypePairs(t1, t2, some)
+	for it.hasNext() {
+		pair := it.next()
 		code := pair.BasicTypeCode
 		data1 := pair.SubtypeData1
 		data2 := pair.SubtypeData2
@@ -194,7 +185,6 @@ func Union(t1, t2 SemType) SemType {
 }
 
 func Intersect(t1, t2 SemType) SemType {
-	common.Assert(t1 != nil && t2 != nil)
 	var all1, all2, some1, some2 BasicTypeBitSet
 	if b1, ok := t1.(BasicTypeBitSet); ok {
 		if b2, ok := t2.(BasicTypeBitSet); ok {
@@ -238,7 +228,9 @@ func Intersect(t1, t2 SemType) SemType {
 		return basicTypeUnion(all)
 	}
 	var subtypes []basicSubtype
-	for pair := range newSubtypePairs(t1, t2, some) {
+	it := newSubtypePairs(t1, t2, some)
+	for it.hasNext() {
+		pair := it.next()
 		code := pair.BasicTypeCode
 		data1 := pair.SubtypeData1
 		data2 := pair.SubtypeData2
@@ -286,7 +278,6 @@ func IsNever(t SemType) bool {
 }
 
 func IsEmpty(cx Context, t SemType) bool {
-	common.Assert(t != nil && cx != nil)
 	if b, ok := t.(BasicTypeBitSet); ok {
 		return b.all() == 0
 	} else {
@@ -294,10 +285,13 @@ func IsEmpty(cx Context, t SemType) bool {
 		if ct.all() != 0 {
 			return false
 		}
-		for _, st := range getUnpackComplexSemType(ct) {
-			if !ops[st.BasicTypeCode.Code()].IsEmpty(cx, st.SubtypeData) {
+		some := ct.some()
+		for _, data := range ct.subtypeDataList() {
+			code := basicTypeCodeFrom(bits.TrailingZeros(uint(some)))
+			if !ops[code.Code()].IsEmpty(cx, data) {
 				return false
 			}
+			some &^= 1 << code.Code()
 		}
 		return true
 	}

--- a/semtypes/subtype_pairs.go
+++ b/semtypes/subtype_pairs.go
@@ -17,7 +17,7 @@
 package semtypes
 
 import (
-	"iter"
+	"math/bits"
 )
 
 type iterState byte
@@ -30,24 +30,16 @@ const (
 
 type subtypePairIterator struct {
 	cache subtypePair
-	t1    []basicSubtype
-	t2    []basicSubtype
+	list1 []ProperSubtypeData
+	list2 []ProperSubtypeData
+	some1 BasicTypeBitSet
+	some2 BasicTypeBitSet
 	bits  BasicTypeBitSet
-	i1    int
-	i2    int
 	state iterState
 }
 
 func (i *subtypePairIterator) include(code BasicTypeCode) bool {
 	return (i.bits.all() & (1 << code.Code())) != 0
-}
-
-func (i *subtypePairIterator) get1() basicSubtype {
-	return i.t1[i.i1]
-}
-
-func (i *subtypePairIterator) get2() basicSubtype {
-	return i.t2[i.i2]
 }
 
 func (i *subtypePairIterator) hasNext() bool {
@@ -71,80 +63,72 @@ func (i *subtypePairIterator) next() subtypePair {
 	return i.cache
 }
 
+func (i *subtypePairIterator) advance1() (BasicTypeCode, SubtypeData) {
+	code := basicTypeCodeFrom(bits.TrailingZeros(uint(i.some1)))
+	data := i.list1[0]
+	i.list1 = i.list1[1:]
+	i.some1 &^= 1 << code.Code()
+	return code, data
+}
+
+func (i *subtypePairIterator) advance2() (BasicTypeCode, SubtypeData) {
+	code := basicTypeCodeFrom(bits.TrailingZeros(uint(i.some2)))
+	data := i.list2[0]
+	i.list2 = i.list2[1:]
+	i.some2 &^= 1 << code.Code()
+	return code, data
+}
+
 func (i *subtypePairIterator) internalNext() (subtypePair, bool) {
 	for {
-		if i.i1 >= len(i.t1) {
-			if i.i2 >= len(i.t2) {
-				break
-			}
-			t := i.get2()
-			code := t.BasicTypeCode
-			data2 := t.SubtypeData
-			i.i2++
+		has1 := i.some1 != 0
+		has2 := i.some2 != 0
+		if !has1 && !has2 {
+			return subtypePair{}, false
+		}
+		if !has1 {
+			code, data2 := i.advance2()
 			if i.include(code) {
 				return createSubTypePair(code, nil, data2), true
 			}
-		} else if i.i2 >= len(i.t2) {
-			t := i.get1()
-			code := t.BasicTypeCode
-			data1 := t.SubtypeData
-			i.i1++
+		} else if !has2 {
+			code, data1 := i.advance1()
 			if i.include(code) {
 				return createSubTypePair(code, data1, nil), true
 			}
 		} else {
-			t1 := i.get1()
-			code1 := t1.BasicTypeCode
-			data1 := t1.SubtypeData
-
-			t2 := i.get2()
-			code2 := t2.BasicTypeCode
-			data2 := t2.SubtypeData
+			code1 := basicTypeCodeFrom(bits.TrailingZeros(uint(i.some1)))
+			code2 := basicTypeCodeFrom(bits.TrailingZeros(uint(i.some2)))
 			if code1 == code2 {
-				i.i1++
-				i.i2++
+				_, data1 := i.advance1()
+				_, data2 := i.advance2()
 				if i.include(code1) {
 					return createSubTypePair(code1, data1, data2), true
 				}
 			} else if code1.Code() < code2.Code() {
-				i.i1++
+				_, data1 := i.advance1()
 				if i.include(code1) {
 					return createSubTypePair(code1, data1, nil), true
 				}
 			} else {
-				i.i2++
+				_, data2 := i.advance2()
 				if i.include(code2) {
 					return createSubTypePair(code2, nil, data2), true
 				}
 			}
 		}
 	}
-	return subtypePair{}, false
 }
 
-func (i *subtypePairIterator) toIterator() iter.Seq[subtypePair] {
-	return func(yield func(subtypePair) bool) {
-		for i.hasNext() {
-			if !yield(i.next()) {
-				break
-			}
-		}
+func newSubtypePairs(s1, s2 SemType, b BasicTypeBitSet) subtypePairIterator {
+	it := subtypePairIterator{bits: b, state: iterNeedsCalc}
+	if ct1, ok := s1.(*ComplexSemType); ok {
+		it.list1 = ct1.subtypeDataList()
+		it.some1 = ct1.some()
 	}
-}
-
-func newSubtypePairs(s1, s2 SemType, bits BasicTypeBitSet) iter.Seq[subtypePair] {
-	i := subtypePairIterator{
-		t1:    unpackToBasicSubtypes(s1),
-		t2:    unpackToBasicSubtypes(s2),
-		bits:  bits,
-		state: iterNeedsCalc,
+	if ct2, ok := s2.(*ComplexSemType); ok {
+		it.list2 = ct2.subtypeDataList()
+		it.some2 = ct2.some()
 	}
-	return i.toIterator()
-}
-
-func unpackToBasicSubtypes(t SemType) []basicSubtype {
-	if _, ok := t.(BasicTypeBitSet); ok {
-		return nil
-	}
-	return getUnpackComplexSemType(t.(*ComplexSemType))
+	return it
 }


### PR DESCRIPTION
## Purpose
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal rework of subtype iteration and complex-type processing for more efficient memory use and iteration logic, reducing intermediate allocations.
  * Removed redundant runtime assertions and streamlined emptiness checks.
  * No user-facing behavior changes; compatibility and external APIs remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->