### PR TITLE
Enable ST1006 and replace generic "this" receivers with concise names

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,8 +26,6 @@ linters:
         - -ST1020
         - -ST1021
         - -ST1022
-        # receiver name should be a reflection of its identity; don't use generic names such as "this" or "self"
-        - -ST1006
 
   disable:
     - unused

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -561,20 +561,20 @@ func (b *BLangService) IsPublic() bool        { return false }
 func (b *BLangInvocation) IsPublic() bool     { return false }
 func (b *BLangMemberTypeDesc) IsPublic() bool { return false }
 
-func (this *bLangNodeBase) SetDeterminedType(ty semtypes.SemType) {
-	this.DeterminedType = ty
+func (b *bLangNodeBase) SetDeterminedType(ty semtypes.SemType) {
+	b.DeterminedType = ty
 }
 
-func (this *bLangNodeBase) GetDeterminedType() semtypes.SemType {
-	return this.DeterminedType
+func (b *bLangNodeBase) GetDeterminedType() semtypes.SemType {
+	return b.DeterminedType
 }
 
-func (this *bLangNodeBase) GetPosition() diagnostics.Location {
-	return this.pos
+func (b *bLangNodeBase) GetPosition() diagnostics.Location {
+	return b.pos
 }
 
-func (this *bLangNodeBase) SetPosition(pos diagnostics.Location) {
-	this.pos = pos
+func (b *bLangNodeBase) SetPosition(pos diagnostics.Location) {
+	b.pos = pos
 }
 
 func (n *BLangClassDefinition) Symbol() model.SymbolRef {
@@ -689,201 +689,201 @@ var (
 	_ BNodeWithSymbol = &BLangTypeDefinition{}
 )
 
-func (this *BLangAnnotationAttachment) GetKind() model.NodeKind {
+func (b *BLangAnnotationAttachment) GetKind() model.NodeKind {
 	// migrated from BLangAnnotationAttachment.java:89:5
 	return model.NodeKind_ANNOTATION_ATTACHMENT
 }
 
-func (this *BLangAnnotationAttachment) GetPackageAlias() model.IdentifierNode {
-	return this.PkgAlias
+func (b *BLangAnnotationAttachment) GetPackageAlias() model.IdentifierNode {
+	return b.PkgAlias
 }
 
-func (this *BLangAnnotationAttachment) SetPackageAlias(pkgAlias model.IdentifierNode) {
+func (b *BLangAnnotationAttachment) SetPackageAlias(pkgAlias model.IdentifierNode) {
 	if id, ok := pkgAlias.(*BLangIdentifier); ok {
-		this.PkgAlias = id
+		b.PkgAlias = id
 	} else {
 		panic("pkgAlias is not a BLangIdentifier")
 	}
 }
 
-func (this *BLangAnnotationAttachment) GetAnnotationName() model.IdentifierNode {
-	return this.AnnotationName
+func (b *BLangAnnotationAttachment) GetAnnotationName() model.IdentifierNode {
+	return b.AnnotationName
 }
 
-func (this *BLangAnnotationAttachment) SetAnnotationName(name model.IdentifierNode) {
+func (b *BLangAnnotationAttachment) SetAnnotationName(name model.IdentifierNode) {
 	if id, ok := name.(*BLangIdentifier); ok {
-		this.AnnotationName = id
+		b.AnnotationName = id
 	} else {
 		panic("name is not a BLangIdentifier")
 	}
 }
 
-func (this *BLangAnnotationAttachment) GetExpressionNode() model.ExpressionNode {
-	return this.Expr
+func (b *BLangAnnotationAttachment) GetExpressionNode() model.ExpressionNode {
+	return b.Expr
 }
 
-func (this *BLangAnnotationAttachment) SetExpressionNode(expr model.ExpressionNode) {
+func (b *BLangAnnotationAttachment) SetExpressionNode(expr model.ExpressionNode) {
 	if expr, ok := expr.(BLangExpression); ok {
-		this.Expr = expr
+		b.Expr = expr
 	} else {
 		panic("expr is not a BLangExpression")
 	}
 }
 
-func (this *BLangAnnotation) GetKind() model.NodeKind {
+func (b *BLangAnnotation) GetKind() model.NodeKind {
 	// migrated from BLangAnnotation.java:135:5
 	return model.NodeKind_ANNOTATION
 }
 
-func (this *BLangAnnotation) GetName() model.IdentifierNode {
+func (b *BLangAnnotation) GetName() model.IdentifierNode {
 	// migrated from BLangAnnotation.java:80:5
-	return this.Name
+	return b.Name
 }
 
-func (this *BLangAnnotation) SetName(name model.IdentifierNode) {
+func (b *BLangAnnotation) SetName(name model.IdentifierNode) {
 	// migrated from BLangAnnotation.java:85:5
 	if id, ok := name.(*BLangIdentifier); ok {
-		this.Name = id
+		b.Name = id
 		return
 	}
 	panic("name is not a BLangIdentifier")
 }
 
-func (this *BLangAnnotation) GetTypeDescriptor() model.TypeDescriptor {
-	return this.typeDescriptor
+func (b *BLangAnnotation) GetTypeDescriptor() model.TypeDescriptor {
+	return b.typeDescriptor
 }
 
-func (this *BLangAnnotation) SetTypeDescriptor(typeDescriptor model.TypeDescriptor) {
-	this.typeDescriptor = typeDescriptor
+func (b *BLangAnnotation) SetTypeDescriptor(typeDescriptor model.TypeDescriptor) {
+	b.typeDescriptor = typeDescriptor
 }
 
-func (this *BLangAnnotation) GetAnnotationAttachments() []model.AnnotationAttachmentNode {
+func (b *BLangAnnotation) GetAnnotationAttachments() []model.AnnotationAttachmentNode {
 	// migrated from BLangAnnotation.java:100:5
-	attachments := make([]model.AnnotationAttachmentNode, len(this.AnnAttachments))
-	for i, attachment := range this.AnnAttachments {
+	attachments := make([]model.AnnotationAttachmentNode, len(b.AnnAttachments))
+	for i, attachment := range b.AnnAttachments {
 		attachments[i] = &attachment
 	}
 	return attachments
 }
 
-func (this *BLangAnnotation) AddAnnotationAttachment(annAttachment model.AnnotationAttachmentNode) {
+func (b *BLangAnnotation) AddAnnotationAttachment(annAttachment model.AnnotationAttachmentNode) {
 	// migrated from BLangAnnotation.java:105:5
 	if annAttachment, ok := annAttachment.(*BLangAnnotationAttachment); ok {
-		this.AnnAttachments = append(this.AnnAttachments, *annAttachment)
+		b.AnnAttachments = append(b.AnnAttachments, *annAttachment)
 		return
 	}
 	panic("annAttachment is not a BLangAnnotationAttachment")
 }
 
-func (this *BLangAnnotation) GetMarkdownDocumentationAttachment() model.MarkdownDocumentationNode {
+func (b *BLangAnnotation) GetMarkdownDocumentationAttachment() model.MarkdownDocumentationNode {
 	// migrated from BLangAnnotation.java:110:5
-	return this.MarkdownDocumentationAttachment
+	return b.MarkdownDocumentationAttachment
 }
 
-func (this *BLangAnnotation) SetMarkdownDocumentationAttachment(documentationNode model.MarkdownDocumentationNode) {
+func (b *BLangAnnotation) SetMarkdownDocumentationAttachment(documentationNode model.MarkdownDocumentationNode) {
 	// migrated from BLangAnnotation.java:115:5
 	if documentationNode, ok := documentationNode.(*BLangMarkdownDocumentation); ok {
-		this.MarkdownDocumentationAttachment = documentationNode
+		b.MarkdownDocumentationAttachment = documentationNode
 		return
 	}
 	panic("documentationNode is not a BLangMarkdownDocumentation")
 }
 
-func (this *BLangBlockFunctionBody) GetKind() model.NodeKind {
+func (b *BLangBlockFunctionBody) GetKind() model.NodeKind {
 	// migrated from BLangBlockFunctionBody.java:73:5
 	return model.NodeKind_BLOCK_FUNCTION_BODY
 }
 
-func (this *BLangExternFunctionBody) GetKind() model.NodeKind {
+func (b *BLangExternFunctionBody) GetKind() model.NodeKind {
 	return model.NodeKind_EXTERN_FUNCTION_BODY
 }
 
-func (this *BLangExprFunctionBody) GetKind() model.NodeKind {
+func (b *BLangExprFunctionBody) GetKind() model.NodeKind {
 	// migrated from BLangExprFunctionBody.java:50:5
 	return model.NodeKind_EXPR_FUNCTION_BODY
 }
 
-func (this *BLangExprFunctionBody) GetExpr() model.ExpressionNode {
+func (b *BLangExprFunctionBody) GetExpr() model.ExpressionNode {
 	// migrated from BLangExprFunctionBody.java:55:5
-	return this.Expr
+	return b.Expr
 }
 
-func (this *BLangIdentifier) GetValue() string {
+func (b *BLangIdentifier) GetValue() string {
 	// migrated from BLangIdentifier.java:32:5
-	return this.Value
+	return b.Value
 }
 
-func (this *BLangIdentifier) GetKind() model.NodeKind {
+func (b *BLangIdentifier) GetKind() model.NodeKind {
 	// migrated from BLangIdentifier.java:32:5
 	return model.NodeKind_IDENTIFIER
 }
 
-func (this *BLangIdentifier) SetValue(value string) {
+func (b *BLangIdentifier) SetValue(value string) {
 	// migrated from BLangIdentifier.java:37:5
-	this.Value = value
+	b.Value = value
 }
 
-func (this *BLangIdentifier) SetOriginalValue(value string) {
+func (b *BLangIdentifier) SetOriginalValue(value string) {
 	// migrated from BLangIdentifier.java:42:5
-	this.OriginalValue = value
+	b.OriginalValue = value
 }
 
-func (this *BLangIdentifier) IsLiteral() bool {
+func (b *BLangIdentifier) IsLiteral() bool {
 	// migrated from BLangIdentifier.java:47:5
-	return this.isLiteral
+	return b.isLiteral
 }
 
-func (this *BLangIdentifier) SetLiteral(isLiteral bool) {
+func (b *BLangIdentifier) SetLiteral(isLiteral bool) {
 	// migrated from BLangIdentifier.java:52:5
-	this.isLiteral = isLiteral
+	b.isLiteral = isLiteral
 }
 
-func (this *BLangImportPackage) GetKind() model.NodeKind {
+func (b *BLangImportPackage) GetKind() model.NodeKind {
 	return model.NodeKind_IMPORT
 }
 
-func (this *BLangImportPackage) GetOrgName() model.IdentifierNode {
-	return this.OrgName
+func (b *BLangImportPackage) GetOrgName() model.IdentifierNode {
+	return b.OrgName
 }
 
-func (this *BLangImportPackage) GetPackageName() []model.IdentifierNode {
-	result := make([]model.IdentifierNode, len(this.PkgNameComps))
-	for i := range this.PkgNameComps {
-		result[i] = &this.PkgNameComps[i]
+func (b *BLangImportPackage) GetPackageName() []model.IdentifierNode {
+	result := make([]model.IdentifierNode, len(b.PkgNameComps))
+	for i := range b.PkgNameComps {
+		result[i] = &b.PkgNameComps[i]
 	}
 	return result
 }
 
-func (this *BLangImportPackage) SetPackageName(nameParts []model.IdentifierNode) {
-	this.PkgNameComps = make([]BLangIdentifier, 0, len(nameParts))
+func (b *BLangImportPackage) SetPackageName(nameParts []model.IdentifierNode) {
+	b.PkgNameComps = make([]BLangIdentifier, 0, len(nameParts))
 	for _, namePart := range nameParts {
 		if id, ok := namePart.(*BLangIdentifier); ok {
-			this.PkgNameComps = append(this.PkgNameComps, *id)
+			b.PkgNameComps = append(b.PkgNameComps, *id)
 		} else {
 			panic("namePart is not a BLangIdentifier")
 		}
 	}
 }
 
-func (this *BLangImportPackage) GetPackageVersion() model.IdentifierNode {
-	return this.Version
+func (b *BLangImportPackage) GetPackageVersion() model.IdentifierNode {
+	return b.Version
 }
 
-func (this *BLangImportPackage) SetPackageVersion(version model.IdentifierNode) {
+func (b *BLangImportPackage) SetPackageVersion(version model.IdentifierNode) {
 	if id, ok := version.(*BLangIdentifier); ok {
-		this.Version = id
+		b.Version = id
 	} else {
 		panic("version is not a BLangIdentifier")
 	}
 }
 
-func (this *BLangImportPackage) GetAlias() model.IdentifierNode {
-	return this.Alias
+func (b *BLangImportPackage) GetAlias() model.IdentifierNode {
+	return b.Alias
 }
 
-func (this *BLangImportPackage) SetAlias(alias model.IdentifierNode) {
+func (b *BLangImportPackage) SetAlias(alias model.IdentifierNode) {
 	if id, ok := alias.(*BLangIdentifier); ok {
-		this.Alias = id
+		b.Alias = id
 	} else {
 		panic("alias is not a BLangIdentifier")
 	}
@@ -897,29 +897,29 @@ func NewBLangClassDefinition() BLangClassDefinition {
 	return this
 }
 
-func (this *BLangClassDefinition) PopUnresolvedInclusions() []*BLangUserDefinedType {
-	inclusions := this.unresolvedInclusions
-	this.unresolvedInclusions = nil
+func (b *BLangClassDefinition) PopUnresolvedInclusions() []*BLangUserDefinedType {
+	inclusions := b.unresolvedInclusions
+	b.unresolvedInclusions = nil
 	return inclusions
 }
 
-func (this *BLangClassDefinition) GetName() model.IdentifierNode {
+func (b *BLangClassDefinition) GetName() model.IdentifierNode {
 	// migrated from BLangClassDefinition.java:88:5
-	return this.Name
+	return b.Name
 }
 
-func (this *BLangClassDefinition) SetName(name model.IdentifierNode) {
+func (b *BLangClassDefinition) SetName(name model.IdentifierNode) {
 	// migrated from BLangClassDefinition.java:93:5
 	if id, ok := name.(*BLangIdentifier); ok {
-		this.Name = id
+		b.Name = id
 		return
 	}
 	panic("name is not a BLangIdentifier")
 }
 
-func (this *BLangClassDefinition) GetMethods() iter.Seq2[string, model.FunctionNode] {
+func (b *BLangClassDefinition) GetMethods() iter.Seq2[string, model.FunctionNode] {
 	return func(yield func(string, model.FunctionNode) bool) {
-		for name, method := range this.Methods {
+		for name, method := range b.Methods {
 			if !yield(name, method) {
 				return
 			}
@@ -927,426 +927,426 @@ func (this *BLangClassDefinition) GetMethods() iter.Seq2[string, model.FunctionN
 	}
 }
 
-func (this *BLangClassDefinition) GetMethod(name string) model.FunctionNode {
-	if method, ok := this.Methods[name]; ok {
+func (b *BLangClassDefinition) GetMethod(name string) model.FunctionNode {
+	if method, ok := b.Methods[name]; ok {
 		return method
 	}
 	return nil
 }
 
-func (this *BLangClassDefinition) AddMethod(name string, function *BLangFunction) {
-	if this.Methods == nil {
-		this.Methods = map[string]*BLangFunction{}
+func (b *BLangClassDefinition) AddMethod(name string, function *BLangFunction) {
+	if b.Methods == nil {
+		b.Methods = map[string]*BLangFunction{}
 	}
-	this.Methods[name] = function
+	b.Methods[name] = function
 }
 
-func (this *BLangClassDefinition) GetInitFunction() model.FunctionNode {
+func (b *BLangClassDefinition) GetInitFunction() model.FunctionNode {
 	// migrated from BLangClassDefinition.java:108:5
-	return this.InitFunction
+	return b.InitFunction
 }
 
-func (this *BLangClassDefinition) AddField(field model.VariableNode) {
+func (b *BLangClassDefinition) AddField(field model.VariableNode) {
 	// migrated from BLangClassDefinition.java:113:5
 	if field, ok := field.(*BLangSimpleVariable); ok {
-		this.Fields = append(this.Fields, field)
+		b.Fields = append(b.Fields, field)
 		return
 	}
 	panic("field is not a BLangSimpleVariable")
 }
 
-func (this *BLangClassDefinition) AddInclusion(symbolRef model.SymbolRef) {
-	this.Inclusions = append(this.Inclusions, symbolRef)
+func (b *BLangClassDefinition) AddInclusion(symbolRef model.SymbolRef) {
+	b.Inclusions = append(b.Inclusions, symbolRef)
 }
 
-func (this *BLangClassDefinition) GetKind() model.NodeKind {
+func (b *BLangClassDefinition) GetKind() model.NodeKind {
 	// migrated from BLangClassDefinition.java:138:5
 	return model.NodeKind_CLASS_DEFN
 }
 
-func (this *BLangClassDefinition) GetAnnotationAttachments() []model.AnnotationAttachmentNode {
+func (b *BLangClassDefinition) GetAnnotationAttachments() []model.AnnotationAttachmentNode {
 	// migrated from BLangClassDefinition.java:168:5
-	attachments := make([]model.AnnotationAttachmentNode, len(this.AnnAttachments))
-	for i, attachment := range this.AnnAttachments {
+	attachments := make([]model.AnnotationAttachmentNode, len(b.AnnAttachments))
+	for i, attachment := range b.AnnAttachments {
 		attachments[i] = &attachment
 	}
 	return attachments
 }
 
-func (this *BLangClassDefinition) AddAnnotationAttachment(annAttachment model.AnnotationAttachmentNode) {
+func (b *BLangClassDefinition) AddAnnotationAttachment(annAttachment model.AnnotationAttachmentNode) {
 	// migrated from BLangClassDefinition.java:173:5
 	if annAttachment, ok := annAttachment.(*BLangAnnotationAttachment); ok {
-		this.AnnAttachments = append(this.AnnAttachments, *annAttachment)
+		b.AnnAttachments = append(b.AnnAttachments, *annAttachment)
 		return
 	}
 	panic("annAttachment is not a BLangAnnotationAttachment")
 }
 
-func (this *BLangClassDefinition) GetMarkdownDocumentationAttachment() model.MarkdownDocumentationNode {
+func (b *BLangClassDefinition) GetMarkdownDocumentationAttachment() model.MarkdownDocumentationNode {
 	// migrated from BLangClassDefinition.java:178:5
-	return this.MarkdownDocumentationAttachment
+	return b.MarkdownDocumentationAttachment
 }
 
-func (this *BLangClassDefinition) SetMarkdownDocumentationAttachment(documentationNode model.MarkdownDocumentationNode) {
+func (b *BLangClassDefinition) SetMarkdownDocumentationAttachment(documentationNode model.MarkdownDocumentationNode) {
 	// migrated from BLangClassDefinition.java:183:5
 	if documentationNode, ok := documentationNode.(*BLangMarkdownDocumentation); ok {
-		this.MarkdownDocumentationAttachment = documentationNode
+		b.MarkdownDocumentationAttachment = documentationNode
 		return
 	}
 	panic("documentationNode is not a BLangMarkdownDocumentation")
 }
 
-func (this *BLangClassDefinition) GetPrecedence() int {
-	return this.precedence
+func (b *BLangClassDefinition) GetPrecedence() int {
+	return b.precedence
 }
 
-func (this *BLangClassDefinition) SetPrecedence(precedence int) {
-	this.precedence = precedence
+func (b *BLangClassDefinition) SetPrecedence(precedence int) {
+	b.precedence = precedence
 }
 
-func (this *BLangClassDefinition) GetTypeData() model.TypeData {
-	return this.typeData
+func (b *BLangClassDefinition) GetTypeData() model.TypeData {
+	return b.typeData
 }
 
-func (this *BLangClassDefinition) SetTypeData(typeData model.TypeData) {
-	this.typeData = typeData
+func (b *BLangClassDefinition) SetTypeData(typeData model.TypeData) {
+	b.typeData = typeData
 }
 
-func (this *BLangClassDefinition) GetCycleDepth() int {
-	return this.CycleDepth
+func (b *BLangClassDefinition) GetCycleDepth() int {
+	return b.CycleDepth
 }
 
-func (this *BLangClassDefinition) SetCycleDepth(depth int) {
-	this.CycleDepth = depth
+func (b *BLangClassDefinition) SetCycleDepth(depth int) {
+	b.CycleDepth = depth
 }
 
-func (this *BLangCompilationUnit) AddTopLevelNode(node model.TopLevelNode) {
+func (b *BLangCompilationUnit) AddTopLevelNode(node model.TopLevelNode) {
 	// migrated from BLangCompilationUnit.java:48:5
-	this.TopLevelNodes = append(this.TopLevelNodes, node)
+	b.TopLevelNodes = append(b.TopLevelNodes, node)
 }
 
-func (this *BLangCompilationUnit) GetTopLevelNodes() []model.TopLevelNode {
+func (b *BLangCompilationUnit) GetTopLevelNodes() []model.TopLevelNode {
 	// migrated from BLangCompilationUnit.java:53:5
-	return this.TopLevelNodes
+	return b.TopLevelNodes
 }
 
-func (this *BLangCompilationUnit) GetName() string {
+func (b *BLangCompilationUnit) GetName() string {
 	// migrated from BLangCompilationUnit.java:58:5
-	return this.Name
+	return b.Name
 }
 
-func (this *BLangCompilationUnit) SetName(name string) {
+func (b *BLangCompilationUnit) SetName(name string) {
 	// migrated from BLangCompilationUnit.java:63:5
-	this.Name = name
+	b.Name = name
 }
 
-func (this *BLangCompilationUnit) GetPackageID() *model.PackageID {
+func (b *BLangCompilationUnit) GetPackageID() *model.PackageID {
 	// migrated from BLangCompilationUnit.java:68:5
-	return this.packageID
+	return b.packageID
 }
 
-func (this *BLangCompilationUnit) SetPackageID(packageID *model.PackageID) {
+func (b *BLangCompilationUnit) SetPackageID(packageID *model.PackageID) {
 	// migrated from BLangCompilationUnit.java:72:5
-	this.packageID = packageID
+	b.packageID = packageID
 }
 
-func (this *BLangCompilationUnit) GetKind() model.NodeKind {
+func (b *BLangCompilationUnit) GetKind() model.NodeKind {
 	// migrated from BLangCompilationUnit.java:76:5
 	return model.NodeKind_COMPILATION_UNIT
 }
 
-func (this *BLangCompilationUnit) SetSourceKind(kind SourceKind) {
+func (b *BLangCompilationUnit) SetSourceKind(kind SourceKind) {
 	// migrated from BLangCompilationUnit.java:81:5
-	this.sourceKind = kind
+	b.sourceKind = kind
 }
 
-func (this *BLangCompilationUnit) GetSourceKind() SourceKind {
+func (b *BLangCompilationUnit) GetSourceKind() SourceKind {
 	// migrated from BLangCompilationUnit.java:86:5
-	return this.sourceKind
+	return b.sourceKind
 }
 
-func (this *BLangConstant) GetName() model.IdentifierNode {
-	return this.Name
+func (b *BLangConstant) GetName() model.IdentifierNode {
+	return b.Name
 }
 
-func (this *BLangConstant) SetName(name model.IdentifierNode) {
+func (b *BLangConstant) SetName(name model.IdentifierNode) {
 	if id, ok := name.(*BLangIdentifier); ok {
-		this.Name = id
+		b.Name = id
 		return
 	}
 	panic("name is not a BLangIdentifier")
 }
 
-func (this *BLangConstant) GetAnnotationAttachments() []model.AnnotationAttachmentNode {
+func (b *BLangConstant) GetAnnotationAttachments() []model.AnnotationAttachmentNode {
 	// migrated from BLangConstant.java:88:5
-	return this.AnnAttachments
+	return b.AnnAttachments
 }
 
-func (this *BLangConstant) AddAnnotationAttachment(annAttachment model.AnnotationAttachmentNode) {
+func (b *BLangConstant) AddAnnotationAttachment(annAttachment model.AnnotationAttachmentNode) {
 	// migrated from BLangConstant.java:93:5
 	if annAttachment, ok := annAttachment.(*BLangAnnotationAttachment); ok {
-		this.AnnAttachments = append(this.AnnAttachments, annAttachment)
+		b.AnnAttachments = append(b.AnnAttachments, annAttachment)
 		return
 	}
 	panic("annAttachment is not a BLangAnnotationAttachment")
 }
 
-func (this *BLangConstant) GetMarkdownDocumentationAttachment() model.MarkdownDocumentationNode {
+func (b *BLangConstant) GetMarkdownDocumentationAttachment() model.MarkdownDocumentationNode {
 	// migrated from BLangConstant.java:98:5
-	return this.MarkdownDocumentationAttachment
+	return b.MarkdownDocumentationAttachment
 }
 
-func (this *BLangConstant) SetMarkdownDocumentationAttachment(documentationNode model.MarkdownDocumentationNode) {
+func (b *BLangConstant) SetMarkdownDocumentationAttachment(documentationNode model.MarkdownDocumentationNode) {
 	// migrated from BLangConstant.java:103:5
 	if documentationNode, ok := documentationNode.(*BLangMarkdownDocumentation); ok {
-		this.MarkdownDocumentationAttachment = documentationNode
+		b.MarkdownDocumentationAttachment = documentationNode
 		return
 	}
 	panic("documentationNode is not a BLangMarkdownDocumentation")
 }
 
-func (this *BLangConstant) GetKind() model.NodeKind {
+func (b *BLangConstant) GetKind() model.NodeKind {
 	// migrated from BLangConstant.java:108:5
 	return model.NodeKind_CONSTANT
 }
 
-func (this *BLangConstant) GetAssociatedType() semtypes.SemType {
-	if this.TypeNode() != nil {
-		return this.TypeNode().GetTypeData().Type
+func (b *BLangConstant) GetAssociatedType() semtypes.SemType {
+	if b.TypeNode() != nil {
+		return b.TypeNode().GetTypeData().Type
 	}
 	return nil
 }
 
-func (this *BLangConstant) GetPrecedence() int {
+func (b *BLangConstant) GetPrecedence() int {
 	// migrated from BLangConstant.java:144:5
 	return 0
 }
 
-func (this *BLangConstant) SetPrecedence(precedence int) {
+func (b *BLangConstant) SetPrecedence(precedence int) {
 	// migrated from BLangConstant.java:149:5
 }
 
-func (this *BLangSimpleVariable) GetName() model.IdentifierNode {
-	return this.Name
+func (b *BLangSimpleVariable) GetName() model.IdentifierNode {
+	return b.Name
 }
 
-func (this *BLangSimpleVariable) GetKind() model.NodeKind {
+func (b *BLangSimpleVariable) GetKind() model.NodeKind {
 	return model.NodeKind_VARIABLE
 }
 
-func (this *BLangSimpleVariable) SetName(name model.IdentifierNode) {
+func (b *BLangSimpleVariable) SetName(name model.IdentifierNode) {
 	if id, ok := name.(*BLangIdentifier); ok {
-		this.Name = id
+		b.Name = id
 		return
 	}
 	panic("name is not a BLangIdentifier")
 }
 
-func (this *BLangMarkdownDocumentation) GetKind() model.NodeKind {
+func (b *BLangMarkdownDocumentation) GetKind() model.NodeKind {
 	return model.NodeKind_MARKDOWN_DOCUMENTATION
 }
 
-func (this *BLangMarkdownDocumentation) GetDocumentationLines() []model.MarkdownDocumentationTextAttributeNode {
-	result := make([]model.MarkdownDocumentationTextAttributeNode, len(this.DocumentationLines))
-	for i := range this.DocumentationLines {
-		result[i] = &this.DocumentationLines[i]
+func (b *BLangMarkdownDocumentation) GetDocumentationLines() []model.MarkdownDocumentationTextAttributeNode {
+	result := make([]model.MarkdownDocumentationTextAttributeNode, len(b.DocumentationLines))
+	for i := range b.DocumentationLines {
+		result[i] = &b.DocumentationLines[i]
 	}
 	return result
 }
 
-func (this *BLangMarkdownDocumentation) AddDocumentationLine(documentationText model.MarkdownDocumentationTextAttributeNode) {
+func (b *BLangMarkdownDocumentation) AddDocumentationLine(documentationText model.MarkdownDocumentationTextAttributeNode) {
 	if line, ok := documentationText.(*BLangMarkdownDocumentationLine); ok {
-		this.DocumentationLines = append(this.DocumentationLines, *line)
+		b.DocumentationLines = append(b.DocumentationLines, *line)
 	} else {
 		panic("documentationText is not a BLangMarkdownDocumentationLine")
 	}
 }
 
-func (this *BLangMarkdownDocumentation) GetParameters() []model.MarkdownDocumentationParameterAttributeNode {
-	result := make([]model.MarkdownDocumentationParameterAttributeNode, len(this.Parameters))
-	for i := range this.Parameters {
-		result[i] = &this.Parameters[i]
+func (b *BLangMarkdownDocumentation) GetParameters() []model.MarkdownDocumentationParameterAttributeNode {
+	result := make([]model.MarkdownDocumentationParameterAttributeNode, len(b.Parameters))
+	for i := range b.Parameters {
+		result[i] = &b.Parameters[i]
 	}
 	return result
 }
 
-func (this *BLangMarkdownDocumentation) AddParameter(parameter model.MarkdownDocumentationParameterAttributeNode) {
+func (b *BLangMarkdownDocumentation) AddParameter(parameter model.MarkdownDocumentationParameterAttributeNode) {
 	if param, ok := parameter.(*BLangMarkdownParameterDocumentation); ok {
-		this.Parameters = append(this.Parameters, *param)
+		b.Parameters = append(b.Parameters, *param)
 	} else {
 		panic("parameter is not a BLangMarkdownParameterDocumentation")
 	}
 }
 
-func (this *BLangMarkdownDocumentation) GetReturnParameter() model.MarkdownDocumentationReturnParameterAttributeNode {
-	return this.ReturnParameter
+func (b *BLangMarkdownDocumentation) GetReturnParameter() model.MarkdownDocumentationReturnParameterAttributeNode {
+	return b.ReturnParameter
 }
 
-func (this *BLangMarkdownDocumentation) GetDeprecationDocumentation() model.MarkDownDocumentationDeprecationAttributeNode {
-	return this.DeprecationDocumentation
+func (b *BLangMarkdownDocumentation) GetDeprecationDocumentation() model.MarkDownDocumentationDeprecationAttributeNode {
+	return b.DeprecationDocumentation
 }
 
-func (this *BLangMarkdownDocumentation) SetReturnParameter(returnParameter model.MarkdownDocumentationReturnParameterAttributeNode) {
+func (b *BLangMarkdownDocumentation) SetReturnParameter(returnParameter model.MarkdownDocumentationReturnParameterAttributeNode) {
 	if param, ok := returnParameter.(*BLangMarkdownReturnParameterDocumentation); ok {
-		this.ReturnParameter = param
+		b.ReturnParameter = param
 	} else {
 		panic("returnParameter is not a BLangMarkdownReturnParameterDocumentation")
 	}
 }
 
-func (this *BLangMarkdownDocumentation) SetDeprecationDocumentation(deprecationDocumentation model.MarkDownDocumentationDeprecationAttributeNode) {
+func (b *BLangMarkdownDocumentation) SetDeprecationDocumentation(deprecationDocumentation model.MarkDownDocumentationDeprecationAttributeNode) {
 	if doc, ok := deprecationDocumentation.(*BLangMarkDownDeprecationDocumentation); ok {
-		this.DeprecationDocumentation = doc
+		b.DeprecationDocumentation = doc
 	} else {
 		panic("deprecationDocumentation is not a BLangMarkDownDeprecationDocumentation")
 	}
 }
 
-func (this *BLangMarkdownDocumentation) SetDeprecatedParametersDocumentation(deprecatedParametersDocumentation model.MarkDownDocumentationDeprecatedParametersAttributeNode) {
+func (b *BLangMarkdownDocumentation) SetDeprecatedParametersDocumentation(deprecatedParametersDocumentation model.MarkDownDocumentationDeprecatedParametersAttributeNode) {
 	if doc, ok := deprecatedParametersDocumentation.(*BLangMarkDownDeprecatedParametersDocumentation); ok {
-		this.DeprecatedParametersDocumentation = doc
+		b.DeprecatedParametersDocumentation = doc
 	} else {
 		panic("deprecatedParametersDocumentation is not a BLangMarkDownDeprecatedParametersDocumentation")
 	}
 }
 
-func (this *BLangMarkdownDocumentation) GetDeprecatedParametersDocumentation() model.MarkDownDocumentationDeprecatedParametersAttributeNode {
-	return this.DeprecatedParametersDocumentation
+func (b *BLangMarkdownDocumentation) GetDeprecatedParametersDocumentation() model.MarkDownDocumentationDeprecatedParametersAttributeNode {
+	return b.DeprecatedParametersDocumentation
 }
 
-func (this *BLangMarkdownDocumentation) GetDocumentation() string {
+func (b *BLangMarkdownDocumentation) GetDocumentation() string {
 	var lines []string
-	for i := range this.DocumentationLines {
-		lines = append(lines, this.DocumentationLines[i].GetText())
+	for i := range b.DocumentationLines {
+		lines = append(lines, b.DocumentationLines[i].GetText())
 	}
 	result := strings.Join(lines, "\n")
 	return strings.ReplaceAll(result, "\r", "")
 }
 
-func (this *BLangMarkdownDocumentation) GetParameterDocumentations() map[string]model.MarkdownDocumentationParameterAttributeNode {
+func (b *BLangMarkdownDocumentation) GetParameterDocumentations() map[string]model.MarkdownDocumentationParameterAttributeNode {
 	result := make(map[string]model.MarkdownDocumentationParameterAttributeNode)
-	for _, parameter := range this.Parameters {
+	for _, parameter := range b.Parameters {
 		paramName := parameter.GetParameterName()
 		result[paramName.GetValue()] = &parameter
 	}
 	return result
 }
 
-func (this *BLangMarkdownDocumentation) GetReturnParameterDocumentation() *string {
-	if this.ReturnParameter == nil {
+func (b *BLangMarkdownDocumentation) GetReturnParameterDocumentation() *string {
+	if b.ReturnParameter == nil {
 		return nil
 	}
-	return new(this.ReturnParameter.GetReturnParameterDocumentation())
+	return new(b.ReturnParameter.GetReturnParameterDocumentation())
 }
 
-func (this *BLangMarkdownDocumentation) GetReferences() []model.MarkdownDocumentationReferenceAttributeNode {
-	result := make([]model.MarkdownDocumentationReferenceAttributeNode, len(this.References))
-	for i := range this.References {
-		result[i] = &this.References[i]
+func (b *BLangMarkdownDocumentation) GetReferences() []model.MarkdownDocumentationReferenceAttributeNode {
+	result := make([]model.MarkdownDocumentationReferenceAttributeNode, len(b.References))
+	for i := range b.References {
+		result[i] = &b.References[i]
 	}
 	return result
 }
 
-func (this *BLangMarkdownDocumentation) AddReference(reference model.MarkdownDocumentationReferenceAttributeNode) {
+func (b *BLangMarkdownDocumentation) AddReference(reference model.MarkdownDocumentationReferenceAttributeNode) {
 	if ref, ok := reference.(*BLangMarkdownReferenceDocumentation); ok {
-		this.References = append(this.References, *ref)
+		b.References = append(b.References, *ref)
 	} else {
 		panic("reference is not a BLangMarkdownReferenceDocumentation")
 	}
 }
 
-func (this *BLangMarkdownReferenceDocumentation) GetType() model.DocumentationReferenceType {
-	return this.Type
+func (b *BLangMarkdownReferenceDocumentation) GetType() model.DocumentationReferenceType {
+	return b.Type
 }
 
-func (this *BLangMarkdownReferenceDocumentation) GetKind() model.NodeKind {
+func (b *BLangMarkdownReferenceDocumentation) GetKind() model.NodeKind {
 	return model.NodeKind_DOCUMENTATION_REFERENCE
 }
 
 // BLangService methods
 
-func (this *BLangService) GetName() model.IdentifierNode {
-	return this.Name
+func (b *BLangService) GetName() model.IdentifierNode {
+	return b.Name
 }
 
-func (this *BLangService) SetName(name model.IdentifierNode) {
+func (b *BLangService) SetName(name model.IdentifierNode) {
 	if id, ok := name.(*BLangIdentifier); ok {
-		this.Name = id
+		b.Name = id
 	} else {
 		panic("name is not a BLangIdentifier")
 	}
 }
 
-func (this *BLangService) GetResources() []model.FunctionNode {
+func (b *BLangService) GetResources() []model.FunctionNode {
 	return []model.FunctionNode{}
 }
 
-func (this *BLangService) IsAnonymousService() bool {
+func (b *BLangService) IsAnonymousService() bool {
 	return false
 }
 
-func (this *BLangService) GetAttachedExprs() []model.ExpressionNode {
-	result := make([]model.ExpressionNode, len(this.AttachedExprs))
-	for i := range this.AttachedExprs {
-		result[i] = this.AttachedExprs[i]
+func (b *BLangService) GetAttachedExprs() []model.ExpressionNode {
+	result := make([]model.ExpressionNode, len(b.AttachedExprs))
+	for i := range b.AttachedExprs {
+		result[i] = b.AttachedExprs[i]
 	}
 	return result
 }
 
-func (this *BLangService) GetServiceClass() model.ClassDefinition {
-	return this.ServiceClass
+func (b *BLangService) GetServiceClass() model.ClassDefinition {
+	return b.ServiceClass
 }
 
-func (this *BLangService) GetAbsolutePath() []model.IdentifierNode {
-	return this.AbsoluteResourcePath
+func (b *BLangService) GetAbsolutePath() []model.IdentifierNode {
+	return b.AbsoluteResourcePath
 }
 
-func (this *BLangService) GetServiceNameLiteral() model.LiteralNode {
-	return this.ServiceNameLiteral
+func (b *BLangService) GetServiceNameLiteral() model.LiteralNode {
+	return b.ServiceNameLiteral
 }
 
-func (this *BLangService) GetAnnotationAttachments() []model.AnnotationAttachmentNode {
-	result := make([]model.AnnotationAttachmentNode, len(this.AnnAttachments))
-	for i := range this.AnnAttachments {
-		result[i] = &this.AnnAttachments[i]
+func (b *BLangService) GetAnnotationAttachments() []model.AnnotationAttachmentNode {
+	result := make([]model.AnnotationAttachmentNode, len(b.AnnAttachments))
+	for i := range b.AnnAttachments {
+		result[i] = &b.AnnAttachments[i]
 	}
 	return result
 }
 
-func (this *BLangService) AddAnnotationAttachment(annAttachment model.AnnotationAttachmentNode) {
+func (b *BLangService) AddAnnotationAttachment(annAttachment model.AnnotationAttachmentNode) {
 	if ann, ok := annAttachment.(*BLangAnnotationAttachment); ok {
-		this.AnnAttachments = append(this.AnnAttachments, *ann)
+		b.AnnAttachments = append(b.AnnAttachments, *ann)
 	} else {
 		panic("annAttachment is not a BLangAnnotationAttachment")
 	}
 }
 
-func (this *BLangService) GetMarkdownDocumentationAttachment() model.MarkdownDocumentationNode {
-	return this.MarkdownDocumentationAttachment
+func (b *BLangService) GetMarkdownDocumentationAttachment() model.MarkdownDocumentationNode {
+	return b.MarkdownDocumentationAttachment
 }
 
-func (this *BLangService) SetMarkdownDocumentationAttachment(documentationNode model.MarkdownDocumentationNode) {
+func (b *BLangService) SetMarkdownDocumentationAttachment(documentationNode model.MarkdownDocumentationNode) {
 	if doc, ok := documentationNode.(*BLangMarkdownDocumentation); ok {
-		this.MarkdownDocumentationAttachment = doc
+		b.MarkdownDocumentationAttachment = doc
 	} else {
 		panic("documentationNode is not a BLangMarkdownDocumentation")
 	}
 }
 
-func (this *BLangService) GetKind() model.NodeKind {
+func (b *BLangService) GetKind() model.NodeKind {
 	return model.NodeKind_SERVICE
 }
 
-func (this *BLangFunction) GetKind() model.NodeKind {
+func (b *BLangFunction) GetKind() model.NodeKind {
 	return model.NodeKind_FUNCTION
 }
 
-func (this *BLangFunction) Scope() model.Scope {
-	return this.scope
+func (b *BLangFunction) Scope() model.Scope {
+	return b.scope
 }
 
-func (this *BLangFunction) SetScope(scope model.Scope) {
-	this.scope = scope
+func (b *BLangFunction) SetScope(scope model.Scope) {
+	b.scope = scope
 }
 
 var _ NodeWithScope = &BLangFunction{}
@@ -1523,298 +1523,298 @@ func NewBLangTypeDefinition() *BLangTypeDefinition {
 	return this
 }
 
-func (this *BLangTypeDefinition) GetName() model.IdentifierNode {
-	return this.Name
+func (b *BLangTypeDefinition) GetName() model.IdentifierNode {
+	return b.Name
 }
 
-func (this *BLangTypeDefinition) SetName(name model.IdentifierNode) {
+func (b *BLangTypeDefinition) SetName(name model.IdentifierNode) {
 	if id, ok := name.(*BLangIdentifier); ok {
-		this.Name = id
+		b.Name = id
 	} else {
 		panic("name is not a BLangIdentifier")
 	}
 }
 
-func (this *BLangTypeDefinition) GetTypeData() model.TypeData {
-	return this.typeData
+func (b *BLangTypeDefinition) GetTypeData() model.TypeData {
+	return b.typeData
 }
 
-func (this *BLangTypeDefinition) SetTypeData(typeData model.TypeData) {
-	this.typeData = typeData
+func (b *BLangTypeDefinition) SetTypeData(typeData model.TypeData) {
+	b.typeData = typeData
 }
 
-func (this *BLangTypeDefinition) GetAnnotationAttachments() []model.AnnotationAttachmentNode {
-	result := make([]model.AnnotationAttachmentNode, len(this.annAttachments))
-	for i := range this.annAttachments {
-		result[i] = &this.annAttachments[i]
+func (b *BLangTypeDefinition) GetAnnotationAttachments() []model.AnnotationAttachmentNode {
+	result := make([]model.AnnotationAttachmentNode, len(b.annAttachments))
+	for i := range b.annAttachments {
+		result[i] = &b.annAttachments[i]
 	}
 	return result
 }
 
-func (this *BLangTypeDefinition) AddAnnotationAttachment(annAttachment model.AnnotationAttachmentNode) {
+func (b *BLangTypeDefinition) AddAnnotationAttachment(annAttachment model.AnnotationAttachmentNode) {
 	if ann, ok := annAttachment.(*BLangAnnotationAttachment); ok {
-		this.annAttachments = append(this.annAttachments, *ann)
+		b.annAttachments = append(b.annAttachments, *ann)
 	} else {
 		panic("annAttachment is not a BLangAnnotationAttachment")
 	}
 }
 
-func (this *BLangTypeDefinition) GetMarkdownDocumentationAttachment() model.MarkdownDocumentationNode {
-	return this.markdownDocumentationAttachment
+func (b *BLangTypeDefinition) GetMarkdownDocumentationAttachment() model.MarkdownDocumentationNode {
+	return b.markdownDocumentationAttachment
 }
 
-func (this *BLangTypeDefinition) SetMarkdownDocumentationAttachment(documentationNode model.MarkdownDocumentationNode) {
+func (b *BLangTypeDefinition) SetMarkdownDocumentationAttachment(documentationNode model.MarkdownDocumentationNode) {
 	if doc, ok := documentationNode.(*BLangMarkdownDocumentation); ok {
-		this.markdownDocumentationAttachment = doc
+		b.markdownDocumentationAttachment = doc
 	} else {
 		panic("documentationNode is not a BLangMarkdownDocumentation")
 	}
 }
 
-func (this *BLangTypeDefinition) GetPrecedence() int {
-	return this.precedence
+func (b *BLangTypeDefinition) GetPrecedence() int {
+	return b.precedence
 }
 
-func (this *BLangTypeDefinition) SetPrecedence(precedence int) {
-	this.precedence = precedence
+func (b *BLangTypeDefinition) SetPrecedence(precedence int) {
+	b.precedence = precedence
 }
 
-func (this *BLangTypeDefinition) GetKind() model.NodeKind {
+func (b *BLangTypeDefinition) GetKind() model.NodeKind {
 	return model.NodeKind_TYPE_DEFINITION
 }
 
-func (this *BLangTypeDefinition) GetCycleDepth() int {
-	return this.CycleDepth
+func (b *BLangTypeDefinition) GetCycleDepth() int {
+	return b.CycleDepth
 }
 
-func (this *BLangTypeDefinition) SetCycleDepth(depth int) {
-	this.CycleDepth = depth
+func (b *BLangTypeDefinition) SetCycleDepth(depth int) {
+	b.CycleDepth = depth
 }
 
-func (this *BLangXMLNS) GetNamespaceURI() model.ExpressionNode {
-	return this.namespaceURI
+func (b *BLangXMLNS) GetNamespaceURI() model.ExpressionNode {
+	return b.namespaceURI
 }
 
-func (this *BLangXMLNS) GetPrefix() model.IdentifierNode {
-	return this.prefix
+func (b *BLangXMLNS) GetPrefix() model.IdentifierNode {
+	return b.prefix
 }
 
-func (this *BLangXMLNS) SetNamespaceURI(namespaceURI model.ExpressionNode) {
+func (b *BLangXMLNS) SetNamespaceURI(namespaceURI model.ExpressionNode) {
 	if expr, ok := namespaceURI.(BLangExpression); ok {
-		this.namespaceURI = expr
+		b.namespaceURI = expr
 	} else {
 		panic("namespaceURI is not a BLangExpression")
 	}
 }
 
-func (this *BLangXMLNS) SetPrefix(prefix model.IdentifierNode) {
+func (b *BLangXMLNS) SetPrefix(prefix model.IdentifierNode) {
 	if ident, ok := prefix.(*BLangIdentifier); ok {
-		this.prefix = ident
+		b.prefix = ident
 	} else {
 		panic("prefix is not a BLangIdentifier")
 	}
 }
 
-func (this *BLangXMLNS) GetKind() model.NodeKind {
+func (b *BLangXMLNS) GetKind() model.NodeKind {
 	return model.NodeKind_XMLNS
 }
 
-func (this *BLangPackage) GetCompilationUnits() []model.CompilationUnitNode {
-	result := make([]model.CompilationUnitNode, len(this.CompUnits))
-	for i := range this.CompUnits {
-		result[i] = &this.CompUnits[i]
+func (b *BLangPackage) GetCompilationUnits() []model.CompilationUnitNode {
+	result := make([]model.CompilationUnitNode, len(b.CompUnits))
+	for i := range b.CompUnits {
+		result[i] = &b.CompUnits[i]
 	}
 	return result
 }
 
-func (this *BLangPackage) AddCompilationUnit(compUnit model.CompilationUnitNode) {
+func (b *BLangPackage) AddCompilationUnit(compUnit model.CompilationUnitNode) {
 	if cu, ok := compUnit.(*BLangCompilationUnit); ok {
-		this.CompUnits = append(this.CompUnits, *cu)
+		b.CompUnits = append(b.CompUnits, *cu)
 	} else {
 		panic("compUnit is not a BLangCompilationUnit")
 	}
 }
 
-func (this *BLangPackage) GetImports() []model.ImportPackageNode {
-	result := make([]model.ImportPackageNode, len(this.Imports))
-	for i := range this.Imports {
-		result[i] = &this.Imports[i]
+func (b *BLangPackage) GetImports() []model.ImportPackageNode {
+	result := make([]model.ImportPackageNode, len(b.Imports))
+	for i := range b.Imports {
+		result[i] = &b.Imports[i]
 	}
 	return result
 }
 
-func (this *BLangPackage) AddImport(importPkg model.ImportPackageNode) {
+func (b *BLangPackage) AddImport(importPkg model.ImportPackageNode) {
 	if imp, ok := importPkg.(*BLangImportPackage); ok {
-		this.Imports = append(this.Imports, *imp)
+		b.Imports = append(b.Imports, *imp)
 	} else {
 		panic("importPkg is not a BLangImportPackage")
 	}
 }
 
-func (this *BLangPackage) GetNamespaceDeclarations() []model.XMLNSDeclarationNode {
-	result := make([]model.XMLNSDeclarationNode, len(this.XmlnsList))
-	for i := range this.XmlnsList {
-		result[i] = &this.XmlnsList[i]
+func (b *BLangPackage) GetNamespaceDeclarations() []model.XMLNSDeclarationNode {
+	result := make([]model.XMLNSDeclarationNode, len(b.XmlnsList))
+	for i := range b.XmlnsList {
+		result[i] = &b.XmlnsList[i]
 	}
 	return result
 }
 
-func (this *BLangPackage) AddNamespaceDeclaration(xmlnsDecl model.XMLNSDeclarationNode) {
+func (b *BLangPackage) AddNamespaceDeclaration(xmlnsDecl model.XMLNSDeclarationNode) {
 	if xmlns, ok := xmlnsDecl.(*BLangXMLNS); ok {
-		this.XmlnsList = append(this.XmlnsList, *xmlns)
-		this.TopLevelNodes = append(this.TopLevelNodes, xmlnsDecl)
+		b.XmlnsList = append(b.XmlnsList, *xmlns)
+		b.TopLevelNodes = append(b.TopLevelNodes, xmlnsDecl)
 	} else {
 		panic("xmlnsDecl is not a BLangXMLNS")
 	}
 }
 
-func (this *BLangPackage) GetConstants() []model.ConstantNode {
-	result := make([]model.ConstantNode, len(this.Constants))
-	for i := range this.Constants {
-		result[i] = &this.Constants[i]
+func (b *BLangPackage) GetConstants() []model.ConstantNode {
+	result := make([]model.ConstantNode, len(b.Constants))
+	for i := range b.Constants {
+		result[i] = &b.Constants[i]
 	}
 	return result
 }
 
-func (this *BLangPackage) GetGlobalVariables() []model.VariableNode {
-	result := make([]model.VariableNode, len(this.GlobalVars))
-	for i := range this.GlobalVars {
-		result[i] = &this.GlobalVars[i]
+func (b *BLangPackage) GetGlobalVariables() []model.VariableNode {
+	result := make([]model.VariableNode, len(b.GlobalVars))
+	for i := range b.GlobalVars {
+		result[i] = &b.GlobalVars[i]
 	}
 	return result
 }
 
-func (this *BLangPackage) AddGlobalVariable(globalVar model.SimpleVariableNode) {
+func (b *BLangPackage) AddGlobalVariable(globalVar model.SimpleVariableNode) {
 	if sv, ok := globalVar.(*BLangSimpleVariable); ok {
-		this.GlobalVars = append(this.GlobalVars, *sv)
-		this.TopLevelNodes = append(this.TopLevelNodes, globalVar)
+		b.GlobalVars = append(b.GlobalVars, *sv)
+		b.TopLevelNodes = append(b.TopLevelNodes, globalVar)
 	} else {
 		panic("globalVar is not a BLangSimpleVariable")
 	}
 }
 
-func (this *BLangPackage) GetServices() []model.ServiceNode {
-	result := make([]model.ServiceNode, len(this.Services))
-	for i := range this.Services {
-		result[i] = &this.Services[i]
+func (b *BLangPackage) GetServices() []model.ServiceNode {
+	result := make([]model.ServiceNode, len(b.Services))
+	for i := range b.Services {
+		result[i] = &b.Services[i]
 	}
 	return result
 }
 
-func (this *BLangPackage) AddService(service model.ServiceNode) {
+func (b *BLangPackage) AddService(service model.ServiceNode) {
 	if svc, ok := service.(*BLangService); ok {
-		this.Services = append(this.Services, *svc)
-		this.TopLevelNodes = append(this.TopLevelNodes, service)
+		b.Services = append(b.Services, *svc)
+		b.TopLevelNodes = append(b.TopLevelNodes, service)
 	} else {
 		panic("service is not a BLangService")
 	}
 }
 
-func (this *BLangPackage) GetFunctions() []model.FunctionNode {
-	result := make([]model.FunctionNode, len(this.Functions))
-	for i := range this.Functions {
-		result[i] = &this.Functions[i]
+func (b *BLangPackage) GetFunctions() []model.FunctionNode {
+	result := make([]model.FunctionNode, len(b.Functions))
+	for i := range b.Functions {
+		result[i] = &b.Functions[i]
 	}
 	return result
 }
 
-func (this *BLangPackage) AddFunction(function model.FunctionNode) {
+func (b *BLangPackage) AddFunction(function model.FunctionNode) {
 	if fn, ok := function.(*BLangFunction); ok {
-		this.Functions = append(this.Functions, *fn)
-		this.TopLevelNodes = append(this.TopLevelNodes, function)
+		b.Functions = append(b.Functions, *fn)
+		b.TopLevelNodes = append(b.TopLevelNodes, function)
 	} else {
 		panic("function is not a BLangFunction")
 	}
 }
 
-func (this *BLangPackage) GetTypeDefinitions() []model.TypeDefinition {
-	result := make([]model.TypeDefinition, len(this.TypeDefinitions))
-	for i := range this.TypeDefinitions {
-		result[i] = &this.TypeDefinitions[i]
+func (b *BLangPackage) GetTypeDefinitions() []model.TypeDefinition {
+	result := make([]model.TypeDefinition, len(b.TypeDefinitions))
+	for i := range b.TypeDefinitions {
+		result[i] = &b.TypeDefinitions[i]
 	}
 	return result
 }
 
-func (this *BLangPackage) AddTypeDefinition(typeDefinition model.TypeDefinition) {
+func (b *BLangPackage) AddTypeDefinition(typeDefinition model.TypeDefinition) {
 	if td, ok := typeDefinition.(*BLangTypeDefinition); ok {
-		this.TypeDefinitions = append(this.TypeDefinitions, *td)
-		this.TopLevelNodes = append(this.TopLevelNodes, typeDefinition)
+		b.TypeDefinitions = append(b.TypeDefinitions, *td)
+		b.TopLevelNodes = append(b.TopLevelNodes, typeDefinition)
 	} else {
 		panic("typeDefinition is not a BLangTypeDefinition")
 	}
 }
 
-func (this *BLangPackage) GetAnnotations() []model.AnnotationNode {
-	result := make([]model.AnnotationNode, len(this.Annotations))
-	for i := range this.Annotations {
-		result[i] = &this.Annotations[i]
+func (b *BLangPackage) GetAnnotations() []model.AnnotationNode {
+	result := make([]model.AnnotationNode, len(b.Annotations))
+	for i := range b.Annotations {
+		result[i] = &b.Annotations[i]
 	}
 	return result
 }
 
-func (this *BLangPackage) AddAnnotation(annotation model.AnnotationNode) {
+func (b *BLangPackage) AddAnnotation(annotation model.AnnotationNode) {
 	if ann, ok := annotation.(*BLangAnnotation); ok {
-		this.Annotations = append(this.Annotations, *ann)
-		this.TopLevelNodes = append(this.TopLevelNodes, annotation)
+		b.Annotations = append(b.Annotations, *ann)
+		b.TopLevelNodes = append(b.TopLevelNodes, annotation)
 	} else {
 		panic("annotation is not a BLangAnnotation")
 	}
 }
 
-func (this *BLangPackage) GetClassDefinitions() []model.ClassDefinition {
-	result := make([]model.ClassDefinition, len(this.ClassDefinitions))
-	for i := range this.ClassDefinitions {
-		result[i] = &this.ClassDefinitions[i]
+func (b *BLangPackage) GetClassDefinitions() []model.ClassDefinition {
+	result := make([]model.ClassDefinition, len(b.ClassDefinitions))
+	for i := range b.ClassDefinitions {
+		result[i] = &b.ClassDefinitions[i]
 	}
 	return result
 }
 
-func (this *BLangPackage) GetKind() model.NodeKind {
+func (b *BLangPackage) GetKind() model.NodeKind {
 	return model.NodeKind_PACKAGE
 }
 
-func (this *BLangPackage) AddTestablePkg(testablePkg *BLangTestablePackage) {
-	this.TestablePkgs = append(this.TestablePkgs, testablePkg)
+func (b *BLangPackage) AddTestablePkg(testablePkg *BLangTestablePackage) {
+	b.TestablePkgs = append(b.TestablePkgs, testablePkg)
 }
 
-func (this *BLangPackage) GetTestablePkgs() []*BLangTestablePackage {
-	return this.TestablePkgs
+func (b *BLangPackage) GetTestablePkgs() []*BLangTestablePackage {
+	return b.TestablePkgs
 }
 
-func (this *BLangPackage) GetTestablePkg() *BLangTestablePackage {
-	if len(this.TestablePkgs) > 0 {
-		return this.TestablePkgs[0]
+func (b *BLangPackage) GetTestablePkg() *BLangTestablePackage {
+	if len(b.TestablePkgs) > 0 {
+		return b.TestablePkgs[0]
 	}
 	return nil
 }
 
-func (this *BLangPackage) ContainsTestablePkg() bool {
-	return len(this.TestablePkgs) > 0
+func (b *BLangPackage) ContainsTestablePkg() bool {
+	return len(b.TestablePkgs) > 0
 }
 
-func (this *BLangPackage) HasTestablePackage() bool {
-	return len(this.TestablePkgs) > 0
+func (b *BLangPackage) HasTestablePackage() bool {
+	return len(b.TestablePkgs) > 0
 }
 
-func (this *BLangPackage) AddClassDefinition(classDefNode *BLangClassDefinition) {
-	this.TopLevelNodes = append(this.TopLevelNodes, classDefNode)
-	this.ClassDefinitions = append(this.ClassDefinitions, *classDefNode)
+func (b *BLangPackage) AddClassDefinition(classDefNode *BLangClassDefinition) {
+	b.TopLevelNodes = append(b.TopLevelNodes, classDefNode)
+	b.ClassDefinitions = append(b.ClassDefinitions, *classDefNode)
 }
 
-func (this *BLangPackage) AddDiagnostic(diagnostic diagnostics.Diagnostic) {
+func (b *BLangPackage) AddDiagnostic(diagnostic diagnostics.Diagnostic) {
 	// Check if diagnostic already exists
-	for _, existing := range this.diagnostics {
+	for _, existing := range b.diagnostics {
 		if diagnosticEqual(existing, diagnostic) {
 			return
 		}
 	}
-	this.diagnostics = append(this.diagnostics, diagnostic)
+	b.diagnostics = append(b.diagnostics, diagnostic)
 	severity := diagnostic.DiagnosticInfo().Severity()
 	switch severity {
 	case diagnostics.Error:
-		this.errorCount++
+		b.errorCount++
 	case diagnostics.Warning:
-		this.warnCount++
+		b.warnCount++
 	}
 }
 
@@ -1826,22 +1826,22 @@ func diagnosticEqual(d1, d2 diagnostics.Diagnostic) bool {
 		info1.Severity() == info2.Severity()
 }
 
-func (this *BLangPackage) GetDiagnostics() []diagnostics.Diagnostic {
-	result := make([]diagnostics.Diagnostic, len(this.diagnostics))
-	copy(result, this.diagnostics)
+func (b *BLangPackage) GetDiagnostics() []diagnostics.Diagnostic {
+	result := make([]diagnostics.Diagnostic, len(b.diagnostics))
+	copy(result, b.diagnostics)
 	return result
 }
 
-func (this *BLangPackage) GetErrorCount() int {
-	return this.errorCount
+func (b *BLangPackage) GetErrorCount() int {
+	return b.errorCount
 }
 
-func (this *BLangPackage) GetWarnCount() int {
-	return this.warnCount
+func (b *BLangPackage) GetWarnCount() int {
+	return b.warnCount
 }
 
-func (this *BLangPackage) HasErrors() bool {
-	return this.errorCount > 0
+func (b *BLangPackage) HasErrors() bool {
+	return b.errorCount > 0
 }
 
 func NewBLangPackage(env semtypes.Env) *BLangPackage {
@@ -1866,26 +1866,26 @@ func NewBLangPackage(env semtypes.Env) *BLangPackage {
 	return this
 }
 
-func (this *BLangTestablePackage) GetMockFunctionNamesMap() map[string]string {
-	return this.mockFunctionNamesMap
+func (b *BLangTestablePackage) GetMockFunctionNamesMap() map[string]string {
+	return b.mockFunctionNamesMap
 }
 
-func (this *BLangTestablePackage) AddMockFunction(id string, function string) {
-	if this.mockFunctionNamesMap == nil {
-		this.mockFunctionNamesMap = make(map[string]string)
+func (b *BLangTestablePackage) AddMockFunction(id string, function string) {
+	if b.mockFunctionNamesMap == nil {
+		b.mockFunctionNamesMap = make(map[string]string)
 	}
-	this.mockFunctionNamesMap[id] = function
+	b.mockFunctionNamesMap[id] = function
 }
 
-func (this *BLangTestablePackage) GetIsLegacyMockingMap() map[string]bool {
-	return this.isLegacyMockingMap
+func (b *BLangTestablePackage) GetIsLegacyMockingMap() map[string]bool {
+	return b.isLegacyMockingMap
 }
 
-func (this *BLangTestablePackage) AddIsLegacyMockingMap(id string, isLegacy bool) {
-	if this.isLegacyMockingMap == nil {
-		this.isLegacyMockingMap = make(map[string]bool)
+func (b *BLangTestablePackage) AddIsLegacyMockingMap(id string, isLegacy bool) {
+	if b.isLegacyMockingMap == nil {
+		b.isLegacyMockingMap = make(map[string]bool)
 	}
-	this.isLegacyMockingMap[id] = isLegacy
+	b.isLegacyMockingMap[id] = isLegacy
 }
 
 func createSimpleVariableNodeWithLocationTokenLocation(location diagnostics.Location, identifier tree.Token, identifierPos diagnostics.Location) *BLangSimpleVariable {

--- a/ast/binding_patterns.go
+++ b/ast/binding_patterns.go
@@ -97,261 +97,261 @@ var (
 	_ BLangNode = &BLangWildCardBindingPattern{}
 )
 
-func (this *BLangCaptureBindingPattern) GetKind() model.NodeKind {
+func (b *BLangCaptureBindingPattern) GetKind() model.NodeKind {
 	// migrated from BLangCaptureBindingPattern.java:55:5
 	return model.NodeKind_CAPTURE_BINDING_PATTERN
 }
 
-func (this *BLangCaptureBindingPattern) GetIdentifier() model.IdentifierNode {
+func (b *BLangCaptureBindingPattern) GetIdentifier() model.IdentifierNode {
 	// migrated from BLangCaptureBindingPattern.java:60:5
-	return &this.Identifier
+	return &b.Identifier
 }
 
-func (this *BLangCaptureBindingPattern) SetIdentifier(identifier model.IdentifierNode) {
+func (b *BLangCaptureBindingPattern) SetIdentifier(identifier model.IdentifierNode) {
 	// migrated from BLangCaptureBindingPattern.java:65:5
 	if id, ok := identifier.(*BLangIdentifier); ok {
-		this.Identifier = *id
+		b.Identifier = *id
 		return
 	}
 	panic("identifier is not a BLangIdentifier")
 }
 
-func (this *BLangErrorBindingPattern) GetKind() model.NodeKind {
+func (b *BLangErrorBindingPattern) GetKind() model.NodeKind {
 	// migrated from BLangErrorBindingPattern.java:59:5
 	return model.NodeKind_ERROR_BINDING_PATTERN
 }
 
-func (this *BLangErrorBindingPattern) GetErrorTypeReference() model.UserDefinedTypeNode {
+func (b *BLangErrorBindingPattern) GetErrorTypeReference() model.UserDefinedTypeNode {
 	// migrated from BLangErrorBindingPattern.java:64:5
-	return this.ErrorTypeReference
+	return b.ErrorTypeReference
 }
 
-func (this *BLangErrorBindingPattern) SetErrorTypeReference(userDefinedTypeNode model.UserDefinedTypeNode) {
+func (b *BLangErrorBindingPattern) SetErrorTypeReference(userDefinedTypeNode model.UserDefinedTypeNode) {
 	// migrated from BLangErrorBindingPattern.java:69:5
 	if userDefinedTypeNode, ok := userDefinedTypeNode.(*BLangUserDefinedType); ok {
-		this.ErrorTypeReference = userDefinedTypeNode
+		b.ErrorTypeReference = userDefinedTypeNode
 		return
 	}
 	panic("userDefinedTypeNode is not a BLangUserDefinedType")
 }
 
-func (this *BLangErrorBindingPattern) GetErrorMessageBindingPatternNode() model.ErrorMessageBindingPatternNode {
+func (b *BLangErrorBindingPattern) GetErrorMessageBindingPatternNode() model.ErrorMessageBindingPatternNode {
 	// migrated from BLangErrorBindingPattern.java:74:5
-	return this.ErrorMessageBindingPattern
+	return b.ErrorMessageBindingPattern
 }
 
-func (this *BLangErrorBindingPattern) SetErrorMessageBindingPatternNode(errorMessageBindingPatternNode model.ErrorMessageBindingPatternNode) {
+func (b *BLangErrorBindingPattern) SetErrorMessageBindingPatternNode(errorMessageBindingPatternNode model.ErrorMessageBindingPatternNode) {
 	// migrated from BLangErrorBindingPattern.java:79:5
 	if errorMessageBindingPatternNode, ok := errorMessageBindingPatternNode.(*BLangErrorMessageBindingPattern); ok {
-		this.ErrorMessageBindingPattern = errorMessageBindingPatternNode
+		b.ErrorMessageBindingPattern = errorMessageBindingPatternNode
 		return
 	}
 	panic("errorMessageBindingPatternNode is not a BLangErrorMessageBindingPattern")
 }
 
-func (this *BLangErrorBindingPattern) GetErrorCauseBindingPatternNode() model.ErrorCauseBindingPatternNode {
+func (b *BLangErrorBindingPattern) GetErrorCauseBindingPatternNode() model.ErrorCauseBindingPatternNode {
 	// migrated from BLangErrorBindingPattern.java:84:5
-	return this.ErrorCauseBindingPattern
+	return b.ErrorCauseBindingPattern
 }
 
-func (this *BLangErrorBindingPattern) SetErrorCauseBindingPatternNode(errorCauseBindingPatternNode model.ErrorCauseBindingPatternNode) {
+func (b *BLangErrorBindingPattern) SetErrorCauseBindingPatternNode(errorCauseBindingPatternNode model.ErrorCauseBindingPatternNode) {
 	// migrated from BLangErrorBindingPattern.java:89:5
 	if errorCauseBindingPatternNode, ok := errorCauseBindingPatternNode.(*BLangErrorCauseBindingPattern); ok {
-		this.ErrorCauseBindingPattern = errorCauseBindingPatternNode
+		b.ErrorCauseBindingPattern = errorCauseBindingPatternNode
 		return
 	}
 	panic("errorCauseBindingPatternNode is not a BLangErrorCauseBindingPattern")
 }
 
-func (this *BLangErrorBindingPattern) GetErrorFieldBindingPatternsNode() model.ErrorFieldBindingPatternsNode {
+func (b *BLangErrorBindingPattern) GetErrorFieldBindingPatternsNode() model.ErrorFieldBindingPatternsNode {
 	// migrated from BLangErrorBindingPattern.java:94:5
-	return this.ErrorFieldBindingPatterns
+	return b.ErrorFieldBindingPatterns
 }
 
-func (this *BLangErrorBindingPattern) SetErrorFieldBindingPatternsNode(errorFieldBindingPatternsNode model.ErrorFieldBindingPatternsNode) {
+func (b *BLangErrorBindingPattern) SetErrorFieldBindingPatternsNode(errorFieldBindingPatternsNode model.ErrorFieldBindingPatternsNode) {
 	// migrated from BLangErrorBindingPattern.java:99:5
 	if errorFieldBindingPatternsNode, ok := errorFieldBindingPatternsNode.(*BLangErrorFieldBindingPatterns); ok {
-		this.ErrorFieldBindingPatterns = errorFieldBindingPatternsNode
+		b.ErrorFieldBindingPatterns = errorFieldBindingPatternsNode
 		return
 	}
 	panic("errorFieldBindingPatternsNode is not a BLangErrorFieldBindingPatterns")
 }
 
-func (this *BLangErrorMessageBindingPattern) GetSimpleBindingPattern() model.SimpleBindingPatternNode {
+func (b *BLangErrorMessageBindingPattern) GetSimpleBindingPattern() model.SimpleBindingPatternNode {
 	// migrated from BLangErrorMessageBindingPattern.java:37:5
-	return this.SimpleBindingPattern
+	return b.SimpleBindingPattern
 }
 
-func (this *BLangErrorMessageBindingPattern) SetSimpleBindingPattern(simpleBindingPattern model.SimpleBindingPatternNode) {
+func (b *BLangErrorMessageBindingPattern) SetSimpleBindingPattern(simpleBindingPattern model.SimpleBindingPatternNode) {
 	// migrated from BLangErrorMessageBindingPattern.java:42:5
 	if simpleBindingPattern, ok := simpleBindingPattern.(*BLangSimpleBindingPattern); ok {
-		this.SimpleBindingPattern = simpleBindingPattern
+		b.SimpleBindingPattern = simpleBindingPattern
 		return
 	}
 	panic("simpleBindingPattern is not a BLangSimpleBindingPattern")
 }
 
-func (this *BLangErrorMessageBindingPattern) GetKind() model.NodeKind {
+func (b *BLangErrorMessageBindingPattern) GetKind() model.NodeKind {
 	// migrated from BLangErrorMessageBindingPattern.java:62:5
 	return model.NodeKind_ERROR_MESSAGE_BINDING_PATTERN
 }
 
-func (this *BLangErrorCauseBindingPattern) GetSimpleBindingPattern() model.SimpleBindingPatternNode {
+func (b *BLangErrorCauseBindingPattern) GetSimpleBindingPattern() model.SimpleBindingPatternNode {
 	// migrated from BLangErrorCauseBindingPattern.java:39:5
-	return this.SimpleBindingPattern
+	return b.SimpleBindingPattern
 }
 
-func (this *BLangErrorCauseBindingPattern) SetSimpleBindingPattern(simpleBindingPattern model.SimpleBindingPatternNode) {
+func (b *BLangErrorCauseBindingPattern) SetSimpleBindingPattern(simpleBindingPattern model.SimpleBindingPatternNode) {
 	// migrated from BLangErrorCauseBindingPattern.java:44:5
 	if simpleBindingPattern, ok := simpleBindingPattern.(*BLangSimpleBindingPattern); ok {
-		this.SimpleBindingPattern = simpleBindingPattern
+		b.SimpleBindingPattern = simpleBindingPattern
 		return
 	}
 	panic("simpleBindingPattern is not a BLangSimpleBindingPattern")
 }
 
-func (this *BLangErrorCauseBindingPattern) GetErrorBindingPatternNode() model.ErrorBindingPatternNode {
+func (b *BLangErrorCauseBindingPattern) GetErrorBindingPatternNode() model.ErrorBindingPatternNode {
 	// migrated from BLangErrorCauseBindingPattern.java:49:5
-	return this.ErrorBindingPattern
+	return b.ErrorBindingPattern
 }
 
-func (this *BLangErrorCauseBindingPattern) SetErrorBindingPatternNode(errorBindingPatternNode model.ErrorBindingPatternNode) {
+func (b *BLangErrorCauseBindingPattern) SetErrorBindingPatternNode(errorBindingPatternNode model.ErrorBindingPatternNode) {
 	// migrated from BLangErrorCauseBindingPattern.java:54:5
 	if errorBindingPatternNode, ok := errorBindingPatternNode.(*BLangErrorBindingPattern); ok {
-		this.ErrorBindingPattern = errorBindingPatternNode
+		b.ErrorBindingPattern = errorBindingPatternNode
 		return
 	}
 	panic("errorBindingPatternNode is not a BLangErrorBindingPattern")
 }
 
-func (this *BLangErrorCauseBindingPattern) GetKind() model.NodeKind {
+func (b *BLangErrorCauseBindingPattern) GetKind() model.NodeKind {
 	// migrated from BLangErrorCauseBindingPattern.java:74:5
 	return model.NodeKind_ERROR_CAUSE_BINDING_PATTERN
 }
 
-func (this *BLangSimpleBindingPattern) GetCaptureBindingPattern() model.CaptureBindingPatternNode {
+func (b *BLangSimpleBindingPattern) GetCaptureBindingPattern() model.CaptureBindingPatternNode {
 	// migrated from BLangSimpleBindingPattern.java:39:5
-	return this.CaptureBindingPattern
+	return b.CaptureBindingPattern
 }
 
-func (this *BLangSimpleBindingPattern) SetCaptureBindingPattern(captureBindingPattern model.CaptureBindingPatternNode) {
+func (b *BLangSimpleBindingPattern) SetCaptureBindingPattern(captureBindingPattern model.CaptureBindingPatternNode) {
 	// migrated from BLangSimpleBindingPattern.java:44:5
 	if captureBindingPattern, ok := captureBindingPattern.(*BLangCaptureBindingPattern); ok {
-		this.CaptureBindingPattern = captureBindingPattern
+		b.CaptureBindingPattern = captureBindingPattern
 		return
 	}
 	panic("captureBindingPattern is not a BLangCaptureBindingPattern")
 }
 
-func (this *BLangSimpleBindingPattern) GetWildCardBindingPattern() model.WildCardBindingPatternNode {
+func (b *BLangSimpleBindingPattern) GetWildCardBindingPattern() model.WildCardBindingPatternNode {
 	// migrated from BLangSimpleBindingPattern.java:49:5
-	return this.WildCardBindingPattern
+	return b.WildCardBindingPattern
 }
 
-func (this *BLangSimpleBindingPattern) SetWildCardBindingPattern(wildCardBindingPattern model.WildCardBindingPatternNode) {
+func (b *BLangSimpleBindingPattern) SetWildCardBindingPattern(wildCardBindingPattern model.WildCardBindingPatternNode) {
 	// migrated from BLangSimpleBindingPattern.java:54:5
 	if wildCardBindingPatternNode, ok := wildCardBindingPattern.(*BLangWildCardBindingPattern); ok {
-		this.WildCardBindingPattern = wildCardBindingPatternNode
+		b.WildCardBindingPattern = wildCardBindingPatternNode
 		return
 	}
 	panic("wildCardBindingPatternNode is not a BLangWildCardBindingPattern")
 }
 
-func (this *BLangSimpleBindingPattern) GetKind() model.NodeKind {
+func (b *BLangSimpleBindingPattern) GetKind() model.NodeKind {
 	// migrated from BLangSimpleBindingPattern.java:74:5
 	return model.NodeKind_SIMPLE_BINDING_PATTERN
 }
 
-func (this *BLangErrorFieldBindingPatterns) GetNamedArgMatchPatterns() []model.NamedArgBindingPatternNode {
+func (b *BLangErrorFieldBindingPatterns) GetNamedArgMatchPatterns() []model.NamedArgBindingPatternNode {
 	// migrated from BLangErrorFieldBindingPatterns.java:42:5
-	namedArgBindingPatterns := make([]model.NamedArgBindingPatternNode, len(this.NamedArgBindingPatterns))
-	for i, namedArgBindingPattern := range this.NamedArgBindingPatterns {
+	namedArgBindingPatterns := make([]model.NamedArgBindingPatternNode, len(b.NamedArgBindingPatterns))
+	for i, namedArgBindingPattern := range b.NamedArgBindingPatterns {
 		namedArgBindingPatterns[i] = &namedArgBindingPattern
 	}
 	return namedArgBindingPatterns
 }
 
-func (this *BLangErrorFieldBindingPatterns) AddNamedArgBindingPattern(namedArgBindingPatternNode model.NamedArgBindingPatternNode) {
+func (b *BLangErrorFieldBindingPatterns) AddNamedArgBindingPattern(namedArgBindingPatternNode model.NamedArgBindingPatternNode) {
 	// migrated from BLangErrorFieldBindingPatterns.java:47:5
 	if namedArgBindingPatternNode, ok := namedArgBindingPatternNode.(*BLangNamedArgBindingPattern); ok {
-		this.NamedArgBindingPatterns = append(this.NamedArgBindingPatterns, *namedArgBindingPatternNode)
+		b.NamedArgBindingPatterns = append(b.NamedArgBindingPatterns, *namedArgBindingPatternNode)
 		return
 	}
 	panic("namedArgBindingPatternNode is not a BLangNamedArgBindingPattern")
 }
 
-func (this *BLangErrorFieldBindingPatterns) GetRestBindingPattern() model.RestBindingPatternNode {
+func (b *BLangErrorFieldBindingPatterns) GetRestBindingPattern() model.RestBindingPatternNode {
 	// migrated from BLangErrorFieldBindingPatterns.java:52:5
-	return this.RestBindingPattern
+	return b.RestBindingPattern
 }
 
-func (this *BLangErrorFieldBindingPatterns) SetRestBindingPattern(restBindingPattern model.RestBindingPatternNode) {
+func (b *BLangErrorFieldBindingPatterns) SetRestBindingPattern(restBindingPattern model.RestBindingPatternNode) {
 	// migrated from BLangErrorFieldBindingPatterns.java:57:5
 	if restBindingPattern, ok := restBindingPattern.(*BLangRestBindingPattern); ok {
-		this.RestBindingPattern = restBindingPattern
+		b.RestBindingPattern = restBindingPattern
 		return
 	}
 	panic("restBindingPattern is not a BLangRestBindingPattern")
 }
 
-func (this *BLangErrorFieldBindingPatterns) GetKind() model.NodeKind {
+func (b *BLangErrorFieldBindingPatterns) GetKind() model.NodeKind {
 	// migrated from BLangErrorFieldBindingPatterns.java:77:5
 	return model.NodeKind_ERROR_FIELD_BINDING_PATTERN
 }
 
-func (this *BLangNamedArgBindingPattern) GetIdentifier() model.IdentifierNode {
+func (b *BLangNamedArgBindingPattern) GetIdentifier() model.IdentifierNode {
 	// migrated from BLangNamedArgBindingPattern.java:40:5
-	return this.ArgName
+	return b.ArgName
 }
 
-func (this *BLangNamedArgBindingPattern) SetIdentifier(variableName model.IdentifierNode) {
+func (b *BLangNamedArgBindingPattern) SetIdentifier(variableName model.IdentifierNode) {
 	// migrated from BLangNamedArgBindingPattern.java:45:5
 	if variableName, ok := variableName.(*BLangIdentifier); ok {
-		this.ArgName = variableName
+		b.ArgName = variableName
 		return
 	}
 	panic("variableName is not a BLangIdentifier")
 }
 
-func (this *BLangNamedArgBindingPattern) GetBindingPattern() model.BindingPatternNode {
+func (b *BLangNamedArgBindingPattern) GetBindingPattern() model.BindingPatternNode {
 	// migrated from BLangNamedArgBindingPattern.java:50:5
-	return this.BindingPattern
+	return b.BindingPattern
 }
 
-func (this *BLangNamedArgBindingPattern) SetBindingPattern(bindingPattern model.BindingPatternNode) {
+func (b *BLangNamedArgBindingPattern) SetBindingPattern(bindingPattern model.BindingPatternNode) {
 	// migrated from BLangNamedArgBindingPattern.java:55:5
-	this.BindingPattern = bindingPattern
+	b.BindingPattern = bindingPattern
 }
 
-func (this *BLangNamedArgBindingPattern) GetKind() model.NodeKind {
+func (b *BLangNamedArgBindingPattern) GetKind() model.NodeKind {
 	// migrated from BLangNamedArgBindingPattern.java:75:5
 	return model.NodeKind_NAMED_ARG_BINDING_PATTERN
 }
 
-func (this *BLangRestBindingPattern) GetIdentifier() model.IdentifierNode {
+func (b *BLangRestBindingPattern) GetIdentifier() model.IdentifierNode {
 	// migrated from BLangRestBindingPattern.java:42:5
-	return this.VariableName
+	return b.VariableName
 }
 
-func (this *BLangRestBindingPattern) SetIdentifier(variableName model.IdentifierNode) {
+func (b *BLangRestBindingPattern) SetIdentifier(variableName model.IdentifierNode) {
 	// migrated from BLangRestBindingPattern.java:47:5
 	if variableName, ok := variableName.(*BLangIdentifier); ok {
-		this.VariableName = variableName
+		b.VariableName = variableName
 		return
 	}
 	panic("variableName is not a BLangIdentifier")
 }
 
-func (this *BLangRestBindingPattern) GetKind() model.NodeKind {
+func (b *BLangRestBindingPattern) GetKind() model.NodeKind {
 	// migrated from BLangRestBindingPattern.java:67:5
 	return model.NodeKind_REST_BINDING_PATTERN
 }
 
-func (this *BLangWildCardBindingPattern) GetKind() model.NodeKind {
+func (b *BLangWildCardBindingPattern) GetKind() model.NodeKind {
 	// migrated from BLangWildCardBindingPattern.java:48:5
 	return model.NodeKind_WILDCARD_BINDING_PATTERN
 }
 
-func (this *BLangWildCardBindingPattern) SetTypeCheckedType(ty BType) {
+func (b *BLangWildCardBindingPattern) SetTypeCheckedType(ty BType) {
 	panic("not implemented")
 }

--- a/ast/clauses.go
+++ b/ast/clauses.go
@@ -94,147 +94,147 @@ var (
 	_ BLangNode = &BLangOnFailClause{}
 )
 
-func (this *BLangFromClause) GetKind() model.NodeKind {
+func (b *BLangFromClause) GetKind() model.NodeKind {
 	return model.NodeKind_FROM
 }
 
-func (this *BLangFromClause) GetCollection() model.ExpressionNode {
-	return this.Collection
+func (b *BLangFromClause) GetCollection() model.ExpressionNode {
+	return b.Collection
 }
 
-func (this *BLangFromClause) SetCollection(collection model.ExpressionNode) {
+func (b *BLangFromClause) SetCollection(collection model.ExpressionNode) {
 	if exp, ok := collection.(BLangExpression); ok {
-		this.Collection = exp
+		b.Collection = exp
 		return
 	}
 	panic("collection is not a BLangExpression")
 }
 
-func (this *BLangFromClause) GetVariableDefinitionNode() model.VariableDefinitionNode {
-	return this.VariableDefinitionNode
+func (b *BLangFromClause) GetVariableDefinitionNode() model.VariableDefinitionNode {
+	return b.VariableDefinitionNode
 }
 
-func (this *BLangFromClause) SetVariableDefinitionNode(variableDefinitionNode model.VariableDefinitionNode) {
-	this.VariableDefinitionNode = variableDefinitionNode
+func (b *BLangFromClause) SetVariableDefinitionNode(variableDefinitionNode model.VariableDefinitionNode) {
+	b.VariableDefinitionNode = variableDefinitionNode
 }
 
-func (this *BLangFromClause) IsDeclaredWithVar() bool {
-	return this.IsDeclaredWithVarFlag
+func (b *BLangFromClause) IsDeclaredWithVar() bool {
+	return b.IsDeclaredWithVarFlag
 }
 
-func (this *BLangLetClause) GetKind() model.NodeKind {
+func (b *BLangLetClause) GetKind() model.NodeKind {
 	return model.NodeKind_LET_CLAUSE
 }
 
-func (this *BLangWhereClause) GetKind() model.NodeKind {
+func (b *BLangWhereClause) GetKind() model.NodeKind {
 	return model.NodeKind_WHERE
 }
 
-func (this *BLangLimitClause) GetKind() model.NodeKind {
+func (b *BLangLimitClause) GetKind() model.NodeKind {
 	return model.NodeKind_LIMIT
 }
 
-func (this *BLangLimitClause) GetExpression() model.ExpressionNode {
-	return this.Expression
+func (b *BLangLimitClause) GetExpression() model.ExpressionNode {
+	return b.Expression
 }
 
-func (this *BLangLimitClause) SetExpression(expression model.ExpressionNode) {
+func (b *BLangLimitClause) SetExpression(expression model.ExpressionNode) {
 	if exp, ok := expression.(BLangExpression); ok {
-		this.Expression = exp
+		b.Expression = exp
 		return
 	}
 	panic("expression is not a BLangExpression")
 }
 
-func (this *BLangSelectClause) GetKind() model.NodeKind {
+func (b *BLangSelectClause) GetKind() model.NodeKind {
 	return model.NodeKind_SELECT
 }
 
-func (this *BLangSelectClause) GetExpression() model.ExpressionNode {
-	return this.Expression
+func (b *BLangSelectClause) GetExpression() model.ExpressionNode {
+	return b.Expression
 }
 
-func (this *BLangSelectClause) SetExpression(expression model.ExpressionNode) {
+func (b *BLangSelectClause) SetExpression(expression model.ExpressionNode) {
 	if exp, ok := expression.(BLangExpression); ok {
-		this.Expression = exp
+		b.Expression = exp
 		return
 	}
 	panic("expression is not a BLangExpression")
 }
 
-func (this *BLangCollectClause) GetKind() model.NodeKind {
+func (b *BLangCollectClause) GetKind() model.NodeKind {
 	// migrated from BLangCollectClause.java:48:5
 	return model.NodeKind_COLLECT
 }
 
-func (this *BLangCollectClause) GetExpression() model.ExpressionNode {
+func (b *BLangCollectClause) GetExpression() model.ExpressionNode {
 	// migrated from BLangCollectClause.java:68:5
-	return this.Expression
+	return b.Expression
 }
 
-func (this *BLangCollectClause) SetExpression(expression model.ExpressionNode) {
+func (b *BLangCollectClause) SetExpression(expression model.ExpressionNode) {
 	// migrated from BLangCollectClause.java:73:5
 	if exp, ok := expression.(BLangExpression); ok {
-		this.Expression = exp
+		b.Expression = exp
 	} else {
 		panic("Expected BLangExpression")
 	}
 }
 
-func (this *BLangDoClause) GetBody() model.BlockStatementNode {
+func (b *BLangDoClause) GetBody() model.BlockStatementNode {
 	// migrated from BLangDoClause.java:46:5
-	return this.Body
+	return b.Body
 }
 
-func (this *BLangDoClause) SetBody(body model.BlockStatementNode) {
+func (b *BLangDoClause) SetBody(body model.BlockStatementNode) {
 	// migrated from BLangDoClause.java:51:5
 	if body, ok := body.(*BLangBlockStmt); ok {
-		this.Body = body
+		b.Body = body
 		return
 	}
 	panic("body is not a BLangBlockStmt")
 }
 
-func (this *BLangDoClause) GetKind() model.NodeKind {
+func (b *BLangDoClause) GetKind() model.NodeKind {
 	// migrated from BLangDoClause.java:66:5
 	return model.NodeKind_DO
 }
 
-func (this *BLangOnFailClause) SetDeclaredWithVar() {
+func (b *BLangOnFailClause) SetDeclaredWithVar() {
 	// migrated from BLangOnFailClause.java:53:5
-	this.isDeclaredWithVar = true
+	b.isDeclaredWithVar = true
 }
 
-func (this *BLangOnFailClause) IsDeclaredWithVar() bool {
+func (b *BLangOnFailClause) IsDeclaredWithVar() bool {
 	// migrated from BLangOnFailClause.java:58:5
-	return this.isDeclaredWithVar
+	return b.isDeclaredWithVar
 }
 
-func (this *BLangOnFailClause) GetVariableDefinitionNode() model.VariableDefinitionNode {
+func (b *BLangOnFailClause) GetVariableDefinitionNode() model.VariableDefinitionNode {
 	// migrated from BLangOnFailClause.java:63:5
-	return this.VariableDefinitionNode
+	return b.VariableDefinitionNode
 }
 
-func (this *BLangOnFailClause) SetVariableDefinitionNode(variableDefinitionNode model.VariableDefinitionNode) {
+func (b *BLangOnFailClause) SetVariableDefinitionNode(variableDefinitionNode model.VariableDefinitionNode) {
 	// migrated from BLangOnFailClause.java:68:5
-	this.VariableDefinitionNode = variableDefinitionNode
+	b.VariableDefinitionNode = variableDefinitionNode
 }
 
-func (this *BLangOnFailClause) GetBody() model.BlockStatementNode {
+func (b *BLangOnFailClause) GetBody() model.BlockStatementNode {
 	// migrated from BLangOnFailClause.java:73:5
-	return this.Body
+	return b.Body
 }
 
-func (this *BLangOnFailClause) SetBody(body model.BlockStatementNode) {
+func (b *BLangOnFailClause) SetBody(body model.BlockStatementNode) {
 	// migrated from BLangOnFailClause.java:98:5
 	if body, ok := body.(*BLangBlockStmt); ok {
-		this.Body = body
+		b.Body = body
 		return
 	}
 	panic("body is not a BLangBlockStmt")
 }
 
-func (this *BLangOnFailClause) GetKind() model.NodeKind {
+func (b *BLangOnFailClause) GetKind() model.NodeKind {
 	// migrated from BLangOnFailClause.java:93:5
 	return model.NodeKind_ON_FAIL
 }

--- a/ast/expressions.go
+++ b/ast/expressions.go
@@ -462,733 +462,733 @@ func (n *BLangInvocation) SetSymbol(symbolRef model.SymbolRef) {
 	n.RawSymbol = &symbolRef
 }
 
-func (this *BLangGroupExpr) GetKind() model.NodeKind {
+func (b *BLangGroupExpr) GetKind() model.NodeKind {
 	// migrated from BLangGroupExpr.java:57:5
 	return model.NodeKind_GROUP_EXPR
 }
 
-func (this *BLangGroupExpr) GetExpression() model.ExpressionNode {
+func (b *BLangGroupExpr) GetExpression() model.ExpressionNode {
 	// migrated from BLangGroupExpr.java:62:5
-	return this.Expression
+	return b.Expression
 }
 
-func (this *BLangTypedescExpr) GetKind() model.NodeKind {
+func (b *BLangTypedescExpr) GetKind() model.NodeKind {
 	// migrated from BLangTypedescExpr.java:52:5
 	return model.NodeKind_TYPEDESC_EXPRESSION
 }
 
-func (this *BLangTypedescExpr) GetTypeDescriptor() model.TypeDescriptor {
-	return this.typeDescriptor
+func (b *BLangTypedescExpr) GetTypeDescriptor() model.TypeDescriptor {
+	return b.typeDescriptor
 }
 
-func (this *BLangTypedescExpr) SetTypeDescriptor(typeDescriptor model.TypeDescriptor) {
-	this.typeDescriptor = typeDescriptor
+func (b *BLangTypedescExpr) SetTypeDescriptor(typeDescriptor model.TypeDescriptor) {
+	b.typeDescriptor = typeDescriptor
 }
 
-func (this *BLangLiteral) GetValueType() BType {
-	return this.valueType
+func (b *BLangLiteral) GetValueType() BType {
+	return b.valueType
 }
 
-func (this *BLangLiteral) SetValueType(bt BType) {
-	this.valueType = bt
+func (b *BLangLiteral) SetValueType(bt BType) {
+	b.valueType = bt
 }
 
-func (this *BLangAlternateWorkerReceive) GetKind() model.NodeKind {
+func (b *BLangAlternateWorkerReceive) GetKind() model.NodeKind {
 	// migrated from BLangAlternateWorkerReceive.java:37:5
 	return model.NodeKind_ALTERNATE_WORKER_RECEIVE
 }
 
-func (this *BLangAnnotAccessExpr) GetKind() model.NodeKind {
+func (b *BLangAnnotAccessExpr) GetKind() model.NodeKind {
 	// migrated from BLangAnnotAccessExpr.java:48:5
 	return model.NodeKind_ANNOT_ACCESS_EXPRESSION
 }
 
-func (this *BLangArrowFunction) GetKind() model.NodeKind {
+func (b *BLangArrowFunction) GetKind() model.NodeKind {
 	// migrated from BLangArrowFunction.java:67:5
 	return model.NodeKind_ARROW_EXPR
 }
 
-func (this *BLangLambdaFunction) GetFunctionNode() model.FunctionNode {
+func (b *BLangLambdaFunction) GetFunctionNode() model.FunctionNode {
 	// migrated from BLangLambdaFunction.java:48:5
-	return this.Function
+	return b.Function
 }
 
-func (this *BLangLambdaFunction) SetFunctionNode(functionNode model.FunctionNode) {
+func (b *BLangLambdaFunction) SetFunctionNode(functionNode model.FunctionNode) {
 	// migrated from BLangLambdaFunction.java:53:5
 	if fn, ok := functionNode.(*BLangFunction); ok {
-		this.Function = fn
+		b.Function = fn
 	} else {
 		panic("functionNode is not a BLangFunction")
 	}
 }
 
-func (this *BLangLambdaFunction) GetKind() model.NodeKind {
+func (b *BLangLambdaFunction) GetKind() model.NodeKind {
 	// migrated from BLangLambdaFunction.java:58:5
 	return model.NodeKind_LAMBDA
 }
 
-func (this *BLangLambdaFunction) SetTypeCheckedType(ty BType) {
+func (b *BLangLambdaFunction) SetTypeCheckedType(ty BType) {
 }
 
-func (this *BLangAlternateWorkerReceive) ToActionString() string {
+func (b *BLangAlternateWorkerReceive) ToActionString() string {
 	// migrated from BLangAlternateWorkerReceive.java:70:5
 	panic("Not implemented")
 }
 
-func (this *BLangWorkerReceive) GetWorkerName() model.IdentifierNode {
+func (b *BLangWorkerReceive) GetWorkerName() model.IdentifierNode {
 	// migrated from BLangWorkerReceive.java:40:5
-	return this.WorkerIdentifier
+	return b.WorkerIdentifier
 }
 
-func (this *BLangWorkerReceive) SetWorkerName(identifierNode model.IdentifierNode) {
+func (b *BLangWorkerReceive) SetWorkerName(identifierNode model.IdentifierNode) {
 	// migrated from BLangWorkerReceive.java:45:5
 	if id, ok := identifierNode.(*BLangIdentifier); ok {
-		this.WorkerIdentifier = id
+		b.WorkerIdentifier = id
 	} else {
 		panic("identifierNode is not a BLangIdentifier")
 	}
 }
 
-func (this *BLangWorkerReceive) GetKind() model.NodeKind {
+func (b *BLangWorkerReceive) GetKind() model.NodeKind {
 	// migrated from BLangWorkerReceive.java:50:5
 	return model.NodeKind_WORKER_RECEIVE
 }
 
-func (this *BLangWorkerReceive) ToActionString() string {
+func (b *BLangWorkerReceive) ToActionString() string {
 	// migrated from BLangWorkerReceive.java:70:5
-	if this.WorkerIdentifier != nil {
-		return fmt.Sprintf(" <- %s", this.WorkerIdentifier.Value)
+	if b.WorkerIdentifier != nil {
+		return fmt.Sprintf(" <- %s", b.WorkerIdentifier.Value)
 	}
 	return " <- "
 }
 
-func (this *BLangBinaryExpr) GetLeftExpression() model.ExpressionNode {
+func (b *BLangBinaryExpr) GetLeftExpression() model.ExpressionNode {
 	// migrated from BLangBinaryExpr.java:45:5
-	return this.LhsExpr
+	return b.LhsExpr
 }
 
-func (this *BLangBinaryExpr) GetRightExpression() model.ExpressionNode {
+func (b *BLangBinaryExpr) GetRightExpression() model.ExpressionNode {
 	// migrated from BLangBinaryExpr.java:50:5
-	return this.RhsExpr
+	return b.RhsExpr
 }
 
-func (this *BLangBinaryExpr) GetOperatorKind() model.OperatorKind {
+func (b *BLangBinaryExpr) GetOperatorKind() model.OperatorKind {
 	// migrated from BLangBinaryExpr.java:55:5
-	return this.OpKind
+	return b.OpKind
 }
 
-func (this *BLangBinaryExpr) GetKind() model.NodeKind {
+func (b *BLangBinaryExpr) GetKind() model.NodeKind {
 	// migrated from BLangBinaryExpr.java:60:5
 	return model.NodeKind_BINARY_EXPR
 }
 
-func (this *BLangQueryExpr) GetKind() model.NodeKind {
+func (b *BLangQueryExpr) GetKind() model.NodeKind {
 	return model.NodeKind_QUERY_EXPR
 }
 
-func (this *BLangQueryExpr) GetQueryClauses() []model.Node {
-	result := make([]model.Node, len(this.QueryClauseList))
-	for i := range this.QueryClauseList {
-		result[i] = this.QueryClauseList[i]
+func (b *BLangQueryExpr) GetQueryClauses() []model.Node {
+	result := make([]model.Node, len(b.QueryClauseList))
+	for i := range b.QueryClauseList {
+		result[i] = b.QueryClauseList[i]
 	}
 	return result
 }
 
-func (this *BLangQueryExpr) AddQueryClause(queryClause model.Node) {
+func (b *BLangQueryExpr) AddQueryClause(queryClause model.Node) {
 	if node, ok := queryClause.(BLangNode); ok {
-		this.QueryClauseList = append(this.QueryClauseList, node)
+		b.QueryClauseList = append(b.QueryClauseList, node)
 		return
 	}
 	panic("query clause is not a BLangNode")
 }
 
-func (this *BLangCheckedExpr) GetExpression() model.ExpressionNode {
+func (b *BLangCheckedExpr) GetExpression() model.ExpressionNode {
 	// migrated from BLangCheckedExpr.java:53:5
-	return this.Expr
+	return b.Expr
 }
 
-func (this *BLangCheckedExpr) GetOperatorKind() model.OperatorKind {
+func (b *BLangCheckedExpr) GetOperatorKind() model.OperatorKind {
 	// migrated from BLangCheckedExpr.java:58:5
 	return model.OperatorKind_CHECK
 }
 
-func (this *BLangCheckedExpr) GetKind() model.NodeKind {
+func (b *BLangCheckedExpr) GetKind() model.NodeKind {
 	// migrated from BLangCheckedExpr.java:78:5
 	return model.NodeKind_CHECK_EXPR
 }
 
-func (this *BLangCheckedExpr) SetTypeCheckedType(ty BType) {
+func (b *BLangCheckedExpr) SetTypeCheckedType(ty BType) {
 	panic("not implemented")
 }
 
-func (this *BLangCheckPanickedExpr) GetOperatorKind() model.OperatorKind {
+func (b *BLangCheckPanickedExpr) GetOperatorKind() model.OperatorKind {
 	// migrated from BLangCheckPanickedExpr.java:39:5
 	return model.OperatorKind_CHECK_PANIC
 }
 
-func (this *BLangCheckPanickedExpr) GetKind() model.NodeKind {
+func (b *BLangCheckPanickedExpr) GetKind() model.NodeKind {
 	// migrated from BLangCheckPanickedExpr.java:59:5
 	return model.NodeKind_CHECK_PANIC_EXPR
 }
 
-func (this *BLangCollectContextInvocation) GetKind() model.NodeKind {
+func (b *BLangCollectContextInvocation) GetKind() model.NodeKind {
 	// migrated from BLangCollectContextInvocation.java:36:5
 	return model.NodeKind_COLLECT_CONTEXT_INVOCATION
 }
 
-func (this *BLangCommitExpr) GetKind() model.NodeKind {
+func (b *BLangCommitExpr) GetKind() model.NodeKind {
 	// migrated from BLangCommitExpr.java:33:5
 	return model.NodeKind_COMMIT
 }
 
-func (this *BLangSimpleVarRef) GetPackageAlias() model.IdentifierNode {
+func (b *BLangSimpleVarRef) GetPackageAlias() model.IdentifierNode {
 	// migrated from BLangSimpleVarRef.java:43:5
-	return this.PkgAlias
+	return b.PkgAlias
 }
 
-func (this *BLangSimpleVarRef) GetVariableName() model.IdentifierNode {
+func (b *BLangSimpleVarRef) GetVariableName() model.IdentifierNode {
 	// migrated from BLangSimpleVarRef.java:48:5
-	return this.VariableName
+	return b.VariableName
 }
 
-func (this *BLangSimpleVarRef) GetKind() model.NodeKind {
+func (b *BLangSimpleVarRef) GetKind() model.NodeKind {
 	// migrated from BLangSimpleVarRef.java:78:5
 	return model.NodeKind_SIMPLE_VARIABLE_REF
 }
 
-func (this *BLangConstRef) GetValue() any {
+func (b *BLangConstRef) GetValue() any {
 	// migrated from BLangConstRef.java:38:5
-	return this.Value
+	return b.Value
 }
 
-func (this *BLangConstRef) SetValue(value any) {
+func (b *BLangConstRef) SetValue(value any) {
 	// migrated from BLangConstRef.java:43:5
-	this.Value = value
+	b.Value = value
 }
 
-func (this *BLangConstRef) GetIsConstant() bool {
+func (b *BLangConstRef) GetIsConstant() bool {
 	return true
 }
 
-func (this *BLangConstRef) SetIsConstant(isConstant bool) {
+func (b *BLangConstRef) SetIsConstant(isConstant bool) {
 	if !isConstant {
 		panic("isConstant is not true")
 	}
 }
 
-func (this *BLangConstRef) GetOriginalValue() string {
+func (b *BLangConstRef) GetOriginalValue() string {
 	// migrated from BLangConstRef.java:48:5
-	return this.OriginalValue
+	return b.OriginalValue
 }
 
-func (this *BLangConstRef) SetOriginalValue(originalValue string) {
+func (b *BLangConstRef) SetOriginalValue(originalValue string) {
 	// migrated from BLangConstRef.java:53:5
-	this.OriginalValue = originalValue
+	b.OriginalValue = originalValue
 }
 
-func (this *BLangConstRef) GetKind() model.NodeKind {
+func (b *BLangConstRef) GetKind() model.NodeKind {
 	// migrated from BLangConstRef.java:73:5
 	return model.NodeKind_CONSTANT_REF
 }
 
-func (this *BLangConstRef) IsKeyValueField() bool {
+func (b *BLangConstRef) IsKeyValueField() bool {
 	// migrated from BLangConstRef.java:78:5
 	return false
 }
 
-func (this *BLangLiteral) GetValue() any {
+func (b *BLangLiteral) GetValue() any {
 	// migrated from BLangLiteral.java:48:5
-	return this.Value
+	return b.Value
 }
 
-func (this *BLangLiteral) GetIsConstant() bool {
-	return this.IsConstant
+func (b *BLangLiteral) GetIsConstant() bool {
+	return b.IsConstant
 }
 
-func (this *BLangLiteral) SetIsConstant(isConstant bool) {
-	this.IsConstant = isConstant
+func (b *BLangLiteral) SetIsConstant(isConstant bool) {
+	b.IsConstant = isConstant
 }
 
-func (this *BLangLiteral) SetValue(value any) {
+func (b *BLangLiteral) SetValue(value any) {
 	// migrated from BLangLiteral.java:68:5
-	this.Value = value
+	b.Value = value
 }
 
-func (this *BLangLiteral) GetOriginalValue() string {
+func (b *BLangLiteral) GetOriginalValue() string {
 	// migrated from BLangLiteral.java:73:5
-	return this.OriginalValue
+	return b.OriginalValue
 }
 
-func (this *BLangLiteral) SetOriginalValue(originalValue string) {
+func (b *BLangLiteral) SetOriginalValue(originalValue string) {
 	// migrated from BLangLiteral.java:78:5
-	this.OriginalValue = originalValue
+	b.OriginalValue = originalValue
 }
 
-func (this *BLangLiteral) GetKind() model.NodeKind {
+func (b *BLangLiteral) GetKind() model.NodeKind {
 	// migrated from BLangLiteral.java:83:5
 	return model.NodeKind_LITERAL
 }
 
-func (this *BLangDynamicArgExpr) GetKind() model.NodeKind {
+func (b *BLangDynamicArgExpr) GetKind() model.NodeKind {
 	// migrated from BLangDynamicArgExpr.java:55:5
 	return model.NodeKind_DYNAMIC_PARAM_EXPR
 }
 
-func (this *BLangElvisExpr) GetLeftExpression() model.ExpressionNode {
+func (b *BLangElvisExpr) GetLeftExpression() model.ExpressionNode {
 	// migrated from BLangElvisExpr.java:38:5
-	return this.LhsExpr
+	return b.LhsExpr
 }
 
-func (this *BLangElvisExpr) GetRightExpression() model.ExpressionNode {
+func (b *BLangElvisExpr) GetRightExpression() model.ExpressionNode {
 	// migrated from BLangElvisExpr.java:43:5
-	return this.RhsExpr
+	return b.RhsExpr
 }
 
-func (this *BLangElvisExpr) GetKind() model.NodeKind {
+func (b *BLangElvisExpr) GetKind() model.NodeKind {
 	// migrated from BLangElvisExpr.java:48:5
 	return model.NodeKind_ELVIS_EXPR
 }
 
-func (this *BLangMarkdownDocumentationLine) GetText() string {
-	return this.Text
+func (b *BLangMarkdownDocumentationLine) GetText() string {
+	return b.Text
 }
 
-func (this *BLangMarkdownDocumentationLine) SetText(text string) {
-	this.Text = text
+func (b *BLangMarkdownDocumentationLine) SetText(text string) {
+	b.Text = text
 }
 
-func (this *BLangMarkdownDocumentationLine) GetKind() model.NodeKind {
+func (b *BLangMarkdownDocumentationLine) GetKind() model.NodeKind {
 	return model.NodeKind_DOCUMENTATION_DESCRIPTION
 }
 
-func (this *BLangMarkdownParameterDocumentation) GetParameterName() model.IdentifierNode {
-	return this.ParameterName
+func (b *BLangMarkdownParameterDocumentation) GetParameterName() model.IdentifierNode {
+	return b.ParameterName
 }
 
-func (this *BLangMarkdownParameterDocumentation) SetParameterName(parameterName model.IdentifierNode) {
+func (b *BLangMarkdownParameterDocumentation) SetParameterName(parameterName model.IdentifierNode) {
 	if identifier, ok := parameterName.(*BLangIdentifier); ok {
-		this.ParameterName = identifier
+		b.ParameterName = identifier
 	} else {
 		panic("parameterName is not a BLangIdentifier")
 	}
 }
 
-func (this *BLangMarkdownParameterDocumentation) GetParameterDocumentationLines() []string {
-	return this.ParameterDocumentationLines
+func (b *BLangMarkdownParameterDocumentation) GetParameterDocumentationLines() []string {
+	return b.ParameterDocumentationLines
 }
 
-func (this *BLangMarkdownParameterDocumentation) AddParameterDocumentationLine(text string) {
-	this.ParameterDocumentationLines = append(this.ParameterDocumentationLines, text)
+func (b *BLangMarkdownParameterDocumentation) AddParameterDocumentationLine(text string) {
+	b.ParameterDocumentationLines = append(b.ParameterDocumentationLines, text)
 }
 
-func (this *BLangMarkdownParameterDocumentation) GetParameterDocumentation() string {
-	return strings.ReplaceAll(strings.Join(this.ParameterDocumentationLines, "\n"), "\r", "")
+func (b *BLangMarkdownParameterDocumentation) GetParameterDocumentation() string {
+	return strings.ReplaceAll(strings.Join(b.ParameterDocumentationLines, "\n"), "\r", "")
 }
 
-func (this *BLangMarkdownParameterDocumentation) GetKind() model.NodeKind {
+func (b *BLangMarkdownParameterDocumentation) GetKind() model.NodeKind {
 	return model.NodeKind_DOCUMENTATION_PARAMETER
 }
 
-func (this *BLangMarkdownReturnParameterDocumentation) GetReturnParameterDocumentationLines() []string {
-	return this.ReturnParameterDocumentationLines
+func (b *BLangMarkdownReturnParameterDocumentation) GetReturnParameterDocumentationLines() []string {
+	return b.ReturnParameterDocumentationLines
 }
 
-func (this *BLangMarkdownReturnParameterDocumentation) AddReturnParameterDocumentationLine(text string) {
-	this.ReturnParameterDocumentationLines = append(this.ReturnParameterDocumentationLines, text)
+func (b *BLangMarkdownReturnParameterDocumentation) AddReturnParameterDocumentationLine(text string) {
+	b.ReturnParameterDocumentationLines = append(b.ReturnParameterDocumentationLines, text)
 }
 
-func (this *BLangMarkdownReturnParameterDocumentation) GetReturnParameterDocumentation() string {
-	return strings.ReplaceAll(strings.Join(this.ReturnParameterDocumentationLines, "\n"), "\r", "")
+func (b *BLangMarkdownReturnParameterDocumentation) GetReturnParameterDocumentation() string {
+	return strings.ReplaceAll(strings.Join(b.ReturnParameterDocumentationLines, "\n"), "\r", "")
 }
 
-func (this *BLangMarkdownReturnParameterDocumentation) GetReturnType() model.ValueType {
-	return this.ReturnType
+func (b *BLangMarkdownReturnParameterDocumentation) GetReturnType() model.ValueType {
+	return b.ReturnType
 }
 
-func (this *BLangMarkdownReturnParameterDocumentation) SetReturnType(ty model.ValueType) {
+func (b *BLangMarkdownReturnParameterDocumentation) SetReturnType(ty model.ValueType) {
 	if bt, ok := ty.(BType); ok {
-		this.ReturnType = bt
+		b.ReturnType = bt
 	} else {
 		panic("ty is not a *BType")
 	}
 }
 
-func (this *BLangMarkdownReturnParameterDocumentation) GetKind() model.NodeKind {
+func (b *BLangMarkdownReturnParameterDocumentation) GetKind() model.NodeKind {
 	return model.NodeKind_DOCUMENTATION_PARAMETER
 }
 
-func (this *BLangMarkDownDeprecationDocumentation) AddDeprecationDocumentationLine(text string) {
-	this.DeprecationDocumentationLines = append(this.DeprecationDocumentationLines, text)
+func (b *BLangMarkDownDeprecationDocumentation) AddDeprecationDocumentationLine(text string) {
+	b.DeprecationDocumentationLines = append(b.DeprecationDocumentationLines, text)
 }
 
-func (this *BLangMarkDownDeprecationDocumentation) AddDeprecationLine(text string) {
-	this.DeprecationLines = append(this.DeprecationLines, text)
+func (b *BLangMarkDownDeprecationDocumentation) AddDeprecationLine(text string) {
+	b.DeprecationLines = append(b.DeprecationLines, text)
 }
 
-func (this *BLangMarkDownDeprecationDocumentation) GetDocumentation() string {
-	return strings.ReplaceAll(strings.Join(this.DeprecationDocumentationLines, "\n"), "\r", "")
+func (b *BLangMarkDownDeprecationDocumentation) GetDocumentation() string {
+	return strings.ReplaceAll(strings.Join(b.DeprecationDocumentationLines, "\n"), "\r", "")
 }
 
-func (this *BLangMarkDownDeprecationDocumentation) GetKind() model.NodeKind {
+func (b *BLangMarkDownDeprecationDocumentation) GetKind() model.NodeKind {
 	return model.NodeKind_DOCUMENTATION_DEPRECATION
 }
 
-func (this *BLangMarkDownDeprecatedParametersDocumentation) AddParameter(parameter model.MarkdownDocumentationParameterAttributeNode) {
+func (b *BLangMarkDownDeprecatedParametersDocumentation) AddParameter(parameter model.MarkdownDocumentationParameterAttributeNode) {
 	if param, ok := parameter.(*BLangMarkdownParameterDocumentation); ok {
-		this.Parameters = append(this.Parameters, *param)
+		b.Parameters = append(b.Parameters, *param)
 	} else {
 		panic("parameter is not a BLangMarkdownParameterDocumentation")
 	}
 }
 
-func (this *BLangMarkDownDeprecatedParametersDocumentation) GetParameters() []model.MarkdownDocumentationParameterAttributeNode {
-	result := make([]model.MarkdownDocumentationParameterAttributeNode, len(this.Parameters))
-	for i := range this.Parameters {
-		result[i] = &this.Parameters[i]
+func (b *BLangMarkDownDeprecatedParametersDocumentation) GetParameters() []model.MarkdownDocumentationParameterAttributeNode {
+	result := make([]model.MarkdownDocumentationParameterAttributeNode, len(b.Parameters))
+	for i := range b.Parameters {
+		result[i] = &b.Parameters[i]
 	}
 	return result
 }
 
-func (this *BLangMarkDownDeprecatedParametersDocumentation) GetKind() model.NodeKind {
+func (b *BLangMarkDownDeprecatedParametersDocumentation) GetKind() model.NodeKind {
 	return model.NodeKind_DOCUMENTATION_DEPRECATED_PARAMETERS
 }
 
-func (this *BLangWorkerSendExprBase) GetExpr() model.ExpressionNode {
-	return this.Expr
+func (b *BLangWorkerSendExprBase) GetExpr() model.ExpressionNode {
+	return b.Expr
 }
 
-func (this *BLangWorkerSendExprBase) GetWorkerName() model.IdentifierNode {
-	return this.WorkerIdentifier
+func (b *BLangWorkerSendExprBase) GetWorkerName() model.IdentifierNode {
+	return b.WorkerIdentifier
 }
 
-func (this *BLangWorkerSendExprBase) SetWorkerName(identifierNode model.IdentifierNode) {
+func (b *BLangWorkerSendExprBase) SetWorkerName(identifierNode model.IdentifierNode) {
 	if id, ok := identifierNode.(*BLangIdentifier); ok {
-		this.WorkerIdentifier = id
+		b.WorkerIdentifier = id
 	} else {
 		panic("identifierNode is not a BLangIdentifier")
 	}
 }
 
-func (this *BLangInvocation) GetPackageAlias() model.IdentifierNode {
-	return this.PkgAlias
+func (b *BLangInvocation) GetPackageAlias() model.IdentifierNode {
+	return b.PkgAlias
 }
 
-func (this *BLangInvocation) GetName() model.IdentifierNode {
-	return this.Name
+func (b *BLangInvocation) GetName() model.IdentifierNode {
+	return b.Name
 }
 
-func (this *BLangInvocation) GetArgumentExpressions() []model.ExpressionNode {
-	result := make([]model.ExpressionNode, len(this.ArgExprs))
-	for i := range this.ArgExprs {
-		result[i] = this.ArgExprs[i]
+func (b *BLangInvocation) GetArgumentExpressions() []model.ExpressionNode {
+	result := make([]model.ExpressionNode, len(b.ArgExprs))
+	for i := range b.ArgExprs {
+		result[i] = b.ArgExprs[i]
 	}
 	return result
 }
 
-func (this *BLangInvocation) GetRequiredArgs() []model.ExpressionNode {
-	result := make([]model.ExpressionNode, len(this.RequiredArgs))
-	for i := range this.RequiredArgs {
-		result[i] = this.RequiredArgs[i]
+func (b *BLangInvocation) GetRequiredArgs() []model.ExpressionNode {
+	result := make([]model.ExpressionNode, len(b.RequiredArgs))
+	for i := range b.RequiredArgs {
+		result[i] = b.RequiredArgs[i]
 	}
 	return result
 }
 
-func (this *BLangInvocation) GetExpression() model.ExpressionNode {
-	return this.Expr
+func (b *BLangInvocation) GetExpression() model.ExpressionNode {
+	return b.Expr
 }
 
-func (this *BLangInvocation) IsIterableOperation() bool {
+func (b *BLangInvocation) IsIterableOperation() bool {
 	return false
 }
 
-func (this *BLangInvocation) IsAsync() bool {
-	return this.Async
+func (b *BLangInvocation) IsAsync() bool {
+	return b.Async
 }
 
-func (this *BLangInvocation) GetAnnotationAttachments() []model.AnnotationAttachmentNode {
-	result := make([]model.AnnotationAttachmentNode, len(this.AnnAttachments))
-	for i := range this.AnnAttachments {
-		result[i] = &this.AnnAttachments[i]
+func (b *BLangInvocation) GetAnnotationAttachments() []model.AnnotationAttachmentNode {
+	result := make([]model.AnnotationAttachmentNode, len(b.AnnAttachments))
+	for i := range b.AnnAttachments {
+		result[i] = &b.AnnAttachments[i]
 	}
 	return result
 }
 
-func (this *BLangInvocation) AddAnnotationAttachment(annAttachment model.AnnotationAttachmentNode) {
+func (b *BLangInvocation) AddAnnotationAttachment(annAttachment model.AnnotationAttachmentNode) {
 	if att, ok := annAttachment.(*BLangAnnotationAttachment); ok {
-		this.AnnAttachments = append(this.AnnAttachments, *att)
+		b.AnnAttachments = append(b.AnnAttachments, *att)
 	} else {
 		panic("annAttachment is not a BLangAnnotationAttachment")
 	}
 }
 
-func (this *BLangInvocation) GetKind() model.NodeKind {
+func (b *BLangInvocation) GetKind() model.NodeKind {
 	return model.NodeKind_INVOCATION
 }
 
-func (this *BLangTypeConversionExpr) GetKind() model.NodeKind {
+func (b *BLangTypeConversionExpr) GetKind() model.NodeKind {
 	return model.NodeKind_TYPE_CONVERSION_EXPR
 }
 
-func (this *BLangTypeConversionExpr) GetExpression() model.ExpressionNode {
-	return this.Expression
+func (b *BLangTypeConversionExpr) GetExpression() model.ExpressionNode {
+	return b.Expression
 }
 
-func (this *BLangTypeConversionExpr) SetExpression(expression model.ExpressionNode) {
+func (b *BLangTypeConversionExpr) SetExpression(expression model.ExpressionNode) {
 	if expr, ok := expression.(BLangExpression); ok {
-		this.Expression = expr
+		b.Expression = expr
 	} else {
 		panic("expression is not a BLangExpression")
 	}
 }
 
-func (this *BLangTypeConversionExpr) GetTypeDescriptor() model.TypeDescriptor {
-	return this.TypeDescriptor
+func (b *BLangTypeConversionExpr) GetTypeDescriptor() model.TypeDescriptor {
+	return b.TypeDescriptor
 }
 
-func (this *BLangTypeConversionExpr) SetTypeDescriptor(typeDescriptor model.TypeDescriptor) {
-	this.TypeDescriptor = typeDescriptor
+func (b *BLangTypeConversionExpr) SetTypeDescriptor(typeDescriptor model.TypeDescriptor) {
+	b.TypeDescriptor = typeDescriptor
 }
 
-func (this *BLangTypeConversionExpr) IsPublic() bool {
+func (b *BLangTypeConversionExpr) IsPublic() bool {
 	return false
 }
 
-func (this *BLangTypeConversionExpr) GetAnnotationAttachments() []model.AnnotationAttachmentNode {
+func (b *BLangTypeConversionExpr) GetAnnotationAttachments() []model.AnnotationAttachmentNode {
 	panic("not implemented")
 }
 
-func (this *BLangTypeConversionExpr) AddAnnotationAttachment(annAttachment model.AnnotationAttachmentNode) {
+func (b *BLangTypeConversionExpr) AddAnnotationAttachment(annAttachment model.AnnotationAttachmentNode) {
 	panic("not implemented")
 }
 
-func (this *BLangTypeConversionExpr) SetTypeCheckedType(ty BType) {
+func (b *BLangTypeConversionExpr) SetTypeCheckedType(ty BType) {
 	panic("not implemented")
 }
 
-func (this *BLangNumericLiteral) GetKind() model.NodeKind {
+func (b *BLangNumericLiteral) GetKind() model.NodeKind {
 	return model.NodeKind_NUMERIC_LITERAL
 }
 
-func (this *BLangLiteral) SetTypeCheckedType(ty BType) {
+func (b *BLangLiteral) SetTypeCheckedType(ty BType) {
 	panic("not implemented")
 }
 
-func (this *BLangInvocation) SetTypeCheckedType(ty BType) {
+func (b *BLangInvocation) SetTypeCheckedType(ty BType) {
 	panic("not implemented")
 }
 
-func (this *BLangSimpleVarRef) SetTypeCheckedType(ty BType) {
+func (b *BLangSimpleVarRef) SetTypeCheckedType(ty BType) {
 	panic("not implemented")
 }
 
-func (this *BLangBinaryExpr) SetTypeCheckedType(ty BType) {
+func (b *BLangBinaryExpr) SetTypeCheckedType(ty BType) {
 	panic("not implemented")
 }
 
-func (this *BLangQueryExpr) SetTypeCheckedType(ty BType) {
+func (b *BLangQueryExpr) SetTypeCheckedType(ty BType) {
 	panic("not implemented")
 }
 
-func (this *BLangUnaryExpr) SetTypeCheckedType(ty BType) {
+func (b *BLangUnaryExpr) SetTypeCheckedType(ty BType) {
 	panic("not implemented")
 }
 
-func (this *BLangIndexBasedAccess) SetTypeCheckedType(ty BType) {
+func (b *BLangIndexBasedAccess) SetTypeCheckedType(ty BType) {
 	panic("not implemented")
 }
 
-func (this *BLangListConstructorExpr) SetTypeCheckedType(ty BType) {
+func (b *BLangListConstructorExpr) SetTypeCheckedType(ty BType) {
 	panic("not implemented")
 }
 
-func (this *BLangGroupExpr) SetTypeCheckedType(ty BType) {
+func (b *BLangGroupExpr) SetTypeCheckedType(ty BType) {
 	panic("not implemented")
 }
 
-func (this *BLangUnaryExpr) GetExpression() model.ExpressionNode {
-	return this.Expr
+func (b *BLangUnaryExpr) GetExpression() model.ExpressionNode {
+	return b.Expr
 }
 
-func (this *BLangUnaryExpr) GetOperatorKind() model.OperatorKind {
-	return this.Operator
+func (b *BLangUnaryExpr) GetOperatorKind() model.OperatorKind {
+	return b.Operator
 }
 
-func (this *BLangUnaryExpr) GetKind() model.NodeKind {
+func (b *BLangUnaryExpr) GetKind() model.NodeKind {
 	return model.NodeKind_UNARY_EXPR
 }
 
-func (this *BLangIndexBasedAccess) GetKind() model.NodeKind {
+func (b *BLangIndexBasedAccess) GetKind() model.NodeKind {
 	return model.NodeKind_INDEX_BASED_ACCESS_EXPR
 }
 
-func (this *BLangIndexBasedAccess) GetExpression() model.ExpressionNode {
-	return this.Expr
+func (b *BLangIndexBasedAccess) GetExpression() model.ExpressionNode {
+	return b.Expr
 }
 
-func (this *BLangIndexBasedAccess) GetIndex() model.ExpressionNode {
-	return this.IndexExpr
+func (b *BLangIndexBasedAccess) GetIndex() model.ExpressionNode {
+	return b.IndexExpr
 }
 
-func (this *BLangFieldBaseAccess) GetKind() model.NodeKind {
+func (b *BLangFieldBaseAccess) GetKind() model.NodeKind {
 	return model.NodeKind_FIELD_BASED_ACCESS_EXPR
 }
 
-func (this *BLangFieldBaseAccess) GetExpression() model.ExpressionNode {
-	return this.Expr
+func (b *BLangFieldBaseAccess) GetExpression() model.ExpressionNode {
+	return b.Expr
 }
 
-func (this *BLangFieldBaseAccess) GetFieldName() model.IdentifierNode {
-	return &this.Field
+func (b *BLangFieldBaseAccess) GetFieldName() model.IdentifierNode {
+	return &b.Field
 }
 
-func (this *BLangFieldBaseAccess) IsOptionalFieldAccess() bool {
-	return this.OptionalFieldAccess
+func (b *BLangFieldBaseAccess) IsOptionalFieldAccess() bool {
+	return b.OptionalFieldAccess
 }
 
-func (this *BLangFieldBaseAccess) SetTypeCheckedType(ty BType) {
+func (b *BLangFieldBaseAccess) SetTypeCheckedType(ty BType) {
 	panic("not implemented")
 }
 
-func (this *BLangListConstructorExpr) GetKind() model.NodeKind {
+func (b *BLangListConstructorExpr) GetKind() model.NodeKind {
 	return model.NodeKind_LIST_CONSTRUCTOR_EXPR
 }
 
-func (this *BLangListConstructorExpr) GetExpressions() []model.ExpressionNode {
-	result := make([]model.ExpressionNode, len(this.Exprs))
-	for i := range this.Exprs {
-		result[i] = this.Exprs[i]
+func (b *BLangListConstructorExpr) GetExpressions() []model.ExpressionNode {
+	result := make([]model.ExpressionNode, len(b.Exprs))
+	for i := range b.Exprs {
+		result[i] = b.Exprs[i]
 	}
 	return result
 }
 
-func (this *BLangErrorConstructorExpr) GetKind() model.NodeKind {
+func (b *BLangErrorConstructorExpr) GetKind() model.NodeKind {
 	return model.NodeKind_ERROR_CONSTRUCTOR_EXPRESSION
 }
 
-func (this *BLangErrorConstructorExpr) GetPositionalArgs() []model.ExpressionNode {
-	result := make([]model.ExpressionNode, len(this.PositionalArgs))
-	for i, arg := range this.PositionalArgs {
+func (b *BLangErrorConstructorExpr) GetPositionalArgs() []model.ExpressionNode {
+	result := make([]model.ExpressionNode, len(b.PositionalArgs))
+	for i, arg := range b.PositionalArgs {
 		result[i] = arg
 	}
 	return result
 }
 
-func (this *BLangErrorConstructorExpr) GetNamedArgs() []model.NamedArgNode {
-	result := make([]model.NamedArgNode, len(this.NamedArgs))
-	for i, arg := range this.NamedArgs {
+func (b *BLangErrorConstructorExpr) GetNamedArgs() []model.NamedArgNode {
+	result := make([]model.NamedArgNode, len(b.NamedArgs))
+	for i, arg := range b.NamedArgs {
 		result[i] = arg
 	}
 	return result
 }
 
-func (this *BLangErrorConstructorExpr) SetTypeCheckedType(ty BType) {
+func (b *BLangErrorConstructorExpr) SetTypeCheckedType(ty BType) {
 	panic("not implemented")
 }
 
-func (this *BLangTypeTestExpr) GetKind() model.NodeKind {
+func (b *BLangTypeTestExpr) GetKind() model.NodeKind {
 	return model.NodeKind_TYPE_TEST_EXPR
 }
 
-func (this *BLangTypeTestExpr) IsNegation() bool {
-	return this.isNegation
+func (b *BLangTypeTestExpr) IsNegation() bool {
+	return b.isNegation
 }
 
-func (this *BLangTypeTestExpr) GetExpression() model.ExpressionNode {
-	return this.Expr
+func (b *BLangTypeTestExpr) GetExpression() model.ExpressionNode {
+	return b.Expr
 }
 
-func (this *BLangTypeTestExpr) GetType() model.TypeData {
-	return this.Type
+func (b *BLangTypeTestExpr) GetType() model.TypeData {
+	return b.Type
 }
 
-func (this *BLangTypeTestExpr) SetTypeCheckedType(ty BType) {
+func (b *BLangTypeTestExpr) SetTypeCheckedType(ty BType) {
 	panic("not implemented")
 }
 
-func (this *BLangMappingKey) GetKind() model.NodeKind {
+func (b *BLangMappingKey) GetKind() model.NodeKind {
 	panic("BLangMappingKey has no NodeKind")
 }
 
-func (this *BLangMappingKeyValueField) GetKind() model.NodeKind {
+func (b *BLangMappingKeyValueField) GetKind() model.NodeKind {
 	return model.NodeKind_RECORD_LITERAL_KEY_VALUE
 }
 
-func (this *BLangMappingKeyValueField) GetKey() model.ExpressionNode {
-	if this.Key == nil {
+func (b *BLangMappingKeyValueField) GetKey() model.ExpressionNode {
+	if b.Key == nil {
 		return nil
 	}
-	return this.Key.Expr
+	return b.Key.Expr
 }
 
-func (this *BLangMappingKeyValueField) GetValue() model.ExpressionNode {
-	return this.ValueExpr
+func (b *BLangMappingKeyValueField) GetValue() model.ExpressionNode {
+	return b.ValueExpr
 }
 
-func (this *BLangMappingKeyValueField) IsKeyValueField() bool {
+func (b *BLangMappingKeyValueField) IsKeyValueField() bool {
 	return true
 }
 
-func (this *BLangMappingConstructorExpr) GetKind() model.NodeKind {
+func (b *BLangMappingConstructorExpr) GetKind() model.NodeKind {
 	return model.NodeKind_RECORD_LITERAL_EXPR
 }
 
-func (this *BLangMappingConstructorExpr) GetFields() []model.MappingField {
-	return this.Fields
+func (b *BLangMappingConstructorExpr) GetFields() []model.MappingField {
+	return b.Fields
 }
 
-func (this *BLangMappingConstructorExpr) SetTypeCheckedType(ty BType) {
-	this.ExpectedType = ty
+func (b *BLangMappingConstructorExpr) SetTypeCheckedType(ty BType) {
+	b.ExpectedType = ty
 }
 
-func (this *BLangNamedArgsExpression) GetKind() model.NodeKind {
+func (b *BLangNamedArgsExpression) GetKind() model.NodeKind {
 	return model.NodeKind_NAMED_ARGS_EXPR
 }
 
-func (this *BLangNamedArgsExpression) SetTypeCheckedType(ty BType) {
+func (b *BLangNamedArgsExpression) SetTypeCheckedType(ty BType) {
 	panic("not implemented")
 }
 
-func (this *BLangNamedArgsExpression) SetName(name model.IdentifierNode) {
+func (b *BLangNamedArgsExpression) SetName(name model.IdentifierNode) {
 	if id, ok := name.(*BLangIdentifier); ok {
-		this.Name = *id
+		b.Name = *id
 	} else {
 		panic("name is not a BLangIdentifier")
 	}
 }
 
-func (this *BLangNamedArgsExpression) GetName() model.IdentifierNode {
-	return &this.Name
+func (b *BLangNamedArgsExpression) GetName() model.IdentifierNode {
+	return &b.Name
 }
 
-func (this *BLangNamedArgsExpression) GetExpression() model.ExpressionNode {
-	return this.Expr
+func (b *BLangNamedArgsExpression) GetExpression() model.ExpressionNode {
+	return b.Expr
 }
 
-func (this *BLangNamedArgsExpression) SetExpression(expr model.ExpressionNode) {
+func (b *BLangNamedArgsExpression) SetExpression(expr model.ExpressionNode) {
 	if e, ok := expr.(BLangExpression); ok {
-		this.Expr = e
+		b.Expr = e
 	} else {
 		panic("expr is not a BLangExpression")
 	}
 }
 
-func (this *BLangTrapExpr) GetKind() model.NodeKind {
+func (b *BLangTrapExpr) GetKind() model.NodeKind {
 	return model.NodeKind_TRAP_EXPR
 }
 
-func (this *BLangTrapExpr) GetExpression() model.ExpressionNode {
-	return this.Expr
+func (b *BLangTrapExpr) GetExpression() model.ExpressionNode {
+	return b.Expr
 }
 
-func (this *BLangTrapExpr) SetTypeCheckedType(ty BType) {
+func (b *BLangTrapExpr) SetTypeCheckedType(ty BType) {
 	panic("not implemented")
 }
 
-func (this *BLangNewExpression) GetKind() model.NodeKind {
+func (b *BLangNewExpression) GetKind() model.NodeKind {
 	return model.NodeKind_TYPE_INIT_EXPR
 }
 
-func (this *BLangNewExpression) SetTypeCheckedType(ty BType) {
+func (b *BLangNewExpression) SetTypeCheckedType(ty BType) {
 	panic("not implemented")
 }
 
@@ -1200,6 +1200,6 @@ func createBLangUnaryExpr(location diagnostics.Location, operator model.Operator
 	return exprNode
 }
 
-func (this *BLangElvisExpr) SetTypeCheckedType(ty BType) {
+func (b *BLangElvisExpr) SetTypeCheckedType(ty BType) {
 	panic("not implemented")
 }

--- a/ast/expressions.go
+++ b/ast/expressions.go
@@ -454,12 +454,12 @@ func (n *BLangVariableReferenceBase) SetSymbol(symbolRef model.SymbolRef) {
 // Symbol returns the resolved SymbolRef for this invocation.
 // Panics if the symbol has not been resolved yet (i.e. is a deferred method symbol).
 // Only call this after type resolution.
-func (n *BLangInvocation) Symbol() model.SymbolRef {
-	return *n.RawSymbol.(*model.SymbolRef)
+func (b *BLangInvocation) Symbol() model.SymbolRef {
+	return *b.RawSymbol.(*model.SymbolRef)
 }
 
-func (n *BLangInvocation) SetSymbol(symbolRef model.SymbolRef) {
-	n.RawSymbol = &symbolRef
+func (b *BLangInvocation) SetSymbol(symbolRef model.SymbolRef) {
+	b.RawSymbol = &symbolRef
 }
 
 func (b *BLangGroupExpr) GetKind() model.NodeKind {

--- a/ast/match_patterns.go
+++ b/ast/match_patterns.go
@@ -60,69 +60,69 @@ var _ BLangNode = &BLangConstPattern{}
 var _ BLangNode = &BLangMatchClause{}
 var _ BLangNode = &BLangWildCardMatchPattern{}
 
-func (this *BLangConstPattern) GetKind() model.NodeKind {
+func (b *BLangConstPattern) GetKind() model.NodeKind {
 	// migrated from BLangConstPattern.java:53:5
 	return model.NodeKind_CONST_MATCH_PATTERN
 }
 
-func (this *BLangConstPattern) GetExpression() model.ExpressionNode {
+func (b *BLangConstPattern) GetExpression() model.ExpressionNode {
 	// migrated from BLangConstPattern.java:58:5
-	return this.Expr
+	return b.Expr
 }
 
-func (this *BLangConstPattern) SetExpression(expression model.ExpressionNode) {
+func (b *BLangConstPattern) SetExpression(expression model.ExpressionNode) {
 	// migrated from BLangConstPattern.java:63:5
 	if expr, ok := expression.(BLangExpression); ok {
-		this.Expr = expr
+		b.Expr = expr
 	} else {
 		panic("Expected BLangExpression")
 	}
 }
 
-func (this *BLangWildCardMatchPattern) GetKind() model.NodeKind {
+func (b *BLangWildCardMatchPattern) GetKind() model.NodeKind {
 	return model.NodeKind_WILDCARD_MATCH_PATTERN
 }
 
-func (this *BLangMatchClause) GetKind() model.NodeKind {
+func (b *BLangMatchClause) GetKind() model.NodeKind {
 	return model.NodeKind_MATCH_CLAUSE
 }
 
-func (this *BLangMatchClause) GetMatchGuard() model.MatchGuard {
-	return this.Guard
+func (b *BLangMatchClause) GetMatchGuard() model.MatchGuard {
+	return b.Guard
 }
 
-func (this *BLangMatchClause) GetBlockStatementNode() model.BlockStatementNode {
-	return &this.Body
+func (b *BLangMatchClause) GetBlockStatementNode() model.BlockStatementNode {
+	return &b.Body
 }
 
-func (this *BLangMatchClause) GetMatchPatterns() []model.MatchPatternNode {
-	result := make([]model.MatchPatternNode, len(this.Patterns))
-	for i, p := range this.Patterns {
+func (b *BLangMatchClause) GetMatchPatterns() []model.MatchPatternNode {
+	result := make([]model.MatchPatternNode, len(b.Patterns))
+	for i, p := range b.Patterns {
 		result[i] = p
 	}
 	return result
 }
 
-func (this *BLangMatchClause) SetMatchClause(node BLangMatchGuard) {
-	this.Guard = node
+func (b *BLangMatchClause) SetMatchClause(node BLangMatchGuard) {
+	b.Guard = node
 }
 
-func (this *BLangMatchClause) SetBlockStatementNode(node BLangBlockStmt) {
-	this.Body = node
+func (b *BLangMatchClause) SetBlockStatementNode(node BLangBlockStmt) {
+	b.Body = node
 }
 
-func (this *BLangMatchClause) SetMatchPatterns(nodes []BLangMatchPattern) {
-	this.Patterns = nodes
+func (b *BLangMatchClause) SetMatchPatterns(nodes []BLangMatchPattern) {
+	b.Patterns = nodes
 }
 
-func (this *BLangMatchClause) GetAcceptedType() semtypes.SemType {
-	return this.AcceptedType
+func (b *BLangMatchClause) GetAcceptedType() semtypes.SemType {
+	return b.AcceptedType
 }
 
-func (this *bLangMatchPatternBase) GetAcceptedType() semtypes.SemType {
-	return this.AcceptedType
+func (b *bLangMatchPatternBase) GetAcceptedType() semtypes.SemType {
+	return b.AcceptedType
 }
 
-func (this *bLangMatchPatternBase) SetAcceptedType(t semtypes.SemType) {
-	this.AcceptedType = t
+func (b *bLangMatchPatternBase) SetAcceptedType(t semtypes.SemType) {
+	b.AcceptedType = t
 }

--- a/ast/module_context_data_holder.go
+++ b/ast/module_context_data_holder.go
@@ -65,38 +65,38 @@ func ModuleDescriptorFrom(moduleName *ModuleName, packageDescriptor *PackageDesc
 
 // PackageName returns the package name
 // Migrated from ModuleDescriptor.java:58:5
-func (this *ModuleDescriptor) PackageName() *PackageName {
-	return this.packageDesc.name()
+func (m *ModuleDescriptor) PackageName() *PackageName {
+	return m.packageDesc.name()
 }
 
 // Org returns the package organization
 // Migrated from ModuleDescriptor.java:62:5
-func (this *ModuleDescriptor) Org() *PackageOrg {
-	return this.packageDesc.org()
+func (m *ModuleDescriptor) Org() *PackageOrg {
+	return m.packageDesc.org()
 }
 
 // Version returns the package version
 // Migrated from ModuleDescriptor.java:66:5
-func (this *ModuleDescriptor) Version() *PackageVersion {
-	return this.packageDesc.version()
+func (m *ModuleDescriptor) Version() *PackageVersion {
+	return m.packageDesc.version()
 }
 
 // Name returns the module name
 // Migrated from ModuleDescriptor.java:70:5
-func (this *ModuleDescriptor) Name() *ModuleName {
-	return this.moduleName
+func (m *ModuleDescriptor) Name() *ModuleName {
+	return m.moduleName
 }
 
 // ModuleCompilationId returns the module compilation ID
 // Migrated from ModuleDescriptor.java:74:5
-func (this *ModuleDescriptor) ModuleCompilationId() *model.PackageID {
-	return this.moduleCompilationId
+func (m *ModuleDescriptor) ModuleCompilationId() *model.PackageID {
+	return m.moduleCompilationId
 }
 
 // ModuleTestCompilationId returns the module test compilation ID
 // Migrated from ModuleDescriptor.java:78:5
-func (this *ModuleDescriptor) ModuleTestCompilationId() *model.PackageID {
-	return this.moduleTestCompilationId
+func (m *ModuleDescriptor) ModuleTestCompilationId() *model.PackageID {
+	return m.moduleTestCompilationId
 }
 
 // ModuleName represents the name of a Package.
@@ -133,20 +133,20 @@ func FromPackageNameWithModuleNamePart(packageName *PackageName, moduleNamePart 
 
 // PackageName returns the package name
 // Migrated from ModuleName.java:50:5
-func (this *ModuleName) PackageName() *PackageName {
-	return this.packageName
+func (m *ModuleName) PackageName() *PackageName {
+	return m.packageName
 }
 
 // ModuleNamePart returns the module name part
 // Migrated from ModuleName.java:54:5
-func (this *ModuleName) ModuleNamePart() string {
-	return this.moduleNamePart
+func (m *ModuleName) ModuleNamePart() string {
+	return m.moduleNamePart
 }
 
 // IsDefaultModuleName checks if this is the default module name
 // Migrated from ModuleName.java:58:5
-func (this *ModuleName) IsDefaultModuleName() bool {
-	return this.moduleNamePart == ""
+func (m *ModuleName) IsDefaultModuleName() bool {
+	return m.moduleNamePart == ""
 }
 
 // PackageName represents the name of a Package.
@@ -174,8 +174,8 @@ func FromString(packageNameStr string) *PackageName {
 
 // value returns the package name string
 // Migrated from PackageName.java:54:5
-func (this *PackageName) value() string {
-	return this.packageNameStr
+func (p *PackageName) value() string {
+	return p.packageNameStr
 }
 
 // PackageOrg represents the organization of a Package.
@@ -217,26 +217,26 @@ func FromPackageOrg(packageOrgStr string) *PackageOrg {
 
 // value returns the package org string
 // Migrated from PackageOrg.java:51:5
-func (this *PackageOrg) value() string {
-	return this.packageOrgStr
+func (p *PackageOrg) value() string {
+	return p.packageOrgStr
 }
 
 // anonymous checks if this is an anonymous organization
 // Migrated from PackageOrg.java:79:5
-func (this *PackageOrg) anonymous() bool {
-	return PKG_ORG_ANON_NAME == this.packageOrgStr
+func (p *PackageOrg) anonymous() bool {
+	return PKG_ORG_ANON_NAME == p.packageOrgStr
 }
 
 // isBallerinaOrg checks if this is the ballerina organization
 // Migrated from PackageOrg.java:83:5
-func (this *PackageOrg) isBallerinaOrg() bool {
-	return this == PKG_ORG_BALLERINA
+func (p *PackageOrg) isBallerinaOrg() bool {
+	return p == PKG_ORG_BALLERINA
 }
 
 // isBallerinaxOrg checks if this is the ballerinax organization
 // Migrated from PackageOrg.java:87:5
-func (this *PackageOrg) isBallerinaxOrg() bool {
-	return this == PKG_ORG_BALLERINAX
+func (p *PackageOrg) isBallerinaxOrg() bool {
+	return p == PKG_ORG_BALLERINAX
 }
 
 // PackageVersion represents the version of a Package.
@@ -272,7 +272,7 @@ func FromSemanticVersion(version *SemanticVersion) *PackageVersion {
 
 // value returns the semantic version
 // Migrated from PackageVersion.java:52:5
-func (this *PackageVersion) value() *SemanticVersion {
+func (p *PackageVersion) value() *SemanticVersion {
 	panic("Not implemented")
 }
 
@@ -326,49 +326,49 @@ func FromPackageOrgNameVersionWithDeprecation(packageOrg *PackageOrg, packageNam
 
 // name returns the package name
 // Migrated from PackageDescriptor.java:86:5
-func (this *PackageDescriptor) name() *PackageName {
-	return this.packageName
+func (p *PackageDescriptor) name() *PackageName {
+	return p.packageName
 }
 
 // org returns the package organization
 // Migrated from PackageDescriptor.java:90:5
-func (this *PackageDescriptor) org() *PackageOrg {
-	return this.packageOrg
+func (p *PackageDescriptor) org() *PackageOrg {
+	return p.packageOrg
 }
 
 // version returns the package version
 // Migrated from PackageDescriptor.java:94:5
-func (this *PackageDescriptor) version() *PackageVersion {
-	return this.packageVersion
+func (p *PackageDescriptor) version() *PackageVersion {
+	return p.packageVersion
 }
 
 // Repository returns the repository (Optional)
 // Migrated from PackageDescriptor.java:98:5
 // Note: Using common.Optional when available
-func (this *PackageDescriptor) Repository() string {
-	return this.repository
+func (p *PackageDescriptor) Repository() string {
+	return p.repository
 }
 
 // isLangLibPackage checks if this is a lang lib package
 // Migrated from PackageDescriptor.java:102:5
-func (this *PackageDescriptor) isLangLibPackage() bool {
+func (p *PackageDescriptor) isLangLibPackage() bool {
 	panic("Not implemented")
 }
 
 // isBuiltInPackage checks if this is a built-in package
 // Migrated from PackageDescriptor.java:106:5
-func (this *PackageDescriptor) isBuiltInPackage() bool {
+func (p *PackageDescriptor) isBuiltInPackage() bool {
 	panic("Not implemented")
 }
 
 // getDeprecated returns whether this package is deprecated
 // Migrated from PackageDescriptor.java:110:5
-func (this *PackageDescriptor) getDeprecated() bool {
-	return this.isDeprecated
+func (p *PackageDescriptor) getDeprecated() bool {
+	return p.isDeprecated
 }
 
 // getDeprecationMsg returns the deprecation message
 // Migrated from PackageDescriptor.java:114:5
-func (this *PackageDescriptor) getDeprecationMsg() string {
-	return this.deprecationMsg
+func (p *PackageDescriptor) getDeprecationMsg() string {
+	return p.deprecationMsg
 }

--- a/ast/oce_dynamic_environment_data.go
+++ b/ast/oce_dynamic_environment_data.go
@@ -50,8 +50,8 @@ func NewOCEDynamicEnvironmentData() *OCEDynamicEnvironmentData {
 }
 
 // CleanUp clears all collections and resets pointer fields
-func (this *OCEDynamicEnvironmentData) CleanUp() {
-	this.Parents = nil
-	this.LambdaFunctionsList = nil
-	this.DesugaredClosureVars = nil
+func (o *OCEDynamicEnvironmentData) CleanUp() {
+	o.Parents = nil
+	o.LambdaFunctionsList = nil
+	o.DesugaredClosureVars = nil
 }

--- a/ast/statements.go
+++ b/ast/statements.go
@@ -157,376 +157,376 @@ var (
 	_ BLangNode = &BLangMatchStatement{}
 )
 
-func (this *BLangAssignment) GetVariable() model.ExpressionNode {
+func (b *BLangAssignment) GetVariable() model.ExpressionNode {
 	// migrated from BLangAssignment.java:48:5
-	return this.VarRef
+	return b.VarRef
 }
 
-func (this *BLangAssignment) GetExpression() model.ExpressionNode {
+func (b *BLangAssignment) GetExpression() model.ExpressionNode {
 	// migrated from BLangAssignment.java:53:5
-	return this.Expr
+	return b.Expr
 }
 
-func (this *BLangAssignment) IsDeclaredWithVar() bool {
+func (b *BLangAssignment) IsDeclaredWithVar() bool {
 	// migrated from BLangAssignment.java:58:5
 	return false
 }
 
-func (this *BLangAssignment) GetKind() model.NodeKind {
+func (b *BLangAssignment) GetKind() model.NodeKind {
 	return model.NodeKind_ASSIGNMENT
 }
 
-func (this *BLangAssignment) SetExpression(expression model.ExpressionNode) {
+func (b *BLangAssignment) SetExpression(expression model.ExpressionNode) {
 	// migrated from BLangAssignment.java:64:5
 	if expr, ok := expression.(BLangExpression); ok {
-		this.Expr = expr
+		b.Expr = expr
 	} else {
 		panic("expression is not a BLangExpression")
 	}
 }
 
-func (this *BLangAssignment) SetDeclaredWithVar(isDeclaredWithVar bool) {
+func (b *BLangAssignment) SetDeclaredWithVar(isDeclaredWithVar bool) {
 	// migrated from BLangAssignment.java:69:5
 }
 
-func (this *BLangAssignment) SetVariable(variableReferenceNode model.VariableReferenceNode) {
+func (b *BLangAssignment) SetVariable(variableReferenceNode model.VariableReferenceNode) {
 	// migrated from BLangAssignment.java:74:5
 	if varRef, ok := variableReferenceNode.(BLangExpression); ok {
-		this.VarRef = varRef
+		b.VarRef = varRef
 	} else {
 		panic("variableReferenceNode is not a BLangExpression")
 	}
 }
 
-func (this *BLangBlockStmt) GetKind() model.NodeKind {
+func (b *BLangBlockStmt) GetKind() model.NodeKind {
 	// migrated from BLangBlockStmt.java:83:5
 	return model.NodeKind_BLOCK
 }
 
-func (this *BLangBlockStmt) GetStatements() []model.StatementNode {
+func (b *BLangBlockStmt) GetStatements() []model.StatementNode {
 	// migrated from BLangBlockStmt.java:88:5
-	return this.Stmts
+	return b.Stmts
 }
 
-func (this *BLangBlockStmt) AddStatement(statement model.StatementNode) {
+func (b *BLangBlockStmt) AddStatement(statement model.StatementNode) {
 	// migrated from BLangBlockStmt.java:93:5
-	this.Stmts = append(this.Stmts, statement)
+	b.Stmts = append(b.Stmts, statement)
 }
 
-func (this *BLangBreak) GetKind() model.NodeKind {
+func (b *BLangBreak) GetKind() model.NodeKind {
 	// migrated from BLangBreak.java:45:5
 	return model.NodeKind_BREAK
 }
 
-func (this *BLangCompoundAssignment) IsDeclaredWithVar() bool {
+func (b *BLangCompoundAssignment) IsDeclaredWithVar() bool {
 	return false
 }
 
-func (this *BLangCompoundAssignment) SetDeclaredWithVar(_ bool) {
+func (b *BLangCompoundAssignment) SetDeclaredWithVar(_ bool) {
 	panic("compound assignemnt can't be declared with var")
 }
 
-func (this *BLangCompoundAssignment) GetOperatorKind() model.OperatorKind {
+func (b *BLangCompoundAssignment) GetOperatorKind() model.OperatorKind {
 	// migrated from BLangCompoundAssignment.java:59:5
-	return this.OpKind
+	return b.OpKind
 }
 
-func (this *BLangCompoundAssignment) GetVariable() model.ExpressionNode {
+func (b *BLangCompoundAssignment) GetVariable() model.ExpressionNode {
 	// migrated from BLangCompoundAssignment.java:64:5
-	return this.VarRef
+	return b.VarRef
 }
 
-func (this *BLangCompoundAssignment) GetExpression() model.ExpressionNode {
+func (b *BLangCompoundAssignment) GetExpression() model.ExpressionNode {
 	// migrated from BLangCompoundAssignment.java:69:5
-	return this.Expr
+	return b.Expr
 }
 
-func (this *BLangCompoundAssignment) SetExpression(expression model.ExpressionNode) {
+func (b *BLangCompoundAssignment) SetExpression(expression model.ExpressionNode) {
 	// migrated from BLangCompoundAssignment.java:74:5
 	if exp, ok := expression.(BLangExpression); ok {
-		this.Expr = exp
+		b.Expr = exp
 	} else {
 		panic("Expected BLangExpression")
 	}
 }
 
-func (this *BLangCompoundAssignment) SetVariable(variableReferenceNode model.VariableReferenceNode) {
+func (b *BLangCompoundAssignment) SetVariable(variableReferenceNode model.VariableReferenceNode) {
 	// migrated from BLangCompoundAssignment.java:79:5
-	this.VarRef = variableReferenceNode
+	b.VarRef = variableReferenceNode
 }
 
-func (this *BLangCompoundAssignment) GetKind() model.NodeKind {
+func (b *BLangCompoundAssignment) GetKind() model.NodeKind {
 	// migrated from BLangCompoundAssignment.java:99:5
 	return model.NodeKind_COMPOUND_ASSIGNMENT
 }
 
-func (this *BLangContinue) GetKind() model.NodeKind {
+func (b *BLangContinue) GetKind() model.NodeKind {
 	// migrated from BLangContinue.java:46:5
 	return model.NodeKind_NEXT
 }
 
-func (this *BLangDo) GetBody() model.BlockStatementNode {
+func (b *BLangDo) GetBody() model.BlockStatementNode {
 	// migrated from BLangDo.java:47:5
-	return &this.Body
+	return &b.Body
 }
 
-func (this *BLangDo) SetBody(body model.BlockStatementNode) {
+func (b *BLangDo) SetBody(body model.BlockStatementNode) {
 	// migrated from BLangDo.java:52:5
 	if blockStmt, ok := body.(*BLangBlockStmt); ok {
-		this.Body = *blockStmt
+		b.Body = *blockStmt
 		return
 	}
 	panic("body is not a BLangBlockStmt")
 }
 
-func (this *BLangDo) GetOnFailClause() model.OnFailClauseNode {
+func (b *BLangDo) GetOnFailClause() model.OnFailClauseNode {
 	// migrated from BLangDo.java:57:5
-	return &this.OnFailClause
+	return &b.OnFailClause
 }
 
-func (this *BLangDo) SetOnFailClause(onFailClause model.OnFailClauseNode) {
+func (b *BLangDo) SetOnFailClause(onFailClause model.OnFailClauseNode) {
 	// migrated from BLangDo.java:62:5
 	if onFailClause, ok := onFailClause.(*BLangOnFailClause); ok {
-		this.OnFailClause = *onFailClause
+		b.OnFailClause = *onFailClause
 		return
 	}
 	panic("onFailClause is not a BLangOnFailClause")
 }
 
-func (this *BLangDo) GetKind() model.NodeKind {
+func (b *BLangDo) GetKind() model.NodeKind {
 	// migrated from BLangDo.java:82:5
 	return model.NodeKind_DO_STMT
 }
 
-func (this *BLangExpressionStmt) GetExpression() model.ExpressionNode {
+func (b *BLangExpressionStmt) GetExpression() model.ExpressionNode {
 	// migrated from BLangExpressionStmt.java:46:5
-	return this.Expr
+	return b.Expr
 }
 
-func (this *BLangExpressionStmt) GetKind() model.NodeKind {
+func (b *BLangExpressionStmt) GetKind() model.NodeKind {
 	return model.NodeKind_EXPRESSION_STATEMENT
 }
 
-func (this *BLangIf) Scope() model.Scope {
-	return this.scope
+func (b *BLangIf) Scope() model.Scope {
+	return b.scope
 }
 
-func (this *BLangIf) SetScope(scope model.Scope) {
-	this.scope = scope
+func (b *BLangIf) SetScope(scope model.Scope) {
+	b.scope = scope
 }
 
-func (this *BLangIf) GetCondition() model.ExpressionNode {
+func (b *BLangIf) GetCondition() model.ExpressionNode {
 	// migrated from BLangIf.java:47:5
-	return this.Expr
+	return b.Expr
 }
 
-func (this *BLangIf) GetBody() model.BlockStatementNode {
+func (b *BLangIf) GetBody() model.BlockStatementNode {
 	// migrated from BLangIf.java:52:5
-	return &this.Body
+	return &b.Body
 }
 
-func (this *BLangIf) GetElseStatement() model.StatementNode {
+func (b *BLangIf) GetElseStatement() model.StatementNode {
 	// migrated from BLangIf.java:57:5
-	return this.ElseStmt
+	return b.ElseStmt
 }
 
-func (this *BLangIf) SetCondition(condition model.ExpressionNode) {
+func (b *BLangIf) SetCondition(condition model.ExpressionNode) {
 	// migrated from BLangIf.java:62:5
 	if expr, ok := condition.(BLangExpression); ok {
-		this.Expr = expr
+		b.Expr = expr
 	} else {
 		panic("condition is not a BLangExpression")
 	}
 }
 
-func (this *BLangIf) SetBody(body model.BlockStatementNode) {
+func (b *BLangIf) SetBody(body model.BlockStatementNode) {
 	// migrated from BLangIf.java:67:5
 	if blockStmt, ok := body.(*BLangBlockStmt); ok {
-		this.Body = *blockStmt
+		b.Body = *blockStmt
 		return
 	}
 	panic("body is not a BLangBlockStmt")
 }
 
-func (this *BLangIf) SetElseStatement(elseStatement model.StatementNode) {
+func (b *BLangIf) SetElseStatement(elseStatement model.StatementNode) {
 	// migrated from BLangIf.java:72:5
-	this.ElseStmt = elseStatement
+	b.ElseStmt = elseStatement
 }
 
-func (this *BLangIf) GetKind() model.NodeKind {
+func (b *BLangIf) GetKind() model.NodeKind {
 	// migrated from BLangIf.java:77:5
 	return model.NodeKind_IF
 }
 
-func (this *BLangWhile) Scope() model.Scope {
-	return this.scope
+func (b *BLangWhile) Scope() model.Scope {
+	return b.scope
 }
 
-func (this *BLangWhile) SetScope(scope model.Scope) {
-	this.scope = scope
+func (b *BLangWhile) SetScope(scope model.Scope) {
+	b.scope = scope
 }
 
-func (this *BLangWhile) GetCondition() model.ExpressionNode {
+func (b *BLangWhile) GetCondition() model.ExpressionNode {
 	// migrated from BLangWhile.java:50:5
-	return this.Expr
+	return b.Expr
 }
 
-func (this *BLangWhile) SetCondition(condition model.ExpressionNode) {
+func (b *BLangWhile) SetCondition(condition model.ExpressionNode) {
 	// migrated from BLangWhile.java:60:5
 	if expr, ok := condition.(BLangExpression); ok {
-		this.Expr = expr
+		b.Expr = expr
 	} else {
 		panic("condition is not a BLangExpression")
 	}
 }
 
-func (this *BLangWhile) GetBody() model.BlockStatementNode {
+func (b *BLangWhile) GetBody() model.BlockStatementNode {
 	// migrated from BLangWhile.java:55:5
-	return &this.Body
+	return &b.Body
 }
 
-func (this *BLangWhile) SetBody(body model.BlockStatementNode) {
+func (b *BLangWhile) SetBody(body model.BlockStatementNode) {
 	// migrated from BLangWhile.java:65:5
 	if blockStmt, ok := body.(*BLangBlockStmt); ok {
-		this.Body = *blockStmt
+		b.Body = *blockStmt
 		return
 	}
 	panic("body is not a BLangBlockStmt")
 }
 
-func (this *BLangWhile) GetOnFailClause() model.OnFailClauseNode {
+func (b *BLangWhile) GetOnFailClause() model.OnFailClauseNode {
 	// migrated from BLangWhile.java:70:5
-	return &this.OnFailClause
+	return &b.OnFailClause
 }
 
-func (this *BLangWhile) SetOnFailClause(onFailClause model.OnFailClauseNode) {
+func (b *BLangWhile) SetOnFailClause(onFailClause model.OnFailClauseNode) {
 	// migrated from BLangWhile.java:75:5
 	if onFailClause, ok := onFailClause.(*BLangOnFailClause); ok {
-		this.OnFailClause = *onFailClause
+		b.OnFailClause = *onFailClause
 		return
 	}
 	panic("onFailClause is not a BLangOnFailClause")
 }
 
-func (this *BLangWhile) GetKind() model.NodeKind {
+func (b *BLangWhile) GetKind() model.NodeKind {
 	// migrated from BLangWhile.java:95:5
 	return model.NodeKind_WHILE
 }
 
-func (this *BLangForeach) Scope() model.Scope {
-	return this.scope
+func (b *BLangForeach) Scope() model.Scope {
+	return b.scope
 }
 
-func (this *BLangForeach) SetScope(scope model.Scope) {
-	this.scope = scope
+func (b *BLangForeach) SetScope(scope model.Scope) {
+	b.scope = scope
 }
 
-func (this *BLangForeach) GetKind() model.NodeKind {
+func (b *BLangForeach) GetKind() model.NodeKind {
 	return model.NodeKind_FOREACH
 }
 
-func (this *BLangForeach) GetVariableDefinitionNode() model.VariableDefinitionNode {
-	return this.VariableDef
+func (b *BLangForeach) GetVariableDefinitionNode() model.VariableDefinitionNode {
+	return b.VariableDef
 }
 
-func (this *BLangForeach) SetVariableDefinitionNode(node model.VariableDefinitionNode) {
+func (b *BLangForeach) SetVariableDefinitionNode(node model.VariableDefinitionNode) {
 	if varDef, ok := node.(*BLangSimpleVariableDef); ok {
-		this.VariableDef = varDef
+		b.VariableDef = varDef
 		return
 	}
 	panic("node is not a *BLangSimpleVariableDef")
 }
 
-func (this *BLangForeach) GetCollection() model.ExpressionNode {
-	return this.Collection
+func (b *BLangForeach) GetCollection() model.ExpressionNode {
+	return b.Collection
 }
 
-func (this *BLangForeach) SetCollection(collection model.ExpressionNode) {
+func (b *BLangForeach) SetCollection(collection model.ExpressionNode) {
 	if expr, ok := collection.(BLangExpression); ok {
-		this.Collection = expr
+		b.Collection = expr
 	} else {
 		panic("collection is not a BLangExpression")
 	}
 }
 
-func (this *BLangForeach) GetBody() model.BlockStatementNode {
-	return &this.Body
+func (b *BLangForeach) GetBody() model.BlockStatementNode {
+	return &b.Body
 }
 
-func (this *BLangForeach) SetBody(body model.BlockStatementNode) {
+func (b *BLangForeach) SetBody(body model.BlockStatementNode) {
 	if blockStmt, ok := body.(*BLangBlockStmt); ok {
-		this.Body = *blockStmt
+		b.Body = *blockStmt
 		return
 	}
 	panic("body is not a BLangBlockStmt")
 }
 
-func (this *BLangForeach) GetIsDeclaredWithVar() bool {
-	return this.IsDeclaredWithVar
+func (b *BLangForeach) GetIsDeclaredWithVar() bool {
+	return b.IsDeclaredWithVar
 }
 
-func (this *BLangForeach) GetOnFailClause() model.OnFailClauseNode {
-	if this.OnFailClause == nil {
+func (b *BLangForeach) GetOnFailClause() model.OnFailClauseNode {
+	if b.OnFailClause == nil {
 		return nil
 	}
-	return this.OnFailClause
+	return b.OnFailClause
 }
 
-func (this *BLangForeach) SetOnFailClause(onFailClause model.OnFailClauseNode) {
+func (b *BLangForeach) SetOnFailClause(onFailClause model.OnFailClauseNode) {
 	if clause, ok := onFailClause.(*BLangOnFailClause); ok {
-		this.OnFailClause = clause
+		b.OnFailClause = clause
 		return
 	}
 	panic("onFailClause is not a *BLangOnFailClause")
 }
 
-func (this *BLangSimpleVariableDef) GetIsInFork() bool {
-	return this.IsInFork
+func (b *BLangSimpleVariableDef) GetIsInFork() bool {
+	return b.IsInFork
 }
 
-func (this *BLangSimpleVariableDef) GetIsWorker() bool {
-	return this.IsWorker
+func (b *BLangSimpleVariableDef) GetIsWorker() bool {
+	return b.IsWorker
 }
 
-func (this *BLangSimpleVariableDef) GetKind() model.NodeKind {
+func (b *BLangSimpleVariableDef) GetKind() model.NodeKind {
 	return model.NodeKind_VARIABLE_DEF
 }
 
-func (this *BLangSimpleVariableDef) GetVariable() model.VariableNode {
-	return this.Var
+func (b *BLangSimpleVariableDef) GetVariable() model.VariableNode {
+	return b.Var
 }
 
-func (this *BLangSimpleVariableDef) SetVariable(variable model.VariableNode) {
+func (b *BLangSimpleVariableDef) SetVariable(variable model.VariableNode) {
 	if v, ok := variable.(*BLangSimpleVariable); ok {
-		this.Var = v
+		b.Var = v
 	} else {
 		panic("variable is not a BLangSimpleVariable")
 	}
 }
 
-func (this *BLangReturn) GetExpression() model.ExpressionNode {
-	return this.Expr
+func (b *BLangReturn) GetExpression() model.ExpressionNode {
+	return b.Expr
 }
 
-func (this *BLangReturn) SetExpression(expression model.ExpressionNode) {
+func (b *BLangReturn) SetExpression(expression model.ExpressionNode) {
 	if expr, ok := expression.(BLangExpression); ok {
-		this.Expr = expr
+		b.Expr = expr
 	} else {
 		panic("expression is not a BLangExpression")
 	}
 }
 
-func (this *BLangReturn) GetKind() model.NodeKind {
+func (b *BLangReturn) GetKind() model.NodeKind {
 	return model.NodeKind_RETURN
 }
 
-func (this *BLangPanic) GetExpression() model.ExpressionNode {
-	return this.Expr
+func (b *BLangPanic) GetExpression() model.ExpressionNode {
+	return b.Expr
 }
 
-func (this *BLangPanic) GetKind() model.NodeKind {
+func (b *BLangPanic) GetKind() model.NodeKind {
 	return model.NodeKind_PANIC
 }
-func (this *BLangMatchStatement) GetKind() model.NodeKind {
+func (b *BLangMatchStatement) GetKind() model.NodeKind {
 	return model.NodeKind_MATCH_STATEMENT
 }

--- a/ast/types.go
+++ b/ast/types.go
@@ -247,105 +247,105 @@ var (
 	_ BLangNode            = &BLangTupleTypeNode{}
 )
 
-func (this *BLangArrayType) GetKind() model.NodeKind {
+func (b *BLangArrayType) GetKind() model.NodeKind {
 	// migrated from BLangArrayType.java:100:5
 	return model.NodeKind_ARRAY_TYPE
 }
 
-func (this *BLangArrayType) GetElementType() model.TypeData {
-	return this.Elemtype
+func (b *BLangArrayType) GetElementType() model.TypeData {
+	return b.Elemtype
 }
 
-func (this *BLangArrayType) GetDimensions() int {
-	return this.Dimensions
+func (b *BLangArrayType) GetDimensions() int {
+	return b.Dimensions
 }
 
-func (this *BLangArrayType) GetSizes() []model.ExpressionNode {
-	expressionNodes := make([]model.ExpressionNode, len(this.Sizes))
-	for i, size := range this.Sizes {
+func (b *BLangArrayType) GetSizes() []model.ExpressionNode {
+	expressionNodes := make([]model.ExpressionNode, len(b.Sizes))
+	for i, size := range b.Sizes {
 		expressionNodes[i] = size
 	}
 	return expressionNodes
 }
 
-func (this *BLangArrayType) IsOpenArray() bool {
-	return this.Dimensions == 0
+func (b *BLangArrayType) IsOpenArray() bool {
+	return b.Dimensions == 0
 }
 
-func (this *bLangTypeBase) IsGrouped() bool {
-	return this.Grouped
+func (b *bLangTypeBase) IsGrouped() bool {
+	return b.Grouped
 }
 
-func (this *BLangBuiltInRefTypeNode) GetTypeKind() model.TypeKind {
-	return this.TypeKind
+func (b *BLangBuiltInRefTypeNode) GetTypeKind() model.TypeKind {
+	return b.TypeKind
 }
 
-func (this *BLangBuiltInRefTypeNode) GetKind() model.NodeKind {
+func (b *BLangBuiltInRefTypeNode) GetKind() model.NodeKind {
 	// migrated from BLangBuiltInRefTypeNode.java:60:5
 	return model.NodeKind_BUILT_IN_REF_TYPE
 }
 
-func (this *BLangValueType) GetTypeKind() model.TypeKind {
-	return this.TypeKind
+func (b *BLangValueType) GetTypeKind() model.TypeKind {
+	return b.TypeKind
 }
 
-func (this *BLangValueType) GetKind() model.NodeKind {
+func (b *BLangValueType) GetKind() model.NodeKind {
 	// migrated from BLangValueType.java:74:5
 	return model.NodeKind_VALUE_TYPE
 }
 
-func (this *BLangUserDefinedType) GetPackageAlias() model.IdentifierNode {
+func (b *BLangUserDefinedType) GetPackageAlias() model.IdentifierNode {
 	// migrated from BLangUserDefinedType.java:55:5
-	return &this.PkgAlias
+	return &b.PkgAlias
 }
 
-func (this *BLangUserDefinedType) GetTypeName() model.IdentifierNode {
+func (b *BLangUserDefinedType) GetTypeName() model.IdentifierNode {
 	// migrated from BLangUserDefinedType.java:60:5
-	return &this.TypeName
+	return &b.TypeName
 }
 
-func (this *BLangUserDefinedType) GetKind() model.NodeKind {
+func (b *BLangUserDefinedType) GetKind() model.NodeKind {
 	// migrated from BLangUserDefinedType.java:70:5
 	return model.NodeKind_USER_DEFINED_TYPE
 }
 
-func (this *BLangUserDefinedType) GetTypeKind() model.TypeKind {
+func (b *BLangUserDefinedType) GetTypeKind() model.TypeKind {
 	panic("not implemented")
 }
 
-func (this *BLangUserDefinedType) Symbol() model.SymbolRef {
-	return this.symbol
+func (b *BLangUserDefinedType) Symbol() model.SymbolRef {
+	return b.symbol
 }
 
-func (this *BLangUserDefinedType) SetSymbol(symbolRef model.SymbolRef) {
-	this.symbol = symbolRef
+func (b *BLangUserDefinedType) SetSymbol(symbolRef model.SymbolRef) {
+	b.symbol = symbolRef
 }
 
-func (this *BField) GetName() model.Name {
-	return this.Name
+func (b *BField) GetName() model.Name {
+	return b.Name
 }
 
-func (this *BField) GetType() model.Type {
-	return this.Type
+func (b *BField) GetType() model.Type {
+	return b.Type
 }
 
-func (this *BField) GetKind() model.NodeKind {
+func (b *BField) GetKind() model.NodeKind {
 	panic("not implemented")
 }
 
-func (this *BField) IsPublic() bool   { return this.flags.has(flagPublic) }
-func (this *BField) IsReadonly() bool { return this.flags.has(flagReadonly) }
-func (this *BField) IsOptional() bool { return this.flags.has(flagOptional) }
-func (this *BField) SetPublic()       { this.flags |= flagPublic }
-func (this *BField) SetReadonly()     { this.flags |= flagReadonly }
-func (this *BField) SetOptional()     { this.flags |= flagOptional }
+func (b *BField) IsPublic() bool   { return b.flags.has(flagPublic) }
+func (b *BField) IsReadonly() bool { return b.flags.has(flagReadonly) }
+func (b *BField) IsOptional() bool { return b.flags.has(flagOptional) }
+func (b *BField) SetPublic()       { b.flags |= flagPublic }
+func (b *BField) SetReadonly()     { b.flags |= flagReadonly }
+func (b *BField) SetOptional()     { b.flags |= flagOptional }
 
-func (this *BField) GetAnnotationAttachments() []model.AnnotationAttachmentNode {
-	return this.AnnAttachments
+func (b *BField) GetAnnotationAttachments() []model.AnnotationAttachmentNode {
+	return b.AnnAttachments
 }
 
-func (this *BField) AddAnnotationAttachment(annAttachment model.AnnotationAttachmentNode) {
-	this.AnnAttachments = append(this.AnnAttachments, annAttachment)
+func (b *BField) AddAnnotationAttachment(annAttachment model.AnnotationAttachmentNode) {
+	b.AnnAttachments = append(b.AnnAttachments, annAttachment)
 }
 
 func typeTagToTypeKind(tag model.TypeTags) model.TypeKind {
@@ -379,42 +379,42 @@ func typeTagToTypeKind(tag model.TypeTags) model.TypeKind {
 	}
 }
 
-func (this *bLangTypeBase) GetTypeKind() model.TypeKind {
-	return typeTagToTypeKind(this.BTypeGetTag())
+func (b *bLangTypeBase) GetTypeKind() model.TypeKind {
+	return typeTagToTypeKind(b.BTypeGetTag())
 }
 
-func (this *bStructureTypeBase) Fields() iter.Seq2[string, BField] {
+func (b *bStructureTypeBase) Fields() iter.Seq2[string, BField] {
 	return func(yield func(string, BField) bool) {
-		for i, name := range this.names {
-			if !yield(name, this.fields[i]) {
+		for i, name := range b.names {
+			if !yield(name, b.fields[i]) {
 				break
 			}
 		}
 	}
 }
 
-func (this *bStructureTypeBase) FieldPtrs() iter.Seq2[string, *BField] {
+func (b *bStructureTypeBase) FieldPtrs() iter.Seq2[string, *BField] {
 	return func(yield func(string, *BField) bool) {
-		for i, name := range this.names {
-			if !yield(name, &this.fields[i]) {
+		for i, name := range b.names {
+			if !yield(name, &b.fields[i]) {
 				break
 			}
 		}
 	}
 }
 
-func (this *bStructureTypeBase) AddField(name string, field BField) {
-	this.names = append(this.names, name)
-	this.fields = append(this.fields, field)
+func (b *bStructureTypeBase) AddField(name string, field BField) {
+	b.names = append(b.names, name)
+	b.fields = append(b.fields, field)
 }
 
-func (this *BLangObjectType) GetKind() model.NodeKind {
+func (b *BLangObjectType) GetKind() model.NodeKind {
 	return model.NodeKind_OBJECT_TYPE
 }
 
-func (this *BLangObjectType) Members() iter.Seq[model.ObjectMember] {
+func (b *BLangObjectType) Members() iter.Seq[model.ObjectMember] {
 	return func(yield func(model.ObjectMember) bool) {
-		for _, member := range this.members {
+		for _, member := range b.members {
 			if !yield(member) {
 				return
 			}
@@ -422,120 +422,120 @@ func (this *BLangObjectType) Members() iter.Seq[model.ObjectMember] {
 	}
 }
 
-func (this *BLangObjectType) Member(name string) (model.ObjectMember, bool) {
-	member, ok := this.members[name]
+func (b *BLangObjectType) Member(name string) (model.ObjectMember, bool) {
+	member, ok := b.members[name]
 	return member, ok
 }
 
-func (this *bObjectFieldBase) Name() string {
-	return this.name
+func (b *bObjectFieldBase) Name() string {
+	return b.name
 }
 
-func (this *bObjectFieldBase) Visibility() model.Visibility {
-	return this.visibility
+func (b *bObjectFieldBase) Visibility() model.Visibility {
+	return b.visibility
 }
 
-func (this *BObjectField) MemberKind() model.ObjectMemberKind {
+func (b *BObjectField) MemberKind() model.ObjectMemberKind {
 	return model.ObjectMemberKindField
 }
 
-func (this *BObjectField) GetKind() model.NodeKind {
+func (b *BObjectField) GetKind() model.NodeKind {
 	return model.NodeKind_OBJECT_FIELD
 }
 
-func (this *BMethodDecl) MemberKind() model.ObjectMemberKind {
-	return this.memberKind
+func (b *BMethodDecl) MemberKind() model.ObjectMemberKind {
+	return b.memberKind
 }
 
-func (this *BMethodDecl) GetKind() model.NodeKind {
+func (b *BMethodDecl) GetKind() model.NodeKind {
 	return model.NodeKind_METHOD_DECL
 }
 
-func (this *bLangTypeBase) GetTypeData() model.TypeData {
-	return this.ty
+func (b *bLangTypeBase) GetTypeData() model.TypeData {
+	return b.ty
 }
 
-func (this *bLangTypeBase) SetTypeData(ty model.TypeData) {
-	this.ty = ty
+func (b *bLangTypeBase) SetTypeData(ty model.TypeData) {
+	b.ty = ty
 }
 
-func (this *bLangTypeBase) BTypeSetTag(tag model.TypeTags) {
-	this.tags = tag
+func (b *bLangTypeBase) BTypeSetTag(tag model.TypeTags) {
+	b.tags = tag
 }
 
-func (this *bLangTypeBase) BTypeGetTag() model.TypeTags {
-	return this.tags
+func (b *bLangTypeBase) BTypeGetTag() model.TypeTags {
+	return b.tags
 }
 
-func (this *bLangTypeBase) bTypeGetName() model.Name {
-	return this.name
+func (b *bLangTypeBase) bTypeGetName() model.Name {
+	return b.name
 }
 
-func (this *bLangTypeBase) bTypeSetName(name model.Name) {
-	this.name = name
+func (b *bLangTypeBase) bTypeSetName(name model.Name) {
+	b.name = name
 }
 
-func (this *bLangTypeBase) bTypeGetFlags() nodeFlags {
-	return this.flags
+func (b *bLangTypeBase) bTypeGetFlags() nodeFlags {
+	return b.flags
 }
 
-func (this *bLangTypeBase) bTypeSetFlags(flags nodeFlags) {
-	this.flags = flags
+func (b *bLangTypeBase) bTypeSetFlags(flags nodeFlags) {
+	b.flags = flags
 }
 
-func (this *BTypeBasic) BTypeGetTag() model.TypeTags {
-	return this.tag
+func (b *BTypeBasic) BTypeGetTag() model.TypeTags {
+	return b.tag
 }
 
-func (this *BTypeBasic) BTypeSetTag(tag model.TypeTags) {
-	this.tag = tag
+func (b *BTypeBasic) BTypeSetTag(tag model.TypeTags) {
+	b.tag = tag
 }
 
-func (this *BTypeBasic) bTypeGetName() model.Name {
-	return this.name
+func (b *BTypeBasic) bTypeGetName() model.Name {
+	return b.name
 }
 
-func (this *BTypeBasic) bTypeSetName(name model.Name) {
-	this.name = name
+func (b *BTypeBasic) bTypeSetName(name model.Name) {
+	b.name = name
 }
 
-func (this *BTypeBasic) bTypeGetFlags() nodeFlags {
-	return this.flags
+func (b *BTypeBasic) bTypeGetFlags() nodeFlags {
+	return b.flags
 }
 
-func (this *BTypeBasic) bTypeSetFlags(flags nodeFlags) {
-	this.flags = flags
+func (b *BTypeBasic) bTypeSetFlags(flags nodeFlags) {
+	b.flags = flags
 }
 
-func (this *BTypeBasic) GetTypeKind() model.TypeKind {
-	return typeTagToTypeKind(this.tag)
+func (b *BTypeBasic) GetTypeKind() model.TypeKind {
+	return typeTagToTypeKind(b.tag)
 }
 
-func (this *BTypeBasic) GetKind() model.NodeKind {
+func (b *BTypeBasic) GetKind() model.NodeKind {
 	panic("not implemented")
 }
 
-func (this *BTypeBasic) GetPosition() diagnostics.Location {
+func (b *BTypeBasic) GetPosition() diagnostics.Location {
 	panic("not implemented")
 }
 
-func (this *BTypeBasic) SetPosition(pos diagnostics.Location) {
+func (b *BTypeBasic) SetPosition(pos diagnostics.Location) {
 	panic("not implemented")
 }
 
-func (this *BTypeBasic) IsGrouped() bool {
+func (b *BTypeBasic) IsGrouped() bool {
 	panic("not implemented")
 }
 
-func (this *BTypeBasic) GetTypeData() model.TypeData {
-	return this.ty
+func (b *BTypeBasic) GetTypeData() model.TypeData {
+	return b.ty
 }
 
-func (this *BTypeBasic) SetTypeData(ty model.TypeData) {
-	this.ty = ty
+func (b *BTypeBasic) SetTypeData(ty model.TypeData) {
+	b.ty = ty
 }
 
-func (this *BTypeBasic) GetDeterminedType() semtypes.SemType {
+func (b *BTypeBasic) GetDeterminedType() semtypes.SemType {
 	panic("not implemented")
 }
 
@@ -547,221 +547,221 @@ func NewBType(tag model.TypeTags, name model.Name, flags uint64) BType {
 	}
 }
 
-func (this *BLangFiniteTypeNode) GetValueSet() []model.ExpressionNode {
-	values := make([]model.ExpressionNode, len(this.ValueSpace))
-	for i, value := range this.ValueSpace {
+func (b *BLangFiniteTypeNode) GetValueSet() []model.ExpressionNode {
+	values := make([]model.ExpressionNode, len(b.ValueSpace))
+	for i, value := range b.ValueSpace {
 		values[i] = value
 	}
 	return values
 }
 
-func (this *BLangFiniteTypeNode) AddValue(value model.ExpressionNode) {
+func (b *BLangFiniteTypeNode) AddValue(value model.ExpressionNode) {
 	if blangExpression, ok := value.(BLangExpression); ok {
-		this.ValueSpace = append(this.ValueSpace, blangExpression)
+		b.ValueSpace = append(b.ValueSpace, blangExpression)
 	} else {
 		panic("value is not a BLangExpression")
 	}
 }
 
-func (this *BLangFiniteTypeNode) GetKind() model.NodeKind {
+func (b *BLangFiniteTypeNode) GetKind() model.NodeKind {
 	// migrated from BLangFiniteTypeNode.java:100:5
 	return model.NodeKind_FINITE_TYPE_NODE
 }
 
-func (this *BLangUnionTypeNode) GetKind() model.NodeKind {
+func (b *BLangUnionTypeNode) GetKind() model.NodeKind {
 	return model.NodeKind_UNION_TYPE_NODE
 }
 
-func (this *BLangUnionTypeNode) Lhs() *model.TypeData {
-	return &this.lhs
+func (b *BLangUnionTypeNode) Lhs() *model.TypeData {
+	return &b.lhs
 }
 
-func (this *BLangUnionTypeNode) Rhs() *model.TypeData {
-	return &this.rhs
+func (b *BLangUnionTypeNode) Rhs() *model.TypeData {
+	return &b.rhs
 }
 
-func (this *BLangUnionTypeNode) SetLhs(typeData model.TypeData) {
-	this.lhs = typeData
+func (b *BLangUnionTypeNode) SetLhs(typeData model.TypeData) {
+	b.lhs = typeData
 }
 
-func (this *BLangUnionTypeNode) SetRhs(typeData model.TypeData) {
-	this.rhs = typeData
+func (b *BLangUnionTypeNode) SetRhs(typeData model.TypeData) {
+	b.rhs = typeData
 }
 
-func (this *BLangIntersectionTypeNode) GetKind() model.NodeKind {
+func (b *BLangIntersectionTypeNode) GetKind() model.NodeKind {
 	return model.NodeKind_INTERSECTION_TYPE_NODE
 }
 
-func (this *BLangIntersectionTypeNode) Lhs() *model.TypeData {
-	return &this.lhs
+func (b *BLangIntersectionTypeNode) Lhs() *model.TypeData {
+	return &b.lhs
 }
 
-func (this *BLangIntersectionTypeNode) Rhs() *model.TypeData {
-	return &this.rhs
+func (b *BLangIntersectionTypeNode) Rhs() *model.TypeData {
+	return &b.rhs
 }
 
-func (this *BLangIntersectionTypeNode) SetLhs(typeData model.TypeData) {
-	this.lhs = typeData
+func (b *BLangIntersectionTypeNode) SetLhs(typeData model.TypeData) {
+	b.lhs = typeData
 }
 
-func (this *BLangIntersectionTypeNode) SetRhs(typeData model.TypeData) {
-	this.rhs = typeData
+func (b *BLangIntersectionTypeNode) SetRhs(typeData model.TypeData) {
+	b.rhs = typeData
 }
 
-func (this *BLangErrorTypeNode) GetDetailType() model.TypeData {
-	return this.DetailType
+func (b *BLangErrorTypeNode) GetDetailType() model.TypeData {
+	return b.DetailType
 }
 
-func (this *BLangErrorTypeNode) IsTop() bool {
-	return this.DetailType.TypeDescriptor == nil
+func (b *BLangErrorTypeNode) IsTop() bool {
+	return b.DetailType.TypeDescriptor == nil
 }
 
-func (this *BLangErrorTypeNode) GetKind() model.NodeKind {
+func (b *BLangErrorTypeNode) GetKind() model.NodeKind {
 	return model.NodeKind_ERROR_TYPE
 }
 
-func (this *BLangTupleTypeNode) GetKind() model.NodeKind {
+func (b *BLangTupleTypeNode) GetKind() model.NodeKind {
 	return model.NodeKind_TUPLE_TYPE_NODE
 }
 
-func (this *BLangErrorTypeNode) IsDistinct() bool { return this.bTypeGetFlags().has(flagDistinct) }
-func (this *BLangErrorTypeNode) SetDistinct() {
-	this.bTypeSetFlags(this.bTypeGetFlags() | flagDistinct)
+func (b *BLangErrorTypeNode) IsDistinct() bool { return b.bTypeGetFlags().has(flagDistinct) }
+func (b *BLangErrorTypeNode) SetDistinct() {
+	b.bTypeSetFlags(b.bTypeGetFlags() | flagDistinct)
 }
 
-func (this *BLangFunctionType) IsAnyFunction() bool {
-	return this.bTypeGetFlags().has(flagAnyFunction)
+func (b *BLangFunctionType) IsAnyFunction() bool {
+	return b.bTypeGetFlags().has(flagAnyFunction)
 }
-func (this *BLangFunctionType) IsIsolated() bool { return this.bTypeGetFlags().has(flagIsolated) }
-func (this *BLangFunctionType) IsTransactional() bool {
-	return this.bTypeGetFlags().has(flagTransactional)
+func (b *BLangFunctionType) IsIsolated() bool { return b.bTypeGetFlags().has(flagIsolated) }
+func (b *BLangFunctionType) IsTransactional() bool {
+	return b.bTypeGetFlags().has(flagTransactional)
 }
-func (this *BLangFunctionType) SetAnyFunction() {
-	this.bTypeSetFlags(this.bTypeGetFlags() | flagAnyFunction)
+func (b *BLangFunctionType) SetAnyFunction() {
+	b.bTypeSetFlags(b.bTypeGetFlags() | flagAnyFunction)
 }
-func (this *BLangFunctionType) SetIsolated() {
-	this.bTypeSetFlags(this.bTypeGetFlags() | flagIsolated)
+func (b *BLangFunctionType) SetIsolated() {
+	b.bTypeSetFlags(b.bTypeGetFlags() | flagIsolated)
 }
-func (this *BLangFunctionType) SetTransactional() {
-	this.bTypeSetFlags(this.bTypeGetFlags() | flagTransactional)
+func (b *BLangFunctionType) SetTransactional() {
+	b.bTypeSetFlags(b.bTypeGetFlags() | flagTransactional)
 }
 
-func (this *BLangConstrainedType) GetKind() model.NodeKind {
+func (b *BLangConstrainedType) GetKind() model.NodeKind {
 	return model.NodeKind_CONSTRAINED_TYPE
 }
 
-func (this *BLangConstrainedType) GetType() model.TypeData {
-	return this.Type
+func (b *BLangConstrainedType) GetType() model.TypeData {
+	return b.Type
 }
 
-func (this *BLangConstrainedType) GetConstraint() model.TypeData {
-	return this.Constraint
+func (b *BLangConstrainedType) GetConstraint() model.TypeData {
+	return b.Constraint
 }
 
-func (this *BLangConstrainedType) GetTypeKind() model.TypeKind {
-	if this.Type.TypeDescriptor == nil {
+func (b *BLangConstrainedType) GetTypeKind() model.TypeKind {
+	if b.Type.TypeDescriptor == nil {
 		panic("base type is nil")
 	}
-	if builtIn, ok := this.Type.TypeDescriptor.(model.BuiltInReferenceTypeNode); ok {
+	if builtIn, ok := b.Type.TypeDescriptor.(model.BuiltInReferenceTypeNode); ok {
 		return builtIn.GetTypeKind()
 	}
 	panic("BLangConstrainedType.Type does not implement BuiltInReferenceTypeNode")
 }
 
-func (this *BLangTupleTypeNode) GetMembers() []model.MemberTypeDesc {
-	members := make([]model.MemberTypeDesc, len(this.Members))
-	for i := range this.Members {
-		members[i] = &this.Members[i]
+func (b *BLangTupleTypeNode) GetMembers() []model.MemberTypeDesc {
+	members := make([]model.MemberTypeDesc, len(b.Members))
+	for i := range b.Members {
+		members[i] = &b.Members[i]
 	}
 	return members
 }
 
-func (this *BLangTupleTypeNode) GetRest() model.TypeDescriptor {
-	if this.Rest == nil {
+func (b *BLangTupleTypeNode) GetRest() model.TypeDescriptor {
+	if b.Rest == nil {
 		return nil
 	}
-	return this.Rest
+	return b.Rest
 }
 
-func (this *BLangMemberTypeDesc) GetKind() model.NodeKind {
+func (b *BLangMemberTypeDesc) GetKind() model.NodeKind {
 	return model.NodeKind_MEMBER_TYPE_DESC
 }
 
-func (this *BLangMemberTypeDesc) GetTypeDesc() model.TypeDescriptor {
-	return this.TypeDesc
+func (b *BLangMemberTypeDesc) GetTypeDesc() model.TypeDescriptor {
+	return b.TypeDesc
 }
 
-func (this *BLangMemberTypeDesc) GetAnnotationAttachments() []model.AnnotationAttachmentNode {
-	return this.AnnAttachments
+func (b *BLangMemberTypeDesc) GetAnnotationAttachments() []model.AnnotationAttachmentNode {
+	return b.AnnAttachments
 }
 
-func (this *BLangMemberTypeDesc) AddAnnotationAttachment(annAttachment model.AnnotationAttachmentNode) {
-	this.AnnAttachments = append(this.AnnAttachments, annAttachment)
+func (b *BLangMemberTypeDesc) AddAnnotationAttachment(annAttachment model.AnnotationAttachmentNode) {
+	b.AnnAttachments = append(b.AnnAttachments, annAttachment)
 }
 
-func (this *BLangMemberTypeDesc) GetMarkdownDocumentationAttachment() model.MarkdownDocumentationNode {
-	return this.MarkdownDocumentationAttachment
+func (b *BLangMemberTypeDesc) GetMarkdownDocumentationAttachment() model.MarkdownDocumentationNode {
+	return b.MarkdownDocumentationAttachment
 }
 
-func (this *BLangMemberTypeDesc) SetMarkdownDocumentationAttachment(documentationNode model.MarkdownDocumentationNode) {
-	this.MarkdownDocumentationAttachment = documentationNode
+func (b *BLangMemberTypeDesc) SetMarkdownDocumentationAttachment(documentationNode model.MarkdownDocumentationNode) {
+	b.MarkdownDocumentationAttachment = documentationNode
 }
 
-func (this *BLangFunctionType) GetTypeKind() model.TypeKind {
+func (b *BLangFunctionType) GetTypeKind() model.TypeKind {
 	return model.TypeKind_FUNCTION
 }
 
-func (this *BLangFunctionType) GetKind() model.NodeKind {
+func (b *BLangFunctionType) GetKind() model.NodeKind {
 	return model.NodeKind_FUNCTION_TYPE
 }
 
-func (this *BLangFunctionTypeParam) GetKind() model.NodeKind {
+func (b *BLangFunctionTypeParam) GetKind() model.NodeKind {
 	return model.NodeKind_VARIABLE
 }
 
-func (this *BLangFunctionTypeParam) GetName() *string {
-	if this.Name == nil {
+func (b *BLangFunctionTypeParam) GetName() *string {
+	if b.Name == nil {
 		return nil
 	}
-	name := this.Name.Value
+	name := b.Name.Value
 	return &name
 }
 
-func (this *BLangFunctionTypeParam) GetTypeDesc() model.Type {
-	return this.TypeDesc
+func (b *BLangFunctionTypeParam) GetTypeDesc() model.Type {
+	return b.TypeDesc
 }
 
-func (this *BLangFunctionType) GetParams() []model.FunctionTypeParam {
-	params := make([]model.FunctionTypeParam, len(this.RequiredParams))
-	for i := range this.RequiredParams {
-		params[i] = &this.RequiredParams[i]
+func (b *BLangFunctionType) GetParams() []model.FunctionTypeParam {
+	params := make([]model.FunctionTypeParam, len(b.RequiredParams))
+	for i := range b.RequiredParams {
+		params[i] = &b.RequiredParams[i]
 	}
 	return params
 }
 
-func (this *BLangFunctionType) GetRestParam() model.FunctionTypeParam {
-	if this.RestParam == nil {
+func (b *BLangFunctionType) GetRestParam() model.FunctionTypeParam {
+	if b.RestParam == nil {
 		return nil
 	}
-	return this.RestParam
+	return b.RestParam
 }
 
-func (this *BLangFunctionType) GetReturnTypeNode() model.TypeDescriptor {
-	return this.ReturnTypeDescriptor
+func (b *BLangFunctionType) GetReturnTypeNode() model.TypeDescriptor {
+	return b.ReturnTypeDescriptor
 }
 
-func (this *BLangRecordType) GetKind() model.NodeKind {
+func (b *BLangRecordType) GetKind() model.NodeKind {
 	return model.NodeKind_RECORD_TYPE
 }
 
-func (this *BLangRecordType) GetRestFieldType() model.TypeData {
-	return this.RestType.GetTypeData()
+func (b *BLangRecordType) GetRestFieldType() model.TypeData {
+	return b.RestType.GetTypeData()
 }
 
-func (this *BLangRecordType) GetFields() iter.Seq2[string, model.Field] {
+func (b *BLangRecordType) GetFields() iter.Seq2[string, model.Field] {
 	return func(yield func(string, model.Field) bool) {
-		for i, name := range this.names {
-			if !yield(name, &this.fields[i]) {
+		for i, name := range b.names {
+			if !yield(name, &b.fields[i]) {
 				return
 			}
 		}
@@ -769,17 +769,17 @@ func (this *BLangRecordType) GetFields() iter.Seq2[string, model.Field] {
 }
 
 // AddMember insert a new member. If there was already a member by the same name return true
-func (this *BLangObjectType) AddMember(member model.ObjectMember) bool {
+func (b *BLangObjectType) AddMember(member model.ObjectMember) bool {
 	name := member.Name()
-	if _, hadValue := this.members[name]; hadValue {
+	if _, hadValue := b.members[name]; hadValue {
 		return true
 	}
-	this.members[name] = member
+	b.members[name] = member
 	return false
 }
 
-func (this *BLangObjectType) PopUnresolvedInclusions() []*BLangUserDefinedType {
-	inclusions := this.unresolvedInclusions
-	this.unresolvedInclusions = nil
+func (b *BLangObjectType) PopUnresolvedInclusions() []*BLangUserDefinedType {
+	inclusions := b.unresolvedInclusions
+	b.unresolvedInclusions = nil
 	return inclusions
 }

--- a/context/context.go
+++ b/context/context.go
@@ -64,101 +64,101 @@ type CompilerContext struct {
 	stage       activeStage
 }
 
-func (this *CompilerContext) DiagnosticEnv() *diagnostics.DiagnosticEnv {
-	return this.env.DiagnosticEnv()
+func (c *CompilerContext) DiagnosticEnv() *diagnostics.DiagnosticEnv {
+	return c.env.DiagnosticEnv()
 }
 
-func (this *CompilerContext) NewSymbolSpace(packageID model.PackageID) *model.SymbolSpace {
-	return this.env.NewSymbolSpace(packageID)
+func (c *CompilerContext) NewSymbolSpace(packageID model.PackageID) *model.SymbolSpace {
+	return c.env.NewSymbolSpace(packageID)
 }
 
-func (this *CompilerContext) NewFunctionScope(parent model.Scope, pkg model.PackageID) *model.FunctionScope {
-	return this.env.NewFunctionScope(parent, pkg)
+func (c *CompilerContext) NewFunctionScope(parent model.Scope, pkg model.PackageID) *model.FunctionScope {
+	return c.env.NewFunctionScope(parent, pkg)
 }
 
-func (this *CompilerContext) NewBlockScope(parent model.Scope, pkg model.PackageID) *model.BlockScope {
-	return this.env.NewBlockScope(parent, pkg)
+func (c *CompilerContext) NewBlockScope(parent model.Scope, pkg model.PackageID) *model.BlockScope {
+	return c.env.NewBlockScope(parent, pkg)
 }
 
-func (this *CompilerContext) AddSymbolToSameSpace(ref model.SymbolRef, name string, symbol model.Symbol) model.SymbolRef {
-	return this.env.AddSymbolToSameSpace(ref, name, symbol)
+func (c *CompilerContext) AddSymbolToSameSpace(ref model.SymbolRef, name string, symbol model.Symbol) model.SymbolRef {
+	return c.env.AddSymbolToSameSpace(ref, name, symbol)
 }
 
-func (this *CompilerContext) GetSymbol(symbol model.SymbolRef) model.Symbol {
-	return this.env.GetSymbol(symbol)
+func (c *CompilerContext) GetSymbol(symbol model.SymbolRef) model.Symbol {
+	return c.env.GetSymbol(symbol)
 }
 
 // CreateNarrowedSymbol create a narrowed symbol for the given baseRef symbol. IMPORTANT: baseRef must be the actual symbol
 // not a narrowed symbol.
-func (this *CompilerContext) CreateNarrowedSymbol(baseRef model.SymbolRef) model.SymbolRef {
-	return this.env.CreateNarrowedSymbol(baseRef)
+func (c *CompilerContext) CreateNarrowedSymbol(baseRef model.SymbolRef) model.SymbolRef {
+	return c.env.CreateNarrowedSymbol(baseRef)
 }
 
-func (this *CompilerContext) CreateFunctionSymbol(space *model.SymbolSpace, name string, signature model.FunctionSignature, fnTy semtypes.SemType) model.SymbolRef {
-	return this.env.CreateFunctionSymbol(space, name, signature, fnTy)
+func (c *CompilerContext) CreateFunctionSymbol(space *model.SymbolSpace, name string, signature model.FunctionSignature, fnTy semtypes.SemType) model.SymbolRef {
+	return c.env.CreateFunctionSymbol(space, name, signature, fnTy)
 }
 
-func (this *CompilerContext) UnnarrowedSymbol(symbol model.SymbolRef) model.SymbolRef {
-	return this.env.UnnarrowedSymbol(symbol)
+func (c *CompilerContext) UnnarrowedSymbol(symbol model.SymbolRef) model.SymbolRef {
+	return c.env.UnnarrowedSymbol(symbol)
 }
 
-func (this *CompilerContext) SymbolName(symbol model.SymbolRef) string {
-	return this.env.GetSymbol(symbol).Name()
+func (c *CompilerContext) SymbolName(symbol model.SymbolRef) string {
+	return c.env.GetSymbol(symbol).Name()
 }
 
-func (this *CompilerContext) SymbolType(symbol model.SymbolRef) semtypes.SemType {
-	return this.env.GetSymbol(symbol).Type()
+func (c *CompilerContext) SymbolType(symbol model.SymbolRef) semtypes.SemType {
+	return c.env.GetSymbol(symbol).Type()
 }
 
-func (this *CompilerContext) SymbolKind(symbol model.SymbolRef) model.SymbolKind {
-	return this.env.GetSymbol(symbol).Kind()
+func (c *CompilerContext) SymbolKind(symbol model.SymbolRef) model.SymbolKind {
+	return c.env.GetSymbol(symbol).Kind()
 }
 
-func (this *CompilerContext) SymbolIsPublic(symbol model.SymbolRef) bool {
-	return this.GetSymbol(symbol).IsPublic()
+func (c *CompilerContext) SymbolIsPublic(symbol model.SymbolRef) bool {
+	return c.GetSymbol(symbol).IsPublic()
 }
 
-func (this *CompilerContext) SetSymbolType(symbol model.SymbolRef, ty semtypes.SemType) {
-	this.GetSymbol(symbol).SetType(ty)
+func (c *CompilerContext) SetSymbolType(symbol model.SymbolRef, ty semtypes.SemType) {
+	c.GetSymbol(symbol).SetType(ty)
 }
 
-func (this *CompilerContext) GetDefaultPackage() *model.PackageID {
-	return this.env.GetDefaultPackage()
+func (c *CompilerContext) GetDefaultPackage() *model.PackageID {
+	return c.env.GetDefaultPackage()
 }
 
-func (this *CompilerContext) NewPackageID(orgName model.Name, nameComps []model.Name, version model.Name) *model.PackageID {
-	return this.env.NewPackageID(orgName, nameComps, version)
+func (c *CompilerContext) NewPackageID(orgName model.Name, nameComps []model.Name, version model.Name) *model.PackageID {
+	return c.env.NewPackageID(orgName, nameComps, version)
 }
 
-func (this *CompilerContext) Unimplemented(message string, pos diagnostics.Location) {
-	this.addDiagnostic("UNIMPLEMENTED_ERROR", diagnostics.Fatal, message, pos)
+func (c *CompilerContext) Unimplemented(message string, pos diagnostics.Location) {
+	c.addDiagnostic("UNIMPLEMENTED_ERROR", diagnostics.Fatal, message, pos)
 }
 
-func (this *CompilerContext) InternalError(message string, pos diagnostics.Location) {
-	this.addDiagnostic("INTERNAL_ERROR", diagnostics.Fatal, message, pos)
+func (c *CompilerContext) InternalError(message string, pos diagnostics.Location) {
+	c.addDiagnostic("INTERNAL_ERROR", diagnostics.Fatal, message, pos)
 }
 
-func (this *CompilerContext) SyntaxError(message string, pos diagnostics.Location) {
-	this.addDiagnostic("SYNTAX_ERROR", diagnostics.Error, message, pos)
+func (c *CompilerContext) SyntaxError(message string, pos diagnostics.Location) {
+	c.addDiagnostic("SYNTAX_ERROR", diagnostics.Error, message, pos)
 }
 
-func (this *CompilerContext) SemanticError(message string, pos diagnostics.Location) {
-	this.addDiagnostic("SEMANTIC_ERROR", diagnostics.Error, message, pos)
+func (c *CompilerContext) SemanticError(message string, pos diagnostics.Location) {
+	c.addDiagnostic("SEMANTIC_ERROR", diagnostics.Error, message, pos)
 }
 
-func (this *CompilerContext) addDiagnostic(code string, severity diagnostics.DiagnosticSeverity, message string, pos diagnostics.Location) {
+func (c *CompilerContext) addDiagnostic(code string, severity diagnostics.DiagnosticSeverity, message string, pos diagnostics.Location) {
 	diagnostic := diagnostics.CreateDiagnostic(diagnostics.NewDiagnosticInfo(&code, message, severity), pos)
-	this.mu.Lock()
-	this.diagnostics = append(this.diagnostics, diagnostic)
-	this.mu.Unlock()
+	c.mu.Lock()
+	c.diagnostics = append(c.diagnostics, diagnostic)
+	c.mu.Unlock()
 }
 
-func (this *CompilerContext) HasDiagnostics() bool {
-	return len(this.diagnostics) > 0
+func (c *CompilerContext) HasDiagnostics() bool {
+	return len(c.diagnostics) > 0
 }
 
-func (this *CompilerContext) HasErrors() bool {
-	for _, diag := range this.diagnostics {
+func (c *CompilerContext) HasErrors() bool {
+	for _, diag := range c.diagnostics {
 		if diag.DiagnosticInfo().Severity() == diagnostics.Error {
 			return true
 		}
@@ -166,8 +166,8 @@ func (this *CompilerContext) HasErrors() bool {
 	return false
 }
 
-func (this *CompilerContext) Diagnostics() []diagnostics.Diagnostic {
-	return this.diagnostics
+func (c *CompilerContext) Diagnostics() []diagnostics.Diagnostic {
+	return c.diagnostics
 }
 
 func NewCompilerContext(env *CompilerEnvironment) *CompilerContext {
@@ -177,42 +177,42 @@ func NewCompilerContext(env *CompilerEnvironment) *CompilerContext {
 }
 
 // GetTypeEnv returns the type environment for this context
-func (this *CompilerContext) GetTypeEnv() semtypes.Env {
-	return this.env.GetTypeEnv()
+func (c *CompilerContext) GetTypeEnv() semtypes.Env {
+	return c.env.GetTypeEnv()
 }
 
-func (this *CompilerContext) GetNextAnonymousFunctionKey(packageID *model.PackageID) string {
-	return this.env.GetNextAnonymousFunctionKey(packageID)
+func (c *CompilerContext) GetNextAnonymousFunctionKey(packageID *model.PackageID) string {
+	return c.env.GetNextAnonymousFunctionKey(packageID)
 }
 
-func (this *CompilerContext) GetNextAnonymousTypeKey(packageID *model.PackageID) string {
-	return this.env.GetNextAnonymousTypeKey(packageID)
+func (c *CompilerContext) GetNextAnonymousTypeKey(packageID *model.PackageID) string {
+	return c.env.GetNextAnonymousTypeKey(packageID)
 }
 
-func (this *CompilerContext) InitModuleStats(moduleName string) {
-	if !this.env.statsEnabled {
+func (c *CompilerContext) InitModuleStats(moduleName string) {
+	if !c.env.statsEnabled {
 		return
 	}
-	this.moduleStats = &ModuleStats{ModuleName: moduleName}
+	c.moduleStats = &ModuleStats{ModuleName: moduleName}
 }
 
-func (this *CompilerContext) StartStage(name CompilationStage) {
-	if !this.env.statsEnabled {
+func (c *CompilerContext) StartStage(name CompilationStage) {
+	if !c.env.statsEnabled {
 		return
 	}
-	this.stage = activeStage{name: name, start: time.Now()}
+	c.stage = activeStage{name: name, start: time.Now()}
 }
 
-func (this *CompilerContext) EndStage() {
-	if !this.env.statsEnabled {
+func (c *CompilerContext) EndStage() {
+	if !c.env.statsEnabled {
 		return
 	}
-	this.moduleStats.Stages = append(this.moduleStats.Stages, StageTiming{
-		Name:     this.stage.name,
-		Duration: time.Since(this.stage.start),
+	c.moduleStats.Stages = append(c.moduleStats.Stages, StageTiming{
+		Name:     c.stage.name,
+		Duration: time.Since(c.stage.start),
 	})
 }
 
-func (this *CompilerContext) GetModuleStats() *ModuleStats {
-	return this.moduleStats
+func (c *CompilerContext) GetModuleStats() *ModuleStats {
+	return c.moduleStats
 }

--- a/context/env.go
+++ b/context/env.go
@@ -37,47 +37,47 @@ type CompilerEnvironment struct {
 	diagnosticContext *diagnostics.DiagnosticEnv
 }
 
-func (this *CompilerEnvironment) DiagnosticEnv() *diagnostics.DiagnosticEnv {
-	return this.diagnosticContext
+func (c *CompilerEnvironment) DiagnosticEnv() *diagnostics.DiagnosticEnv {
+	return c.diagnosticContext
 }
 
-func (this *CompilerEnvironment) NewSymbolSpace(packageID model.PackageID) *model.SymbolSpace {
-	this.symbolSpacesMu.Lock()
-	space := model.NewSymbolSpaceInner(packageID, len(this.symbolSpaces))
-	this.symbolSpaces = append(this.symbolSpaces, space)
-	this.symbolSpacesMu.Unlock()
+func (c *CompilerEnvironment) NewSymbolSpace(packageID model.PackageID) *model.SymbolSpace {
+	c.symbolSpacesMu.Lock()
+	space := model.NewSymbolSpaceInner(packageID, len(c.symbolSpaces))
+	c.symbolSpaces = append(c.symbolSpaces, space)
+	c.symbolSpacesMu.Unlock()
 	return space
 }
 
-func (this *CompilerEnvironment) NewFunctionScope(parent model.Scope, pkg model.PackageID) *model.FunctionScope {
+func (c *CompilerEnvironment) NewFunctionScope(parent model.Scope, pkg model.PackageID) *model.FunctionScope {
 	return &model.FunctionScope{
 		BlockScopeBase: model.BlockScopeBase{
 			Parent: parent,
-			Main:   this.NewSymbolSpace(pkg),
+			Main:   c.NewSymbolSpace(pkg),
 		},
 	}
 }
 
-func (this *CompilerEnvironment) NewBlockScope(parent model.Scope, pkg model.PackageID) *model.BlockScope {
+func (c *CompilerEnvironment) NewBlockScope(parent model.Scope, pkg model.PackageID) *model.BlockScope {
 	return &model.BlockScope{
 		BlockScopeBase: model.BlockScopeBase{
 			Parent: parent,
-			Main:   this.NewSymbolSpace(pkg),
+			Main:   c.NewSymbolSpace(pkg),
 		},
 	}
 }
 
-func (this *CompilerEnvironment) GetSymbol(symbol model.SymbolRef) model.Symbol {
-	this.symbolSpacesMu.RLock()
-	symbolSpace := this.symbolSpaces[symbol.SpaceIndex]
-	this.symbolSpacesMu.RUnlock()
+func (c *CompilerEnvironment) GetSymbol(symbol model.SymbolRef) model.Symbol {
+	c.symbolSpacesMu.RLock()
+	symbolSpace := c.symbolSpaces[symbol.SpaceIndex]
+	c.symbolSpacesMu.RUnlock()
 	return symbolSpace.SymbolAt(symbol.Index)
 }
 
-func (this *CompilerEnvironment) AddSymbolToSameSpace(ref model.SymbolRef, name string, symbol model.Symbol) model.SymbolRef {
-	this.symbolSpacesMu.RLock()
-	space := this.symbolSpaces[ref.SpaceIndex]
-	this.symbolSpacesMu.RUnlock()
+func (c *CompilerEnvironment) AddSymbolToSameSpace(ref model.SymbolRef, name string, symbol model.Symbol) model.SymbolRef {
+	c.symbolSpacesMu.RLock()
+	space := c.symbolSpaces[ref.SpaceIndex]
+	c.symbolSpacesMu.RUnlock()
 	space.AddSymbol(name, symbol)
 	newRef, _ := space.GetSymbol(name)
 	return newRef
@@ -85,61 +85,61 @@ func (this *CompilerEnvironment) AddSymbolToSameSpace(ref model.SymbolRef, name 
 
 // CreateNarrowedSymbol create a narrowed symbol for the given baseRef symbol. IMPORTANT: baseRef must be the actual symbol
 // not a narrowed symbol.
-func (this *CompilerEnvironment) CreateNarrowedSymbol(baseRef model.SymbolRef) model.SymbolRef {
-	this.symbolSpacesMu.RLock()
-	symbolSpace := this.symbolSpaces[baseRef.SpaceIndex]
-	this.symbolSpacesMu.RUnlock()
-	underlyingSymbolCopy := this.GetSymbol(baseRef).Copy()
+func (c *CompilerEnvironment) CreateNarrowedSymbol(baseRef model.SymbolRef) model.SymbolRef {
+	c.symbolSpacesMu.RLock()
+	symbolSpace := c.symbolSpaces[baseRef.SpaceIndex]
+	c.symbolSpacesMu.RUnlock()
+	underlyingSymbolCopy := c.GetSymbol(baseRef).Copy()
 	symbolIndex := symbolSpace.AppendSymbol(underlyingSymbolCopy)
 	narrowedSymbol := model.SymbolRef{
 		Package:    baseRef.Package,
 		SpaceIndex: baseRef.SpaceIndex,
 		Index:      symbolIndex,
 	}
-	this.underlyingSymbol.Store(narrowedSymbol, baseRef)
+	c.underlyingSymbol.Store(narrowedSymbol, baseRef)
 	return narrowedSymbol
 }
 
-func (this *CompilerEnvironment) CreateFunctionSymbol(space *model.SymbolSpace, name string, signature model.FunctionSignature, fnTy semtypes.SemType) model.SymbolRef {
+func (c *CompilerEnvironment) CreateFunctionSymbol(space *model.SymbolSpace, name string, signature model.FunctionSignature, fnTy semtypes.SemType) model.SymbolRef {
 	sym := model.NewFunctionSymbol(name, signature, false)
 	sym.SetType(fnTy)
 	symbolIndex := space.AppendSymbol(sym)
 	return space.RefAt(symbolIndex)
 }
 
-func (this *CompilerEnvironment) UnnarrowedSymbol(symbol model.SymbolRef) model.SymbolRef {
-	if underlying, ok := this.underlyingSymbol.Load(symbol); ok {
+func (c *CompilerEnvironment) UnnarrowedSymbol(symbol model.SymbolRef) model.SymbolRef {
+	if underlying, ok := c.underlyingSymbol.Load(symbol); ok {
 		return underlying.(model.SymbolRef)
 	}
 	return symbol
 }
 
-func (this *CompilerEnvironment) SymbolName(symbol model.SymbolRef) string {
-	return this.GetSymbol(symbol).Name()
+func (c *CompilerEnvironment) SymbolName(symbol model.SymbolRef) string {
+	return c.GetSymbol(symbol).Name()
 }
 
-func (this *CompilerEnvironment) SymbolType(symbol model.SymbolRef) semtypes.SemType {
-	return this.GetSymbol(symbol).Type()
+func (c *CompilerEnvironment) SymbolType(symbol model.SymbolRef) semtypes.SemType {
+	return c.GetSymbol(symbol).Type()
 }
 
-func (this *CompilerEnvironment) SymbolKind(symbol model.SymbolRef) model.SymbolKind {
-	return this.GetSymbol(symbol).Kind()
+func (c *CompilerEnvironment) SymbolKind(symbol model.SymbolRef) model.SymbolKind {
+	return c.GetSymbol(symbol).Kind()
 }
 
-func (this *CompilerEnvironment) SymbolIsPublic(symbol model.SymbolRef) bool {
-	return this.GetSymbol(symbol).IsPublic()
+func (c *CompilerEnvironment) SymbolIsPublic(symbol model.SymbolRef) bool {
+	return c.GetSymbol(symbol).IsPublic()
 }
 
-func (this *CompilerEnvironment) SetSymbolType(symbol model.SymbolRef, ty semtypes.SemType) {
-	this.GetSymbol(symbol).SetType(ty)
+func (c *CompilerEnvironment) SetSymbolType(symbol model.SymbolRef, ty semtypes.SemType) {
+	c.GetSymbol(symbol).SetType(ty)
 }
 
-func (this *CompilerEnvironment) GetDefaultPackage() *model.PackageID {
-	return this.packageInterner.GetDefaultPackage()
+func (c *CompilerEnvironment) GetDefaultPackage() *model.PackageID {
+	return c.packageInterner.GetDefaultPackage()
 }
 
-func (this *CompilerEnvironment) NewPackageID(orgName model.Name, nameComps []model.Name, version model.Name) *model.PackageID {
-	return model.NewPackageID(this.packageInterner, orgName, nameComps, version)
+func (c *CompilerEnvironment) NewPackageID(orgName model.Name, nameComps []model.Name, version model.Name) *model.PackageID {
+	return model.NewPackageID(c.packageInterner, orgName, nameComps, version)
 }
 
 func NewCompilerEnvironment(typeEnv semtypes.Env, statsEnabled bool) *CompilerEnvironment {
@@ -154,8 +154,8 @@ func NewCompilerEnvironment(typeEnv semtypes.Env, statsEnabled bool) *CompilerEn
 }
 
 // GetTypeEnv returns the type environment for this context
-func (this *CompilerEnvironment) GetTypeEnv() semtypes.Env {
-	return this.typeEnv
+func (c *CompilerEnvironment) GetTypeEnv() semtypes.Env {
+	return c.typeEnv
 }
 
 const (
@@ -164,15 +164,15 @@ const (
 	ANON_TYPE         = ANON_PREFIX + "Type$"
 )
 
-func (this *CompilerEnvironment) GetNextAnonymousFunctionKey(packageID *model.PackageID) string {
-	nextValue := this.anonFuncCount[packageID]
-	this.anonFuncCount[packageID] = nextValue + 1
+func (c *CompilerEnvironment) GetNextAnonymousFunctionKey(packageID *model.PackageID) string {
+	nextValue := c.anonFuncCount[packageID]
+	c.anonFuncCount[packageID] = nextValue + 1
 	return ANON_PREFIX + "Func$_" + strconv.Itoa(nextValue)
 }
 
-func (this *CompilerEnvironment) GetNextAnonymousTypeKey(packageID *model.PackageID) string {
-	nextValue := this.anonTypeCount[packageID]
-	this.anonTypeCount[packageID] = nextValue + 1
+func (c *CompilerEnvironment) GetNextAnonymousTypeKey(packageID *model.PackageID) string {
+	nextValue := c.anonTypeCount[packageID]
+	c.anonTypeCount[packageID] = nextValue + 1
 	if packageID != nil && model.ANNOTATIONS_PKG != packageID {
 		return BUILTIN_ANON_TYPE + "_" + strconv.Itoa(nextValue)
 	}

--- a/model/package_id.go
+++ b/model/package_id.go
@@ -38,8 +38,8 @@ const (
 
 type Name string
 
-func (this *Name) Value() string {
-	return string(*this)
+func (n *Name) Value() string {
+	return string(*n)
 }
 
 const (
@@ -174,8 +174,8 @@ type PackageID struct {
 	IsTestPkg      bool
 }
 
-func (this *PackageID) IsUnnamed() bool {
-	return this.isUnnamed || (this.OrgName == nil && this.PkgName == nil && this.Version == nil)
+func (p *PackageID) IsUnnamed() bool {
+	return p.isUnnamed || (p.OrgName == nil && p.PkgName == nil && p.Version == nil)
 }
 
 func NewPackageID(interner *PackageIDInterner, orgName Name, nameComps []Name, version Name) *PackageID {
@@ -255,21 +255,21 @@ type PackageIDInterner struct {
 	packageMap map[packageKey]*PackageID
 }
 
-func (this *PackageIDInterner) GetDefaultPackage() *PackageID {
+func (p *PackageIDInterner) GetDefaultPackage() *PackageID {
 	return DEFAULT
 }
 
-func (this *PackageIDInterner) Intern(packageID *PackageID) *PackageID {
+func (p *PackageIDInterner) Intern(packageID *PackageID) *PackageID {
 	packageKey := packageKeyFromPackageID(packageID)
-	this.rwLock.RLock()
-	internedPackage, ok := this.packageMap[packageKey]
-	this.rwLock.RUnlock()
+	p.rwLock.RLock()
+	internedPackage, ok := p.packageMap[packageKey]
+	p.rwLock.RUnlock()
 	if ok {
 		return internedPackage
 	}
-	this.rwLock.Lock()
-	defer this.rwLock.Unlock()
-	this.packageMap[packageKey] = packageID
+	p.rwLock.Lock()
+	defer p.rwLock.Unlock()
+	p.packageMap[packageKey] = packageID
 	return packageID
 }
 

--- a/parser/error_handler.go
+++ b/parser/error_handler.go
@@ -162,9 +162,9 @@ func NewSolutionWithDepth(action Action, ctx common.ParserRuleContext, tokenKind
 	}
 }
 
-func (this *Solution) ToString() string {
+func (s *Solution) ToString() string {
 	actionStr := "UNKNOWN"
-	switch this.Action {
+	switch s.Action {
 	case ACTION_INSERT:
 		actionStr = "INSERT"
 	case ACTION_REMOVE:
@@ -172,7 +172,7 @@ func (this *Solution) ToString() string {
 	case ACTION_KEEP:
 		actionStr = "KEEP"
 	}
-	return actionStr + "'" + this.TokenText + "'"
+	return actionStr + "'" + s.TokenText + "'"
 }
 
 // ============================================================================
@@ -1044,8 +1044,8 @@ func NewBallerinaParserErrorHandlerFromTokenReader(tokenReader *TokenReader) Bal
 	return this
 }
 
-func (this *BallerinaParserErrorHandler) isEndOfObjectTypeNode(nextLookahead int) bool {
-	nextToken := this.tokenReader.PeekN(nextLookahead)
+func (b *BallerinaParserErrorHandler) isEndOfObjectTypeNode(nextLookahead int) bool {
+	nextToken := b.tokenReader.PeekN(nextLookahead)
 	switch nextToken.Kind() {
 	case common.CLOSE_BRACE_TOKEN,
 		common.EOF_TOKEN,
@@ -1054,7 +1054,7 @@ func (this *BallerinaParserErrorHandler) isEndOfObjectTypeNode(nextLookahead int
 		common.SERVICE_KEYWORD:
 		return true
 	default:
-		nextNextToken := this.tokenReader.PeekN(nextLookahead + 1)
+		nextNextToken := b.tokenReader.PeekN(nextLookahead + 1)
 		switch nextNextToken.Kind() {
 		case common.CLOSE_BRACE_TOKEN,
 			common.EOF_TOKEN,
@@ -1068,7 +1068,7 @@ func (this *BallerinaParserErrorHandler) isEndOfObjectTypeNode(nextLookahead int
 	}
 }
 
-func (this *BallerinaParserErrorHandler) SeekMatch(currentCtx common.ParserRuleContext, lookahead int, currentDepth int, isEntryPoint bool) (result *Result) {
+func (b *BallerinaParserErrorHandler) SeekMatch(currentCtx common.ParserRuleContext, lookahead int, currentDepth int, isEntryPoint bool) (result *Result) {
 	traceRecovery(currentCtx, func() string {
 		return fmt.Sprintf("(SeekMatch start %s %d %d %s)", formatParserRuleContext(currentCtx), lookahead, currentDepth, formatBool(isEntryPoint))
 	})
@@ -1080,8 +1080,8 @@ func (this *BallerinaParserErrorHandler) SeekMatch(currentCtx common.ParserRuleC
 	matchingRulesCount := 0
 	for currentDepth < LOOKAHEAD_LIMIT {
 		skipRule = false
-		lookahead = this.getNextLookahead(lookahead)
-		nextToken := this.tokenReader.PeekN(lookahead)
+		lookahead = b.getNextLookahead(lookahead)
+		nextToken := b.tokenReader.PeekN(lookahead)
 		switch currentCtx {
 		case common.PARSER_RULE_CONTEXT_EOF:
 			hasMatch = (nextToken.Kind() == common.EOF_TOKEN)
@@ -1133,7 +1133,7 @@ func (this *BallerinaParserErrorHandler) SeekMatch(currentCtx common.ParserRuleC
 		case common.PARSER_RULE_CONTEXT_SEMICOLON:
 			hasMatch = (nextToken.Kind() == common.SEMICOLON_TOKEN)
 		case common.PARSER_RULE_CONTEXT_BINARY_OPERATOR:
-			hasMatch = this.isBinaryOperator(nextToken)
+			hasMatch = b.isBinaryOperator(nextToken)
 		case common.PARSER_RULE_CONTEXT_COMMA,
 			common.PARSER_RULE_CONTEXT_ERROR_MESSAGE_BINDING_PATTERN_END_COMMA,
 			common.PARSER_RULE_CONTEXT_ERROR_MESSAGE_MATCH_PATTERN_END_COMMA:
@@ -1172,7 +1172,7 @@ func (this *BallerinaParserErrorHandler) SeekMatch(currentCtx common.ParserRuleC
 			common.PARSER_RULE_CONTEXT_RESOURCE_METHOD_CALL_SLASH_TOKEN:
 			hasMatch = (nextToken.Kind() == common.SLASH_TOKEN)
 		case common.PARSER_RULE_CONTEXT_BASIC_LITERAL:
-			hasMatch = this.isBasicLiteral(nextToken.Kind())
+			hasMatch = b.isBasicLiteral(nextToken.Kind())
 		case common.PARSER_RULE_CONTEXT_COLON,
 			common.PARSER_RULE_CONTEXT_VAR_REF_COLON,
 			common.PARSER_RULE_CONTEXT_TYPE_REF_COLON:
@@ -1180,7 +1180,7 @@ func (this *BallerinaParserErrorHandler) SeekMatch(currentCtx common.ParserRuleC
 		case common.PARSER_RULE_CONTEXT_STRING_LITERAL_TOKEN:
 			hasMatch = (nextToken.Kind() == common.STRING_LITERAL_TOKEN)
 		case common.PARSER_RULE_CONTEXT_UNARY_OPERATOR:
-			hasMatch = this.isUnaryOperator(nextToken)
+			hasMatch = b.isUnaryOperator(nextToken)
 		case common.PARSER_RULE_CONTEXT_HEX_INTEGER_LITERAL_TOKEN:
 			hasMatch = (nextToken.Kind() == common.HEX_INTEGER_LITERAL_TOKEN)
 		case common.PARSER_RULE_CONTEXT_AT:
@@ -1203,7 +1203,7 @@ func (this *BallerinaParserErrorHandler) SeekMatch(currentCtx common.ParserRuleC
 		case common.PARSER_RULE_CONTEXT_IDENT_AFTER_OBJECT_IDENT:
 			hasMatch = ((nextToken.Kind() == common.FUNCTION_KEYWORD) || (nextToken.Kind() == common.FIELD_KEYWORD))
 		case common.PARSER_RULE_CONTEXT_SINGLE_KEYWORD_ATTACH_POINT_IDENT:
-			hasMatch = this.isSingleKeywordAttachPointIdent(nextToken.Kind())
+			hasMatch = b.isSingleKeywordAttachPointIdent(nextToken.Kind())
 		case common.PARSER_RULE_CONTEXT_OBJECT_IDENT:
 			hasMatch = (nextToken.Kind() == common.OBJECT_KEYWORD)
 		case common.PARSER_RULE_CONTEXT_RECORD_IDENT:
@@ -1306,13 +1306,13 @@ func (this *BallerinaParserErrorHandler) SeekMatch(currentCtx common.ParserRuleC
 			common.PARSER_RULE_CONTEXT_TYPE_DESC_BEFORE_IDENTIFIER_IN_GROUPING_KEY:
 			fallthrough
 		default:
-			if this.isKeyword(currentCtx) {
-				expectedTokenKind := this.getExpectedKeywordKind(currentCtx)
+			if b.isKeyword(currentCtx) {
+				expectedTokenKind := b.getExpectedKeywordKind(currentCtx)
 				hasMatch = ((nextToken.Kind() == expectedTokenKind) || isKeywordMatch(expectedTokenKind, nextToken))
 				break
 			}
-			if this.HasAlternativePaths(currentCtx) {
-				result := this.seekMatchInAlternativePaths(currentCtx, lookahead, currentDepth, matchingRulesCount,
+			if b.HasAlternativePaths(currentCtx) {
+				result := b.seekMatchInAlternativePaths(currentCtx, lookahead, currentDepth, matchingRulesCount,
 					isEntryPoint)
 				return &result
 			}
@@ -1320,7 +1320,7 @@ func (this *BallerinaParserErrorHandler) SeekMatch(currentCtx common.ParserRuleC
 			hasMatch = true
 		}
 		if !hasMatch {
-			return this.fixAndContinue(currentCtx, lookahead, currentDepth, matchingRulesCount, isEntryPoint)
+			return b.fixAndContinue(currentCtx, lookahead, currentDepth, matchingRulesCount, isEntryPoint)
 		}
 		if !skipRule {
 			currentDepth++
@@ -1328,21 +1328,21 @@ func (this *BallerinaParserErrorHandler) SeekMatch(currentCtx common.ParserRuleC
 			lookahead++
 			isEntryPoint = false
 		}
-		currentCtx = this.GetNextRule(currentCtx, lookahead)
+		currentCtx = b.GetNextRule(currentCtx, lookahead)
 	}
 	result = NewResult(make([]*Solution, 0), matchingRulesCount)
 	result.solution = NewSolution(ACTION_KEEP, currentCtx, common.NONE, currentCtx.String())
 	return result
 }
 
-func (this *BallerinaParserErrorHandler) getNextLookahead(lookahead int) int {
-	for this.tokenReader.PeekN(lookahead).Kind() == common.DOCUMENTATION_STRING {
+func (b *BallerinaParserErrorHandler) getNextLookahead(lookahead int) int {
+	for b.tokenReader.PeekN(lookahead).Kind() == common.DOCUMENTATION_STRING {
 		lookahead++
 	}
 	return lookahead
 }
 
-func (this *BallerinaParserErrorHandler) isKeyword(currentCtx common.ParserRuleContext) bool {
+func (b *BallerinaParserErrorHandler) isKeyword(currentCtx common.ParserRuleContext) bool {
 	switch currentCtx {
 	case common.PARSER_RULE_CONTEXT_EOF,
 		common.PARSER_RULE_CONTEXT_PUBLIC_KEYWORD,
@@ -1429,7 +1429,7 @@ func (this *BallerinaParserErrorHandler) isKeyword(currentCtx common.ParserRuleC
 	}
 }
 
-func (this *BallerinaParserErrorHandler) HasAlternativePaths(currentCtx common.ParserRuleContext) bool {
+func (b *BallerinaParserErrorHandler) HasAlternativePaths(currentCtx common.ParserRuleContext) bool {
 	switch currentCtx {
 	case common.PARSER_RULE_CONTEXT_TOP_LEVEL_NODE,
 		common.PARSER_RULE_CONTEXT_TOP_LEVEL_NODE_WITHOUT_MODIFIER,
@@ -1686,7 +1686,7 @@ func (this *BallerinaParserErrorHandler) HasAlternativePaths(currentCtx common.P
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getShortestAlternative(currentCtx common.ParserRuleContext) common.ParserRuleContext {
+func (b *BallerinaParserErrorHandler) getShortestAlternative(currentCtx common.ParserRuleContext) common.ParserRuleContext {
 	switch currentCtx {
 	case common.PARSER_RULE_CONTEXT_TOP_LEVEL_NODE,
 		common.PARSER_RULE_CONTEXT_TOP_LEVEL_NODE_WITHOUT_MODIFIER,
@@ -2147,7 +2147,7 @@ func (this *BallerinaParserErrorHandler) getShortestAlternative(currentCtx commo
 	}
 }
 
-func (this *BallerinaParserErrorHandler) seekMatchInAlternativePaths(currentCtx common.ParserRuleContext, lookahead int, currentDepth int, matchingRulesCount int, isEntryPoint bool) (result Result) {
+func (b *BallerinaParserErrorHandler) seekMatchInAlternativePaths(currentCtx common.ParserRuleContext, lookahead int, currentDepth int, matchingRulesCount int, isEntryPoint bool) (result Result) {
 	traceRecovery(currentCtx, func() string {
 		return fmt.Sprintf("(seekMatchInAlternativePaths start %s %d %d %d %s)", formatParserRuleContext(currentCtx), lookahead, currentDepth, matchingRulesCount, formatBool(isEntryPoint))
 	})
@@ -2169,11 +2169,11 @@ func (this *BallerinaParserErrorHandler) seekMatchInAlternativePaths(currentCtx 
 	case common.PARSER_RULE_CONTEXT_FUNC_TYPE_DESC_START_WITHOUT_FIRST_QUAL:
 		alternativeRules = FUNC_TYPE_DESC_START_WITHOUT_FIRST_QUAL
 	case common.PARSER_RULE_CONTEXT_FUNC_OPTIONAL_RETURNS:
-		parentCtx := this.GetParentContext()
+		parentCtx := b.GetParentContext()
 		var alternatives []common.ParserRuleContext
 		switch parentCtx {
 		case common.PARSER_RULE_CONTEXT_FUNC_DEF:
-			grandParentCtx := this.GetGrandParentContext()
+			grandParentCtx := b.GetGrandParentContext()
 			if grandParentCtx == common.PARSER_RULE_CONTEXT_OBJECT_TYPE_MEMBER {
 				alternatives = METHOD_DECL_OPTIONAL_RETURNS
 			} else {
@@ -2210,7 +2210,7 @@ func (this *BallerinaParserErrorHandler) seekMatchInAlternativePaths(currentCtx 
 	case common.PARSER_RULE_CONTEXT_RECORD_BODY_START:
 		alternativeRules = RECORD_BODY_START
 	case common.PARSER_RULE_CONTEXT_TYPE_DESCRIPTOR:
-		if !this.isInTypeDescContext() {
+		if !b.isInTypeDescContext() {
 			panic("assertion failed")
 		}
 		alternativeRules = TYPE_DESCRIPTORS
@@ -2392,13 +2392,13 @@ func (this *BallerinaParserErrorHandler) seekMatchInAlternativePaths(currentCtx 
 	case common.PARSER_RULE_CONTEXT_TUPLE_MEMBER:
 		alternativeRules = TUPLE_MEMBER
 	default:
-		return this.seekMatchInStmtRelatedAlternativePaths(currentCtx, lookahead, currentDepth, matchingRulesCount,
+		return b.seekMatchInStmtRelatedAlternativePaths(currentCtx, lookahead, currentDepth, matchingRulesCount,
 			isEntryPoint)
 	}
-	return *this.seekInAlternativesPaths(lookahead, currentDepth, matchingRulesCount, alternativeRules, isEntryPoint)
+	return *b.seekInAlternativesPaths(lookahead, currentDepth, matchingRulesCount, alternativeRules, isEntryPoint)
 }
 
-func (this *BallerinaParserErrorHandler) seekMatchInStmtRelatedAlternativePaths(currentCtx common.ParserRuleContext, lookahead int, currentDepth int, matchingRulesCount int, isEntryPoint bool) (result Result) {
+func (b *BallerinaParserErrorHandler) seekMatchInStmtRelatedAlternativePaths(currentCtx common.ParserRuleContext, lookahead int, currentDepth int, matchingRulesCount int, isEntryPoint bool) (result Result) {
 	traceRecovery(currentCtx, func() string {
 		return fmt.Sprintf("(seekMatchInStmtRelatedAlternativePaths start %s %d %d %d %s)", formatParserRuleContext(currentCtx), lookahead, currentDepth, matchingRulesCount, formatBool(isEntryPoint))
 	})
@@ -2410,7 +2410,7 @@ func (this *BallerinaParserErrorHandler) seekMatchInStmtRelatedAlternativePaths(
 	case common.PARSER_RULE_CONTEXT_VAR_DECL_STMT_RHS:
 		alternativeRules = VAR_DECL_RHS
 	case common.PARSER_RULE_CONTEXT_STATEMENT, common.PARSER_RULE_CONTEXT_STATEMENT_WITHOUT_ANNOTS:
-		return this.seekInStatements(currentCtx, lookahead, currentDepth, matchingRulesCount, isEntryPoint)
+		return b.seekInStatements(currentCtx, lookahead, currentDepth, matchingRulesCount, isEntryPoint)
 	case common.PARSER_RULE_CONTEXT_TYPE_NAME_OR_VAR_NAME:
 		alternativeRules = TYPE_OR_VAR_NAME
 	case common.PARSER_RULE_CONTEXT_ELSE_BLOCK:
@@ -2430,7 +2430,7 @@ func (this *BallerinaParserErrorHandler) seekMatchInStmtRelatedAlternativePaths(
 	case common.PARSER_RULE_CONTEXT_EXPRESSION_STATEMENT_START:
 		alternativeRules = EXPRESSION_STATEMENT_START
 	case common.PARSER_RULE_CONTEXT_TYPE_DESC_RHS:
-		if !this.isInTypeDescContext() {
+		if !b.isInTypeDescContext() {
 			panic("assertion failed")
 		}
 		alternativeRules = TYPE_DESC_RHS
@@ -2581,13 +2581,13 @@ func (this *BallerinaParserErrorHandler) seekMatchInStmtRelatedAlternativePaths(
 	case common.PARSER_RULE_CONTEXT_ASSIGNMENT_STMT_RHS:
 		alternativeRules = ASSIGNMENT_STMT_RHS
 	default:
-		return this.seekMatchInExprRelatedAlternativePaths(currentCtx, lookahead, currentDepth, matchingRulesCount,
+		return b.seekMatchInExprRelatedAlternativePaths(currentCtx, lookahead, currentDepth, matchingRulesCount,
 			isEntryPoint)
 	}
-	return *this.seekInAlternativesPaths(lookahead, currentDepth, matchingRulesCount, alternativeRules, isEntryPoint)
+	return *b.seekInAlternativesPaths(lookahead, currentDepth, matchingRulesCount, alternativeRules, isEntryPoint)
 }
 
-func (this *BallerinaParserErrorHandler) seekMatchInExprRelatedAlternativePaths(currentCtx common.ParserRuleContext, lookahead int, currentDepth int, matchingRulesCount int, isEntryPoint bool) (result Result) {
+func (b *BallerinaParserErrorHandler) seekMatchInExprRelatedAlternativePaths(currentCtx common.ParserRuleContext, lookahead int, currentDepth int, matchingRulesCount int, isEntryPoint bool) (result Result) {
 	traceRecovery(currentCtx, func() string {
 		return fmt.Sprintf("(seekMatchInExprRelatedAlternativePaths start %s %d %d %d %s)", formatParserRuleContext(currentCtx), lookahead, currentDepth, matchingRulesCount, formatBool(isEntryPoint))
 	})
@@ -2607,7 +2607,7 @@ func (this *BallerinaParserErrorHandler) seekMatchInExprRelatedAlternativePaths(
 	case common.PARSER_RULE_CONTEXT_ARG_END:
 		alternativeRules = ARG_END
 	case common.PARSER_RULE_CONTEXT_ACCESS_EXPRESSION:
-		return this.seekInAccessExpression(currentCtx, lookahead, currentDepth, matchingRulesCount, isEntryPoint)
+		return b.seekInAccessExpression(currentCtx, lookahead, currentDepth, matchingRulesCount, isEntryPoint)
 	case common.PARSER_RULE_CONTEXT_FIRST_MAPPING_FIELD:
 		alternativeRules = FIRST_MAPPING_FIELD_START
 	case common.PARSER_RULE_CONTEXT_MAPPING_FIELD:
@@ -2692,9 +2692,9 @@ func (this *BallerinaParserErrorHandler) seekMatchInExprRelatedAlternativePaths(
 	case common.PARSER_RULE_CONTEXT_RESULT_CLAUSE:
 		alternativeRules = RESULT_CLAUSE
 	case common.PARSER_RULE_CONTEXT_EXPRESSION_RHS:
-		return this.seekMatchInExpressionRhs(lookahead, currentDepth, matchingRulesCount, isEntryPoint, false)
+		return b.seekMatchInExpressionRhs(lookahead, currentDepth, matchingRulesCount, isEntryPoint, false)
 	case common.PARSER_RULE_CONTEXT_VARIABLE_REF_RHS:
-		return this.seekMatchInExpressionRhs(lookahead, currentDepth, matchingRulesCount, isEntryPoint, true)
+		return b.seekMatchInExpressionRhs(lookahead, currentDepth, matchingRulesCount, isEntryPoint, true)
 	case common.PARSER_RULE_CONTEXT_ERROR_CONSTRUCTOR_RHS:
 		alternativeRules = ERROR_CONSTRUCTOR_RHS
 	case common.PARSER_RULE_CONTEXT_SINGLE_OR_ALTERNATE_WORKER_SEPARATOR:
@@ -2706,28 +2706,28 @@ func (this *BallerinaParserErrorHandler) seekMatchInExprRelatedAlternativePaths(
 	default:
 		panic("seekMatchInExprRelatedAlternativePaths found: " + currentCtx.String())
 	}
-	return *this.seekInAlternativesPaths(lookahead, currentDepth, matchingRulesCount, alternativeRules, isEntryPoint)
+	return *b.seekInAlternativesPaths(lookahead, currentDepth, matchingRulesCount, alternativeRules, isEntryPoint)
 }
 
-func (this *BallerinaParserErrorHandler) seekInStatements(currentCtx common.ParserRuleContext, lookahead int, currentDepth int, currentMatches int, isEntryPoint bool) Result {
-	nextToken := this.tokenReader.PeekN(lookahead)
+func (b *BallerinaParserErrorHandler) seekInStatements(currentCtx common.ParserRuleContext, lookahead int, currentDepth int, currentMatches int, isEntryPoint bool) Result {
+	nextToken := b.tokenReader.PeekN(lookahead)
 	if nextToken.Kind() == common.SEMICOLON_TOKEN {
-		result := this.seekMatchInSubTree(common.PARSER_RULE_CONTEXT_STATEMENT, lookahead+1, currentDepth+1,
+		result := b.seekMatchInSubTree(common.PARSER_RULE_CONTEXT_STATEMENT, lookahead+1, currentDepth+1,
 			isEntryPoint)
 		result.pushFix(NewSolutionWithDepth(ACTION_REMOVE, currentCtx, nextToken.Kind(), nextToken.Text(), currentDepth))
-		return *this.getFinalResult(currentMatches, result)
+		return *b.getFinalResult(currentMatches, result)
 	}
-	return *this.seekInAlternativesPaths(lookahead, currentDepth, currentMatches, STATEMENTS, isEntryPoint)
+	return *b.seekInAlternativesPaths(lookahead, currentDepth, currentMatches, STATEMENTS, isEntryPoint)
 }
 
-func (this *BallerinaParserErrorHandler) seekInAccessExpression(currentCtx common.ParserRuleContext, lookahead int, currentDepth int, currentMatches int, isEntryPoint bool) Result {
-	nextToken := this.tokenReader.PeekN(lookahead)
+func (b *BallerinaParserErrorHandler) seekInAccessExpression(currentCtx common.ParserRuleContext, lookahead int, currentDepth int, currentMatches int, isEntryPoint bool) Result {
+	nextToken := b.tokenReader.PeekN(lookahead)
 	currentDepth++
 	if nextToken.Kind() != common.IDENTIFIER_TOKEN {
-		return *this.fixAndContinue(currentCtx, lookahead, currentDepth, currentMatches, isEntryPoint)
+		return *b.fixAndContinue(currentCtx, lookahead, currentDepth, currentMatches, isEntryPoint)
 	}
 	var nextContext common.ParserRuleContext
-	nextNextToken := this.tokenReader.PeekN(lookahead + 1)
+	nextNextToken := b.tokenReader.PeekN(lookahead + 1)
 	switch nextNextToken.Kind() {
 	case common.OPEN_PAREN_TOKEN:
 		nextContext = common.PARSER_RULE_CONTEXT_OPEN_PARENTHESIS
@@ -2736,16 +2736,16 @@ func (this *BallerinaParserErrorHandler) seekInAccessExpression(currentCtx commo
 	case common.OPEN_BRACKET_TOKEN:
 		nextContext = common.PARSER_RULE_CONTEXT_MEMBER_ACCESS_KEY_EXPR
 	default:
-		nextContext = this.getNextRuleForExpr()
+		nextContext = b.getNextRuleForExpr()
 	}
 	currentMatches++
 	lookahead++
-	result := this.SeekMatch(nextContext, lookahead, currentDepth, isEntryPoint)
-	return *this.getFinalResult(currentMatches, result)
+	result := b.SeekMatch(nextContext, lookahead, currentDepth, isEntryPoint)
+	return *b.getFinalResult(currentMatches, result)
 }
 
-func (this *BallerinaParserErrorHandler) seekMatchInExpressionRhs(lookahead int, currentDepth int, currentMatches int, isEntryPoint bool, allowFuncCall bool) Result {
-	parentCtx := this.GetParentContext()
+func (b *BallerinaParserErrorHandler) seekMatchInExpressionRhs(lookahead int, currentDepth int, currentMatches int, isEntryPoint bool, allowFuncCall bool) Result {
+	parentCtx := b.GetParentContext()
 	var alternatives []common.ParserRuleContext
 	switch parentCtx {
 	case common.PARSER_RULE_CONTEXT_ARG_LIST:
@@ -2774,15 +2774,15 @@ func (this *BallerinaParserErrorHandler) seekMatchInExpressionRhs(lookahead int,
 	case common.PARSER_RULE_CONTEXT_QUERY_EXPRESSION:
 		alternatives = []common.ParserRuleContext{common.PARSER_RULE_CONTEXT_QUERY_PIPELINE_RHS, common.PARSER_RULE_CONTEXT_BINARY_OPERATOR, common.PARSER_RULE_CONTEXT_DOT, common.PARSER_RULE_CONTEXT_ANNOT_CHAINING_TOKEN, common.PARSER_RULE_CONTEXT_OPTIONAL_CHAINING_TOKEN, common.PARSER_RULE_CONTEXT_CONDITIONAL_EXPRESSION, common.PARSER_RULE_CONTEXT_XML_NAVIGATE_EXPR, common.PARSER_RULE_CONTEXT_MEMBER_ACCESS_KEY_EXPR}
 	default:
-		if this.isParameter(parentCtx) {
+		if b.isParameter(parentCtx) {
 			alternatives = []common.ParserRuleContext{common.PARSER_RULE_CONTEXT_CLOSE_PARENTHESIS, common.PARSER_RULE_CONTEXT_BINARY_OPERATOR, common.PARSER_RULE_CONTEXT_DOT, common.PARSER_RULE_CONTEXT_ANNOT_CHAINING_TOKEN, common.PARSER_RULE_CONTEXT_OPTIONAL_CHAINING_TOKEN, common.PARSER_RULE_CONTEXT_CONDITIONAL_EXPRESSION, common.PARSER_RULE_CONTEXT_XML_NAVIGATE_EXPR, common.PARSER_RULE_CONTEXT_MEMBER_ACCESS_KEY_EXPR, common.PARSER_RULE_CONTEXT_COMMA}
 		}
 	}
 	if alternatives != nil {
 		if allowFuncCall {
-			alternatives = this.modifyAlternativesWithArgListStart(alternatives)
+			alternatives = b.modifyAlternativesWithArgListStart(alternatives)
 		}
-		return *this.seekInAlternativesPaths(lookahead, currentDepth, currentMatches, alternatives, isEntryPoint)
+		return *b.seekInAlternativesPaths(lookahead, currentDepth, currentMatches, alternatives, isEntryPoint)
 	}
 	var nextContext common.ParserRuleContext
 	if ((parentCtx == common.PARSER_RULE_CONTEXT_IF_BLOCK) || (parentCtx == common.PARSER_RULE_CONTEXT_WHILE_BLOCK)) || (parentCtx == common.PARSER_RULE_CONTEXT_FOREACH_STMT) {
@@ -2791,7 +2791,7 @@ func (this *BallerinaParserErrorHandler) seekMatchInExpressionRhs(lookahead int,
 		nextContext = common.PARSER_RULE_CONTEXT_MATCH_BODY
 	} else if parentCtx == common.PARSER_RULE_CONTEXT_CALL_STMT {
 		nextContext = common.PARSER_RULE_CONTEXT_METHOD_CALL_DOT
-	} else if (((((this.isStatement(parentCtx) || (parentCtx == common.PARSER_RULE_CONTEXT_RECORD_FIELD)) || (parentCtx == common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR_MEMBER)) || (parentCtx == common.PARSER_RULE_CONTEXT_CLASS_MEMBER)) || (parentCtx == common.PARSER_RULE_CONTEXT_OBJECT_TYPE_MEMBER)) || (parentCtx == common.PARSER_RULE_CONTEXT_LISTENER_DECL)) || (parentCtx == common.PARSER_RULE_CONTEXT_CONSTANT_DECL) {
+	} else if (((((b.isStatement(parentCtx) || (parentCtx == common.PARSER_RULE_CONTEXT_RECORD_FIELD)) || (parentCtx == common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR_MEMBER)) || (parentCtx == common.PARSER_RULE_CONTEXT_CLASS_MEMBER)) || (parentCtx == common.PARSER_RULE_CONTEXT_OBJECT_TYPE_MEMBER)) || (parentCtx == common.PARSER_RULE_CONTEXT_LISTENER_DECL)) || (parentCtx == common.PARSER_RULE_CONTEXT_CONSTANT_DECL) {
 		nextContext = common.PARSER_RULE_CONTEXT_SEMICOLON
 	} else if parentCtx == common.PARSER_RULE_CONTEXT_ANNOTATIONS {
 		nextContext = common.PARSER_RULE_CONTEXT_ANNOTATION_END
@@ -2810,7 +2810,7 @@ func (this *BallerinaParserErrorHandler) seekMatchInExpressionRhs(lookahead int,
 	} else if parentCtx == common.PARSER_RULE_CONTEXT_MATCH_BODY {
 		nextContext = common.PARSER_RULE_CONTEXT_RIGHT_DOUBLE_ARROW
 	} else if (parentCtx == common.PARSER_RULE_CONTEXT_SELECT_CLAUSE) || (parentCtx == common.PARSER_RULE_CONTEXT_COLLECT_CLAUSE) {
-		nextToken := this.tokenReader.PeekN(lookahead)
+		nextToken := b.tokenReader.PeekN(lookahead)
 		switch nextToken.Kind() {
 		case common.ON_KEYWORD, common.CONFLICT_KEYWORD:
 			nextContext = common.PARSER_RULE_CONTEXT_ON_CONFLICT_CLAUSE
@@ -2826,21 +2826,21 @@ func (this *BallerinaParserErrorHandler) seekMatchInExpressionRhs(lookahead int,
 	} else {
 		panic("seekMatchInExpressionRhs found: " + parentCtx.String())
 	}
-	alternatives = this.getExpressionRhsAlternatives(nextContext)
+	alternatives = b.getExpressionRhsAlternatives(nextContext)
 	if allowFuncCall {
-		alternatives = this.modifyAlternativesWithArgListStart(alternatives)
+		alternatives = b.modifyAlternativesWithArgListStart(alternatives)
 	}
-	return *this.seekInAlternativesPaths(lookahead, currentDepth, currentMatches, alternatives, isEntryPoint)
+	return *b.seekInAlternativesPaths(lookahead, currentDepth, currentMatches, alternatives, isEntryPoint)
 }
 
-func (this *BallerinaParserErrorHandler) getExpressionRhsAlternatives(nextContext common.ParserRuleContext) []common.ParserRuleContext {
+func (b *BallerinaParserErrorHandler) getExpressionRhsAlternatives(nextContext common.ParserRuleContext) []common.ParserRuleContext {
 	if ((nextContext == common.PARSER_RULE_CONTEXT_SEMICOLON) || (nextContext == common.PARSER_RULE_CONTEXT_QUERY_EXPRESSION_END)) || (nextContext == common.PARSER_RULE_CONTEXT_MATCH_BODY) {
 		return []common.ParserRuleContext{nextContext, common.PARSER_RULE_CONTEXT_BINARY_OPERATOR, common.PARSER_RULE_CONTEXT_IS_KEYWORD, common.PARSER_RULE_CONTEXT_DOT, common.PARSER_RULE_CONTEXT_ANNOT_CHAINING_TOKEN, common.PARSER_RULE_CONTEXT_OPTIONAL_CHAINING_TOKEN, common.PARSER_RULE_CONTEXT_CONDITIONAL_EXPRESSION, common.PARSER_RULE_CONTEXT_XML_NAVIGATE_EXPR, common.PARSER_RULE_CONTEXT_MEMBER_ACCESS_KEY_EXPR, common.PARSER_RULE_CONTEXT_RIGHT_ARROW, common.PARSER_RULE_CONTEXT_SYNC_SEND_TOKEN}
 	}
 	return []common.ParserRuleContext{common.PARSER_RULE_CONTEXT_BINARY_OPERATOR, common.PARSER_RULE_CONTEXT_IS_KEYWORD, common.PARSER_RULE_CONTEXT_DOT, common.PARSER_RULE_CONTEXT_ANNOT_CHAINING_TOKEN, common.PARSER_RULE_CONTEXT_OPTIONAL_CHAINING_TOKEN, common.PARSER_RULE_CONTEXT_CONDITIONAL_EXPRESSION, common.PARSER_RULE_CONTEXT_XML_NAVIGATE_EXPR, common.PARSER_RULE_CONTEXT_MEMBER_ACCESS_KEY_EXPR, common.PARSER_RULE_CONTEXT_RIGHT_ARROW, common.PARSER_RULE_CONTEXT_SYNC_SEND_TOKEN, nextContext}
 }
 
-func (this *BallerinaParserErrorHandler) modifyAlternativesWithArgListStart(alternatives []common.ParserRuleContext) []common.ParserRuleContext {
+func (b *BallerinaParserErrorHandler) modifyAlternativesWithArgListStart(alternatives []common.ParserRuleContext) []common.ParserRuleContext {
 	// Create new slice with capacity for one additional element
 	newAlternatives := make([]common.ParserRuleContext, len(alternatives)+1)
 	// Copy all existing elements
@@ -2850,8 +2850,8 @@ func (this *BallerinaParserErrorHandler) modifyAlternativesWithArgListStart(alte
 	return newAlternatives
 }
 
-func (this *BallerinaParserErrorHandler) GetNextRule(currentCtx common.ParserRuleContext, nextLookahead int) common.ParserRuleContext {
-	this.startContextIfRequired(currentCtx)
+func (b *BallerinaParserErrorHandler) GetNextRule(currentCtx common.ParserRuleContext, nextLookahead int) common.ParserRuleContext {
+	b.startContextIfRequired(currentCtx)
 	var parentCtx common.ParserRuleContext
 	var nextToken tree.STToken
 	switch currentCtx {
@@ -2878,40 +2878,40 @@ func (this *BallerinaParserErrorHandler) GetNextRule(currentCtx common.ParserRul
 	case common.PARSER_RULE_CONTEXT_FUNC_BODY_BLOCK:
 		return common.PARSER_RULE_CONTEXT_OPEN_BRACE
 	case common.PARSER_RULE_CONTEXT_STATEMENT, common.PARSER_RULE_CONTEXT_STATEMENT_WITHOUT_ANNOTS:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_CLOSE_BRACE
 	case common.PARSER_RULE_CONTEXT_ASSIGN_OP:
-		return this.getNextRuleForEqualOp()
+		return b.getNextRuleForEqualOp()
 	case common.PARSER_RULE_CONTEXT_COMPOUND_BINARY_OPERATOR:
 		return common.PARSER_RULE_CONTEXT_ASSIGN_OP
 	case common.PARSER_RULE_CONTEXT_CLOSE_BRACE:
-		return this.getNextRuleForCloseBrace(nextLookahead)
+		return b.getNextRuleForCloseBrace(nextLookahead)
 	case common.PARSER_RULE_CONTEXT_CLOSE_PARENTHESIS:
-		return this.getNextRuleForCloseParenthesis()
+		return b.getNextRuleForCloseParenthesis()
 	case common.PARSER_RULE_CONTEXT_EXPRESSION, common.PARSER_RULE_CONTEXT_BASIC_LITERAL:
-		return this.getNextRuleForExpr()
+		return b.getNextRuleForExpr()
 	case common.PARSER_RULE_CONTEXT_FUNC_NAME:
-		grandParentCtx := this.GetGrandParentContext()
+		grandParentCtx := b.GetGrandParentContext()
 		if (grandParentCtx == common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR_MEMBER) || (grandParentCtx == common.PARSER_RULE_CONTEXT_CLASS_MEMBER) {
 			return common.PARSER_RULE_CONTEXT_OPTIONAL_RELATIVE_PATH
 		}
 		return common.PARSER_RULE_CONTEXT_OPEN_PARENTHESIS
 	case common.PARSER_RULE_CONTEXT_OPEN_BRACE:
-		return this.getNextRuleForOpenBrace()
+		return b.getNextRuleForOpenBrace()
 	case common.PARSER_RULE_CONTEXT_OPEN_PARENTHESIS:
-		return this.getNextRuleForOpenParenthesis()
+		return b.getNextRuleForOpenParenthesis()
 	case common.PARSER_RULE_CONTEXT_SEMICOLON:
-		return this.getNextRuleForSemicolon(nextLookahead)
+		return b.getNextRuleForSemicolon(nextLookahead)
 	case common.PARSER_RULE_CONTEXT_SIMPLE_TYPE_DESCRIPTOR:
 		return common.PARSER_RULE_CONTEXT_TYPE_DESC_RHS
 	case common.PARSER_RULE_CONTEXT_VARIABLE_NAME, common.PARSER_RULE_CONTEXT_PARAMETER_NAME_RHS:
-		return this.getNextRuleForVarName()
+		return b.getNextRuleForVarName()
 	case common.PARSER_RULE_CONTEXT_REQUIRED_PARAM,
 		common.PARSER_RULE_CONTEXT_DEFAULTABLE_PARAM,
 		common.PARSER_RULE_CONTEXT_REST_PARAM:
 		return common.PARSER_RULE_CONTEXT_PARAM_START
 	case common.PARSER_RULE_CONTEXT_REST_PARAM_RHS:
-		this.SwitchContext(common.PARSER_RULE_CONTEXT_REST_PARAM)
+		b.SwitchContext(common.PARSER_RULE_CONTEXT_REST_PARAM)
 		return common.PARSER_RULE_CONTEXT_ELLIPSIS
 	case common.PARSER_RULE_CONTEXT_ASSIGNMENT_STMT:
 		return common.PARSER_RULE_CONTEXT_VARIABLE_NAME
@@ -2922,14 +2922,14 @@ func (this *BallerinaParserErrorHandler) GetNextRule(currentCtx common.ParserRul
 	case common.PARSER_RULE_CONTEXT_BINARY_OPERATOR:
 		return common.PARSER_RULE_CONTEXT_EXPRESSION
 	case common.PARSER_RULE_CONTEXT_COMMA:
-		return this.getNextRuleForComma()
+		return b.getNextRuleForComma()
 	case common.PARSER_RULE_CONTEXT_AFTER_PARAMETER_TYPE:
-		return this.getNextRuleForParamType()
+		return b.getNextRuleForParamType()
 	case common.PARSER_RULE_CONTEXT_MODULE_TYPE_DEFINITION:
 		return common.PARSER_RULE_CONTEXT_TYPE_KEYWORD
 	case common.PARSER_RULE_CONTEXT_CLOSED_RECORD_BODY_END:
-		this.EndContext()
-		nextToken = this.tokenReader.PeekN(nextLookahead)
+		b.EndContext()
+		nextToken = b.tokenReader.PeekN(nextLookahead)
 		if nextToken.Kind() == common.EOF_TOKEN {
 			return common.PARSER_RULE_CONTEXT_EOF
 		}
@@ -2937,7 +2937,7 @@ func (this *BallerinaParserErrorHandler) GetNextRule(currentCtx common.ParserRul
 	case common.PARSER_RULE_CONTEXT_CLOSED_RECORD_BODY_START:
 		return common.PARSER_RULE_CONTEXT_RECORD_FIELD_OR_RECORD_END
 	case common.PARSER_RULE_CONTEXT_ELLIPSIS:
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		switch parentCtx {
 		case common.PARSER_RULE_CONTEXT_MAPPING_CONSTRUCTOR,
 			common.PARSER_RULE_CONTEXT_LIST_CONSTRUCTOR,
@@ -2957,16 +2957,16 @@ func (this *BallerinaParserErrorHandler) GetNextRule(currentCtx common.ParserRul
 			return common.PARSER_RULE_CONTEXT_VARIABLE_NAME
 		}
 	case common.PARSER_RULE_CONTEXT_QUESTION_MARK:
-		return this.getNextRuleForQuestionMark()
+		return b.getNextRuleForQuestionMark()
 	case common.PARSER_RULE_CONTEXT_RECORD_TYPE_DESCRIPTOR:
 		return common.PARSER_RULE_CONTEXT_RECORD_KEYWORD
 	case common.PARSER_RULE_CONTEXT_ASTERISK:
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		switch parentCtx {
 		case common.PARSER_RULE_CONTEXT_ARRAY_TYPE_DESCRIPTOR:
 			return common.PARSER_RULE_CONTEXT_CLOSE_BRACKET
 		case common.PARSER_RULE_CONTEXT_XML_ATOMIC_NAME_PATTERN:
-			this.EndContext()
+			b.EndContext()
 			return common.PARSER_RULE_CONTEXT_XML_NAME_PATTERN_RHS
 		case common.PARSER_RULE_CONTEXT_REQUIRED_PARAM,
 			common.PARSER_RULE_CONTEXT_DEFAULTABLE_PARAM:
@@ -2986,11 +2986,11 @@ func (this *BallerinaParserErrorHandler) GetNextRule(currentCtx common.ParserRul
 	case common.PARSER_RULE_CONTEXT_FIRST_OBJECT_TYPE_QUALIFIER:
 		return common.PARSER_RULE_CONTEXT_OBJECT_TYPE_WITHOUT_FIRST_QUALIFIER
 	case common.PARSER_RULE_CONTEXT_OPEN_BRACKET:
-		return this.getNextRuleForOpenBracket()
+		return b.getNextRuleForOpenBracket()
 	case common.PARSER_RULE_CONTEXT_CLOSE_BRACKET:
-		return this.getNextRuleForCloseBracket()
+		return b.getNextRuleForCloseBracket()
 	case common.PARSER_RULE_CONTEXT_DOT:
-		return this.getNextRuleForDot()
+		return b.getNextRuleForDot()
 	case common.PARSER_RULE_CONTEXT_METHOD_CALL_DOT:
 		return common.PARSER_RULE_CONTEXT_VARIABLE_NAME
 	case common.PARSER_RULE_CONTEXT_BLOCK_STMT:
@@ -3010,7 +3010,7 @@ func (this *BallerinaParserErrorHandler) GetNextRule(currentCtx common.ParserRul
 	case common.PARSER_RULE_CONTEXT_IMPORT_PREFIX, common.PARSER_RULE_CONTEXT_NAMESPACE_PREFIX:
 		return common.PARSER_RULE_CONTEXT_SEMICOLON
 	case common.PARSER_RULE_CONTEXT_SLASH:
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		switch parentCtx {
 		case common.PARSER_RULE_CONTEXT_ABSOLUTE_RESOURCE_PATH:
 			return common.PARSER_RULE_CONTEXT_IDENTIFIER
@@ -3039,16 +3039,16 @@ func (this *BallerinaParserErrorHandler) GetNextRule(currentCtx common.ParserRul
 	case common.PARSER_RULE_CONTEXT_MAPPING_FIELD_NAME:
 		return common.PARSER_RULE_CONTEXT_SPECIFIC_FIELD_RHS
 	case common.PARSER_RULE_CONTEXT_COLON:
-		return this.getNextRuleForColon()
+		return b.getNextRuleForColon()
 	case common.PARSER_RULE_CONTEXT_VAR_REF_COLON:
-		this.StartContext(common.PARSER_RULE_CONTEXT_VARIABLE_REF)
+		b.StartContext(common.PARSER_RULE_CONTEXT_VARIABLE_REF)
 		return common.PARSER_RULE_CONTEXT_IDENTIFIER
 	case common.PARSER_RULE_CONTEXT_TYPE_REF_COLON:
-		this.StartContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
-		this.StartContext(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN)
+		b.StartContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+		b.StartContext(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN)
 		return common.PARSER_RULE_CONTEXT_IDENTIFIER
 	case common.PARSER_RULE_CONTEXT_STRING_LITERAL_TOKEN:
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		if parentCtx == common.PARSER_RULE_CONTEXT_SERVICE_DECL {
 			return common.PARSER_RULE_CONTEXT_ON_KEYWORD
 		}
@@ -3091,14 +3091,14 @@ func (this *BallerinaParserErrorHandler) GetNextRule(currentCtx common.ParserRul
 		return common.PARSER_RULE_CONTEXT_QUALIFIED_IDENTIFIER_START_IDENTIFIER
 	case common.PARSER_RULE_CONTEXT_QUALIFIED_IDENTIFIER_START_IDENTIFIER,
 		common.PARSER_RULE_CONTEXT_XML_ATOMIC_NAME_IDENTIFIER:
-		nextToken = this.tokenReader.PeekN(nextLookahead)
+		nextToken = b.tokenReader.PeekN(nextLookahead)
 		if nextToken.Kind() == common.COLON_TOKEN {
 			return common.PARSER_RULE_CONTEXT_COLON
 		}
 		fallthrough
 	case common.PARSER_RULE_CONTEXT_IDENTIFIER,
 		common.PARSER_RULE_CONTEXT_SIMPLE_TYPE_DESC_IDENTIFIER:
-		return this.getNextRuleForIdentifier()
+		return b.getNextRuleForIdentifier()
 	case common.PARSER_RULE_CONTEXT_QUALIFIED_IDENTIFIER_PREDECLARED_PREFIX:
 		return common.PARSER_RULE_CONTEXT_COLON
 	case common.PARSER_RULE_CONTEXT_PATH_SEGMENT_IDENT:
@@ -3111,7 +3111,7 @@ func (this *BallerinaParserErrorHandler) GetNextRule(currentCtx common.ParserRul
 		return common.PARSER_RULE_CONTEXT_EXPRESSION
 	case common.PARSER_RULE_CONTEXT_DECIMAL_INTEGER_LITERAL_TOKEN,
 		common.PARSER_RULE_CONTEXT_HEX_INTEGER_LITERAL_TOKEN:
-		return this.getNextRuleForDecimalIntegerLiteral()
+		return b.getNextRuleForDecimalIntegerLiteral()
 	case common.PARSER_RULE_CONTEXT_EXPRESSION_STATEMENT:
 		return common.PARSER_RULE_CONTEXT_EXPRESSION_STATEMENT_START
 	case common.PARSER_RULE_CONTEXT_LOCK_STMT:
@@ -3171,28 +3171,28 @@ func (this *BallerinaParserErrorHandler) GetNextRule(currentCtx common.ParserRul
 	case common.PARSER_RULE_CONTEXT_ABSOLUTE_PATH_SINGLE_SLASH:
 		return common.PARSER_RULE_CONTEXT_SERVICE_DECL_RHS
 	case common.PARSER_RULE_CONTEXT_SERVICE_DECL_RHS:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_ON_KEYWORD
 	case common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR_BLOCK:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_OPEN_BRACE
 	case common.PARSER_RULE_CONTEXT_SERVICE_VAR_DECL_RHS:
-		this.SwitchContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+		b.SwitchContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
 		return common.PARSER_RULE_CONTEXT_TYPED_BINDING_PATTERN_TYPE_RHS
 	case common.PARSER_RULE_CONTEXT_RELATIVE_RESOURCE_PATH:
 		return common.PARSER_RULE_CONTEXT_RELATIVE_RESOURCE_PATH_START
 	case common.PARSER_RULE_CONTEXT_RESOURCE_PATH_PARAM:
 		return common.PARSER_RULE_CONTEXT_OPEN_BRACKET
 	case common.PARSER_RULE_CONTEXT_RESOURCE_ACCESSOR_DEF_OR_DECL_RHS:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_OPEN_PARENTHESIS
 	case common.PARSER_RULE_CONTEXT_ERROR_CONSTRUCTOR:
 		return common.PARSER_RULE_CONTEXT_ERROR_KEYWORD
 	case common.PARSER_RULE_CONTEXT_ERROR_CONS_ERROR_KEYWORD_RHS:
-		this.StartContext(common.PARSER_RULE_CONTEXT_ERROR_CONSTRUCTOR)
+		b.StartContext(common.PARSER_RULE_CONTEXT_ERROR_CONSTRUCTOR)
 		return common.PARSER_RULE_CONTEXT_ERROR_CONSTRUCTOR_RHS
 	case common.PARSER_RULE_CONTEXT_LIST_BINDING_PATTERN_RHS:
-		return this.getNextRuleForBindingPatternDefault()
+		return b.getNextRuleForBindingPatternDefault()
 	case common.PARSER_RULE_CONTEXT_TUPLE_MEMBERS:
 		return common.PARSER_RULE_CONTEXT_TUPLE_MEMBER
 	case common.PARSER_RULE_CONTEXT_SINGLE_OR_ALTERNATE_WORKER:
@@ -3201,14 +3201,14 @@ func (this *BallerinaParserErrorHandler) GetNextRule(currentCtx common.ParserRul
 		return common.PARSER_RULE_CONTEXT_XML_STEP_EXTEND
 	case common.PARSER_RULE_CONTEXT_XML_STEP_EXTEND_END,
 		common.PARSER_RULE_CONTEXT_SINGLE_OR_ALTERNATE_WORKER_END:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_EXPRESSION_RHS
 	default:
-		return this.getNextRuleInternal(currentCtx, nextLookahead)
+		return b.getNextRuleInternal(currentCtx, nextLookahead)
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleInternal(currentCtx common.ParserRuleContext, nextLookahead int) common.ParserRuleContext {
+func (b *BallerinaParserErrorHandler) getNextRuleInternal(currentCtx common.ParserRuleContext, nextLookahead int) common.ParserRuleContext {
 	var parentCtx common.ParserRuleContext
 	var grandParentCtx common.ParserRuleContext
 	switch currentCtx {
@@ -3219,7 +3219,7 @@ func (this *BallerinaParserErrorHandler) getNextRuleInternal(currentCtx common.P
 	case common.PARSER_RULE_CONTEXT_TYPE_CAST:
 		return common.PARSER_RULE_CONTEXT_LT
 	case common.PARSER_RULE_CONTEXT_PIPE:
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		switch parentCtx {
 		case common.PARSER_RULE_CONTEXT_ALTERNATE_WAIT_EXPRS:
 			return common.PARSER_RULE_CONTEXT_EXPRESSION
@@ -3243,7 +3243,7 @@ func (this *BallerinaParserErrorHandler) getNextRuleInternal(currentCtx common.P
 	case common.PARSER_RULE_CONTEXT_ORDER_KEY_LIST:
 		return common.PARSER_RULE_CONTEXT_EXPRESSION
 	case common.PARSER_RULE_CONTEXT_END_OF_TYPE_DESC:
-		return this.getNextRuleForTypeDescriptor()
+		return b.getNextRuleForTypeDescriptor()
 	case common.PARSER_RULE_CONTEXT_TYPED_BINDING_PATTERN:
 		return common.PARSER_RULE_CONTEXT_TYPE_DESCRIPTOR
 	case common.PARSER_RULE_CONTEXT_BINDING_PATTERN_STARTING_IDENTIFIER:
@@ -3259,17 +3259,17 @@ func (this *BallerinaParserErrorHandler) getNextRuleInternal(currentCtx common.P
 	case common.PARSER_RULE_CONTEXT_FIELD_BINDING_PATTERN_NAME:
 		return common.PARSER_RULE_CONTEXT_FIELD_BINDING_PATTERN_END
 	case common.PARSER_RULE_CONTEXT_LT:
-		return this.getNextRuleForLt()
+		return b.getNextRuleForLt()
 	case common.PARSER_RULE_CONTEXT_INFERRED_TYPEDESC_DEFAULT_START_LT:
 		return common.PARSER_RULE_CONTEXT_INFERRED_TYPEDESC_DEFAULT_END_GT
 	case common.PARSER_RULE_CONTEXT_GT:
-		return this.getNextRuleForGt()
+		return b.getNextRuleForGt()
 	case common.PARSER_RULE_CONTEXT_STREAM_TYPE_PARAM_START_TOKEN:
 		return common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_STREAM_TYPE_DESC
 	case common.PARSER_RULE_CONTEXT_INFERRED_TYPEDESC_DEFAULT_END_GT:
 		return common.PARSER_RULE_CONTEXT_END_OF_PARAMS_OR_NEXT_PARAM_START
 	case common.PARSER_RULE_CONTEXT_TYPE_CAST_PARAM_START:
-		this.StartContext(common.PARSER_RULE_CONTEXT_TYPE_CAST)
+		b.StartContext(common.PARSER_RULE_CONTEXT_TYPE_CAST)
 		return common.PARSER_RULE_CONTEXT_TYPE_CAST_PARAM
 	case common.PARSER_RULE_CONTEXT_TEMPLATE_END:
 		return common.PARSER_RULE_CONTEXT_EXPRESSION_RHS
@@ -3284,13 +3284,13 @@ func (this *BallerinaParserErrorHandler) getNextRuleInternal(currentCtx common.P
 	case common.PARSER_RULE_CONTEXT_ARG_LIST_OPEN_PAREN:
 		return common.PARSER_RULE_CONTEXT_ARG_LIST
 	case common.PARSER_RULE_CONTEXT_ARG_LIST_END:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_ARG_LIST_CLOSE_PAREN
 	case common.PARSER_RULE_CONTEXT_ARG_LIST_CLOSE_PAREN:
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		switch parentCtx {
 		case common.PARSER_RULE_CONTEXT_ERROR_CONSTRUCTOR:
-			this.EndContext()
+			b.EndContext()
 		case common.PARSER_RULE_CONTEXT_XML_STEP_EXTENDS:
 			return common.PARSER_RULE_CONTEXT_XML_STEP_EXTEND
 		case common.PARSER_RULE_CONTEXT_CLIENT_RESOURCE_ACCESS_ACTION:
@@ -3302,8 +3302,8 @@ func (this *BallerinaParserErrorHandler) getNextRuleInternal(currentCtx common.P
 	case common.PARSER_RULE_CONTEXT_ARG_LIST:
 		return common.PARSER_RULE_CONTEXT_ARG_START_OR_ARG_LIST_END
 	case common.PARSER_RULE_CONTEXT_QUERY_EXPRESSION_END:
-		this.EndContext()
-		this.EndContext()
+		b.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_EXPRESSION_RHS
 	case common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_ANNOTATION_DECL,
 		common.PARSER_RULE_CONTEXT_TYPE_DESC_BEFORE_IDENTIFIER,
@@ -3325,7 +3325,7 @@ func (this *BallerinaParserErrorHandler) getNextRuleInternal(currentCtx common.P
 		return common.PARSER_RULE_CONTEXT_CLASS_DESCRIPTOR
 	case common.PARSER_RULE_CONTEXT_VAR_DECL_STARTED_WITH_DENTIFIER,
 		common.PARSER_RULE_CONTEXT_TYPE_DESC_RHS_IN_TYPED_BP:
-		this.StartContext(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN)
+		b.StartContext(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN)
 		return common.PARSER_RULE_CONTEXT_TYPE_DESC_RHS
 	case common.PARSER_RULE_CONTEXT_ROW_TYPE_PARAM:
 		return common.PARSER_RULE_CONTEXT_LT
@@ -3356,21 +3356,21 @@ func (this *BallerinaParserErrorHandler) getNextRuleInternal(currentCtx common.P
 	case common.PARSER_RULE_CONTEXT_QUERY_EXPRESSION:
 		return common.PARSER_RULE_CONTEXT_FROM_CLAUSE
 	case common.PARSER_RULE_CONTEXT_QUERY_CONSTRUCT_TYPE_RHS:
-		this.StartContext(common.PARSER_RULE_CONTEXT_QUERY_EXPRESSION)
+		b.StartContext(common.PARSER_RULE_CONTEXT_QUERY_EXPRESSION)
 		return common.PARSER_RULE_CONTEXT_FROM_CLAUSE
 	case common.PARSER_RULE_CONTEXT_EXPRESSION_START_TABLE_KEYWORD_RHS:
-		this.StartContext(common.PARSER_RULE_CONTEXT_TABLE_CONSTRUCTOR_OR_QUERY_EXPRESSION)
+		b.StartContext(common.PARSER_RULE_CONTEXT_TABLE_CONSTRUCTOR_OR_QUERY_EXPRESSION)
 		return common.PARSER_RULE_CONTEXT_TABLE_KEYWORD_RHS
 	case common.PARSER_RULE_CONTEXT_QUERY_EXPRESSION_RHS:
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		if parentCtx == common.PARSER_RULE_CONTEXT_LET_CLAUSE_LET_VAR_DECL {
-			this.EndContext()
+			b.EndContext()
 		}
 		return common.PARSER_RULE_CONTEXT_RESULT_CLAUSE
 	case common.PARSER_RULE_CONTEXT_INTERMEDIATE_CLAUSE:
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		if parentCtx == common.PARSER_RULE_CONTEXT_LET_CLAUSE_LET_VAR_DECL {
-			this.EndContext()
+			b.EndContext()
 		}
 		return common.PARSER_RULE_CONTEXT_INTERMEDIATE_CLAUSE_START
 	case common.PARSER_RULE_CONTEXT_QUERY_ACTION_RHS:
@@ -3382,41 +3382,41 @@ func (this *BallerinaParserErrorHandler) getNextRuleInternal(currentCtx common.P
 	case common.PARSER_RULE_CONTEXT_EXPR_FUNC_BODY_START:
 		return common.PARSER_RULE_CONTEXT_EXPRESSION
 	case common.PARSER_RULE_CONTEXT_MODULE_LEVEL_AMBIGUOUS_FUNC_TYPE_DESC_RHS:
-		this.EndContext()
-		this.StartContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
-		this.StartContext(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN)
+		b.EndContext()
+		b.StartContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+		b.StartContext(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN)
 		return common.PARSER_RULE_CONTEXT_TYPE_DESC_RHS
 	case common.PARSER_RULE_CONTEXT_STMT_LEVEL_AMBIGUOUS_FUNC_TYPE_DESC_RHS:
-		this.EndContext()
-		if !this.isInTypeDescContext() {
-			this.SwitchContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
-			this.StartContext(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN)
+		b.EndContext()
+		if !b.isInTypeDescContext() {
+			b.SwitchContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+			b.StartContext(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN)
 		}
 		return common.PARSER_RULE_CONTEXT_TYPE_DESC_RHS
 	case common.PARSER_RULE_CONTEXT_FUNC_TYPE_DESC_END:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_TYPE_DESC_RHS
 	case common.PARSER_RULE_CONTEXT_BRACED_EXPR_OR_ANON_FUNC_PARAMS:
 		return common.PARSER_RULE_CONTEXT_IMPLICIT_ANON_FUNC_PARAM
 	case common.PARSER_RULE_CONTEXT_IMPLICIT_ANON_FUNC_PARAM:
 		return common.PARSER_RULE_CONTEXT_BRACED_EXPR_OR_ANON_FUNC_PARAM_RHS
 	case common.PARSER_RULE_CONTEXT_EXPLICIT_ANON_FUNC_EXPR_BODY_START:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_EXPR_FUNC_BODY_START
 	case common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR_MEMBER:
 		return common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR_MEMBER_START
 	case common.PARSER_RULE_CONTEXT_CLASS_MEMBER, common.PARSER_RULE_CONTEXT_OBJECT_TYPE_MEMBER:
 		return common.PARSER_RULE_CONTEXT_CLASS_MEMBER_OR_OBJECT_MEMBER_START
 	case common.PARSER_RULE_CONTEXT_ANNOTATION_END:
-		return this.getNextRuleForAnnotationEnd(nextLookahead)
+		return b.getNextRuleForAnnotationEnd(nextLookahead)
 	case common.PARSER_RULE_CONTEXT_PLUS_TOKEN, common.PARSER_RULE_CONTEXT_MINUS_TOKEN:
 		return common.PARSER_RULE_CONTEXT_SIGNED_INT_OR_FLOAT_RHS
 	case common.PARSER_RULE_CONTEXT_SIGNED_INT_OR_FLOAT_RHS:
-		return this.getNextRuleForExpr()
+		return b.getNextRuleForExpr()
 	case common.PARSER_RULE_CONTEXT_TUPLE_TYPE_DESC_START:
 		return common.PARSER_RULE_CONTEXT_TUPLE_MEMBERS
 	case common.PARSER_RULE_CONTEXT_METHOD_NAME:
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		if parentCtx == common.PARSER_RULE_CONTEXT_XML_STEP_EXTENDS {
 			return common.PARSER_RULE_CONTEXT_ARG_LIST_OPEN_PAREN
 		}
@@ -3434,7 +3434,7 @@ func (this *BallerinaParserErrorHandler) getNextRuleInternal(currentCtx common.P
 	case common.PARSER_RULE_CONTEXT_WAIT_FIELD_NAME:
 		return common.PARSER_RULE_CONTEXT_WAIT_FIELD_NAME_RHS
 	case common.PARSER_RULE_CONTEXT_ALTERNATE_WAIT_EXPR_LIST_END:
-		return this.getNextRuleForWaitExprListEnd()
+		return b.getNextRuleForWaitExprListEnd()
 	case common.PARSER_RULE_CONTEXT_MULTI_WAIT_FIELDS:
 		return common.PARSER_RULE_CONTEXT_OPEN_BRACE
 	case common.PARSER_RULE_CONTEXT_ALTERNATE_WAIT_EXPRS:
@@ -3444,16 +3444,16 @@ func (this *BallerinaParserErrorHandler) getNextRuleInternal(currentCtx common.P
 	case common.PARSER_RULE_CONTEXT_DO_CLAUSE:
 		return common.PARSER_RULE_CONTEXT_DO_KEYWORD
 	case common.PARSER_RULE_CONTEXT_LET_CLAUSE_END:
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		if parentCtx == common.PARSER_RULE_CONTEXT_LET_CLAUSE_LET_VAR_DECL {
-			this.EndContext()
+			b.EndContext()
 			return common.PARSER_RULE_CONTEXT_QUERY_PIPELINE_RHS
 		}
 		return common.PARSER_RULE_CONTEXT_QUERY_PIPELINE_RHS
 	case common.PARSER_RULE_CONTEXT_GROUP_BY_CLAUSE_END,
 		common.PARSER_RULE_CONTEXT_ORDER_CLAUSE_END,
 		common.PARSER_RULE_CONTEXT_JOIN_CLAUSE_END:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_QUERY_PIPELINE_RHS
 	case common.PARSER_RULE_CONTEXT_MEMBER_ACCESS_KEY_EXPR:
 		return common.PARSER_RULE_CONTEXT_OPEN_BRACKET
@@ -3486,10 +3486,10 @@ func (this *BallerinaParserErrorHandler) getNextRuleInternal(currentCtx common.P
 	case common.PARSER_RULE_CONTEXT_MATCH_PATTERN:
 		return common.PARSER_RULE_CONTEXT_MATCH_PATTERN_START
 	case common.PARSER_RULE_CONTEXT_MATCH_PATTERN_END:
-		this.EndContext()
-		return this.getNextRuleForMatchPattern()
+		b.EndContext()
+		return b.getNextRuleForMatchPattern()
 	case common.PARSER_RULE_CONTEXT_MATCH_PATTERN_RHS:
-		return this.getNextRuleForMatchPattern()
+		return b.getNextRuleForMatchPattern()
 	case common.PARSER_RULE_CONTEXT_RIGHT_DOUBLE_ARROW:
 		return common.PARSER_RULE_CONTEXT_BLOCK_STMT
 	case common.PARSER_RULE_CONTEXT_LIST_MATCH_PATTERN:
@@ -3535,7 +3535,7 @@ func (this *BallerinaParserErrorHandler) getNextRuleInternal(currentCtx common.P
 	case common.PARSER_RULE_CONTEXT_OBJECT_MEMBER_VISIBILITY_QUAL:
 		return common.PARSER_RULE_CONTEXT_OBJECT_FUNC_OR_FIELD_WITHOUT_VISIBILITY
 	case common.PARSER_RULE_CONTEXT_OBJECT_FIELD_START:
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		if parentCtx == common.PARSER_RULE_CONTEXT_OBJECT_TYPE_MEMBER {
 			return common.PARSER_RULE_CONTEXT_TYPE_DESC_BEFORE_IDENTIFIER
 		}
@@ -3543,7 +3543,7 @@ func (this *BallerinaParserErrorHandler) getNextRuleInternal(currentCtx common.P
 	case common.PARSER_RULE_CONTEXT_ON_FAIL_CLAUSE:
 		return common.PARSER_RULE_CONTEXT_ON_KEYWORD
 	case common.PARSER_RULE_CONTEXT_OBJECT_FIELD_RHS:
-		grandParentCtx = this.GetGrandParentContext()
+		grandParentCtx = b.GetGrandParentContext()
 		if grandParentCtx == common.PARSER_RULE_CONTEXT_OBJECT_TYPE_DESCRIPTOR {
 			return common.PARSER_RULE_CONTEXT_SEMICOLON
 		} else {
@@ -3570,48 +3570,48 @@ func (this *BallerinaParserErrorHandler) getNextRuleInternal(currentCtx common.P
 	case common.PARSER_RULE_CONTEXT_MAP_TYPE_DESCRIPTOR:
 		return common.PARSER_RULE_CONTEXT_MAP_KEYWORD
 	case common.PARSER_RULE_CONTEXT_FUNC_TYPE_FUNC_KEYWORD_RHS:
-		return this.getNextRuleForFuncTypeFuncKeywordRhs()
+		return b.getNextRuleForFuncTypeFuncKeywordRhs()
 	case common.PARSER_RULE_CONTEXT_TRANSACTION_STMT_TRANSACTION_KEYWORD_RHS:
-		this.StartContext(common.PARSER_RULE_CONTEXT_TRANSACTION_STMT)
+		b.StartContext(common.PARSER_RULE_CONTEXT_TRANSACTION_STMT)
 		return common.PARSER_RULE_CONTEXT_BLOCK_STMT
 	case common.PARSER_RULE_CONTEXT_BRACED_EXPRESSION:
 		return common.PARSER_RULE_CONTEXT_OPEN_PARENTHESIS
 	case common.PARSER_RULE_CONTEXT_ARRAY_LENGTH_START:
-		this.SwitchContext(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN)
-		this.StartContext(common.PARSER_RULE_CONTEXT_ARRAY_TYPE_DESCRIPTOR)
+		b.SwitchContext(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN)
+		b.StartContext(common.PARSER_RULE_CONTEXT_ARRAY_TYPE_DESCRIPTOR)
 		return common.PARSER_RULE_CONTEXT_ARRAY_LENGTH
 	case common.PARSER_RULE_CONTEXT_RESOURCE_METHOD_CALL_SLASH_TOKEN:
 		return common.PARSER_RULE_CONTEXT_CLIENT_RESOURCE_ACCESS_ACTION
 	case common.PARSER_RULE_CONTEXT_CLIENT_RESOURCE_ACCESS_ACTION:
 		return common.PARSER_RULE_CONTEXT_OPTIONAL_RESOURCE_ACCESS_PATH
 	case common.PARSER_RULE_CONTEXT_ACTION_END:
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		if parentCtx == common.PARSER_RULE_CONTEXT_CLIENT_RESOURCE_ACCESS_ACTION {
-			this.EndContext()
+			b.EndContext()
 		}
-		return this.getNextRuleForAction()
+		return b.getNextRuleForAction()
 	case common.PARSER_RULE_CONTEXT_NATURAL_EXPRESSION:
 		return common.PARSER_RULE_CONTEXT_NATURAL_EXPRESSION_START
 	default:
-		return this.getNextRuleForKeywords(currentCtx, nextLookahead)
+		return b.getNextRuleForKeywords(currentCtx, nextLookahead)
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForKeywords(currentCtx common.ParserRuleContext, nextLookahead int) common.ParserRuleContext {
+func (b *BallerinaParserErrorHandler) getNextRuleForKeywords(currentCtx common.ParserRuleContext, nextLookahead int) common.ParserRuleContext {
 	var parentCtx common.ParserRuleContext
 	switch currentCtx {
 	case common.PARSER_RULE_CONTEXT_PUBLIC_KEYWORD:
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		if (((parentCtx == common.PARSER_RULE_CONTEXT_OBJECT_TYPE_DESCRIPTOR) || (parentCtx == common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR_MEMBER)) || (parentCtx == common.PARSER_RULE_CONTEXT_CLASS_MEMBER)) || (parentCtx == common.PARSER_RULE_CONTEXT_OBJECT_TYPE_MEMBER) {
 			return common.PARSER_RULE_CONTEXT_OBJECT_FUNC_OR_FIELD_WITHOUT_VISIBILITY
-		} else if this.isParameter(parentCtx) {
+		} else if b.isParameter(parentCtx) {
 			return common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_PARAM
 		}
 		return common.PARSER_RULE_CONTEXT_TOP_LEVEL_NODE_WITHOUT_MODIFIER
 	case common.PARSER_RULE_CONTEXT_PRIVATE_KEYWORD:
 		return common.PARSER_RULE_CONTEXT_OBJECT_FUNC_OR_FIELD_WITHOUT_VISIBILITY
 	case common.PARSER_RULE_CONTEXT_ON_KEYWORD:
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		switch parentCtx {
 		case common.PARSER_RULE_CONTEXT_ANNOTATION_DECL:
 			return common.PARSER_RULE_CONTEXT_ANNOT_ATTACH_POINTS_LIST
@@ -3628,13 +3628,13 @@ func (this *BallerinaParserErrorHandler) getNextRuleForKeywords(currentCtx commo
 	case common.PARSER_RULE_CONTEXT_LISTENER_KEYWORD:
 		return common.PARSER_RULE_CONTEXT_TYPE_DESC_BEFORE_IDENTIFIER
 	case common.PARSER_RULE_CONTEXT_FINAL_KEYWORD:
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		if (parentCtx == common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR_MEMBER) || (parentCtx == common.PARSER_RULE_CONTEXT_CLASS_MEMBER) {
 			return common.PARSER_RULE_CONTEXT_TYPE_DESC_BEFORE_IDENTIFIER
 		}
 		return common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN
 	case common.PARSER_RULE_CONTEXT_CONST_KEYWORD:
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		if parentCtx == common.PARSER_RULE_CONTEXT_ANNOTATION_DECL {
 			return common.PARSER_RULE_CONTEXT_ANNOTATION_KEYWORD
 		}
@@ -3667,7 +3667,7 @@ func (this *BallerinaParserErrorHandler) getNextRuleForKeywords(currentCtx commo
 	case common.PARSER_RULE_CONTEXT_CHECKING_KEYWORD:
 		return common.PARSER_RULE_CONTEXT_EXPRESSION
 	case common.PARSER_RULE_CONTEXT_FAIL_KEYWORD:
-		if this.GetParentContext() == common.PARSER_RULE_CONTEXT_ON_FAIL_CLAUSE {
+		if b.GetParentContext() == common.PARSER_RULE_CONTEXT_ON_FAIL_CLAUSE {
 			return common.PARSER_RULE_CONTEXT_ON_FAIL_OPTIONAL_BINDING_PATTERN
 		}
 		return common.PARSER_RULE_CONTEXT_EXPRESSION
@@ -3676,7 +3676,7 @@ func (this *BallerinaParserErrorHandler) getNextRuleForKeywords(currentCtx commo
 	case common.PARSER_RULE_CONTEXT_IMPORT_KEYWORD:
 		return common.PARSER_RULE_CONTEXT_IMPORT_ORG_OR_MODULE_NAME
 	case common.PARSER_RULE_CONTEXT_AS_KEYWORD:
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		switch parentCtx {
 		case common.PARSER_RULE_CONTEXT_IMPORT_DECL:
 			return common.PARSER_RULE_CONTEXT_IMPORT_PREFIX
@@ -3691,7 +3691,7 @@ func (this *BallerinaParserErrorHandler) getNextRuleForKeywords(currentCtx commo
 	case common.PARSER_RULE_CONTEXT_EXTERNAL_KEYWORD:
 		return common.PARSER_RULE_CONTEXT_SEMICOLON
 	case common.PARSER_RULE_CONTEXT_FUNCTION_KEYWORD:
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		switch parentCtx {
 		case common.PARSER_RULE_CONTEXT_ANON_FUNC_EXPRESSION:
 			return common.PARSER_RULE_CONTEXT_OPEN_PARENTHESIS
@@ -3708,13 +3708,13 @@ func (this *BallerinaParserErrorHandler) getNextRuleForKeywords(currentCtx commo
 	case common.PARSER_RULE_CONTEXT_TYPE_KEYWORD:
 		return common.PARSER_RULE_CONTEXT_TYPE_NAME
 	case common.PARSER_RULE_CONTEXT_OBJECT_KEYWORD:
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		if parentCtx == common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR {
 			return common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR_TYPE_REF
 		}
 		return common.PARSER_RULE_CONTEXT_OPEN_BRACE
 	case common.PARSER_RULE_CONTEXT_OBJECT_TYPE_OBJECT_KEYWORD_RHS:
-		this.StartContext(common.PARSER_RULE_CONTEXT_OBJECT_TYPE_DESCRIPTOR)
+		b.StartContext(common.PARSER_RULE_CONTEXT_OBJECT_TYPE_DESCRIPTOR)
 		return common.PARSER_RULE_CONTEXT_OPEN_BRACE
 	case common.PARSER_RULE_CONTEXT_ABSTRACT_KEYWORD, common.PARSER_RULE_CONTEXT_CLIENT_KEYWORD:
 		return common.PARSER_RULE_CONTEXT_OBJECT_KEYWORD
@@ -3725,40 +3725,40 @@ func (this *BallerinaParserErrorHandler) getNextRuleForKeywords(currentCtx commo
 	case common.PARSER_RULE_CONTEXT_FOREACH_KEYWORD:
 		return common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN
 	case common.PARSER_RULE_CONTEXT_IN_KEYWORD:
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		if parentCtx == common.PARSER_RULE_CONTEXT_LET_EXPR_LET_VAR_DECL {
-			this.EndContext()
+			b.EndContext()
 		}
 		return common.PARSER_RULE_CONTEXT_EXPRESSION
 	case common.PARSER_RULE_CONTEXT_KEY_KEYWORD:
-		if this.isInTypeDescContext() {
+		if b.isInTypeDescContext() {
 			return common.PARSER_RULE_CONTEXT_KEY_CONSTRAINTS_RHS
 		}
 		return common.PARSER_RULE_CONTEXT_OPEN_PARENTHESIS
 	case common.PARSER_RULE_CONTEXT_ERROR_KEYWORD:
-		return this.getNextRuleForErrorKeyword()
+		return b.getNextRuleForErrorKeyword()
 	case common.PARSER_RULE_CONTEXT_LET_KEYWORD:
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		switch parentCtx {
 		case common.PARSER_RULE_CONTEXT_QUERY_EXPRESSION:
-			nextToken := this.tokenReader.PeekN(nextLookahead)
-			nextNextToken := this.tokenReader.PeekN(nextLookahead + 1)
+			nextToken := b.tokenReader.PeekN(nextLookahead)
+			nextNextToken := b.tokenReader.PeekN(nextLookahead + 1)
 			if isEndOfLetVarDeclarations(nextToken, nextNextToken) {
 				return common.PARSER_RULE_CONTEXT_LET_CLAUSE_END
 			}
 			return common.PARSER_RULE_CONTEXT_LET_CLAUSE_LET_VAR_DECL
 		case common.PARSER_RULE_CONTEXT_LET_CLAUSE_LET_VAR_DECL:
-			this.EndContext()
+			b.EndContext()
 			return common.PARSER_RULE_CONTEXT_LET_CLAUSE_LET_VAR_DECL
 		}
 		return common.PARSER_RULE_CONTEXT_LET_EXPR_LET_VAR_DECL
 	case common.PARSER_RULE_CONTEXT_TABLE_KEYWORD:
-		if this.isInTypeDescContext() {
+		if b.isInTypeDescContext() {
 			return common.PARSER_RULE_CONTEXT_ROW_TYPE_PARAM
 		}
 		return common.PARSER_RULE_CONTEXT_TABLE_KEYWORD_RHS
 	case common.PARSER_RULE_CONTEXT_STREAM_KEYWORD:
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		if parentCtx == common.PARSER_RULE_CONTEXT_TABLE_CONSTRUCTOR_OR_QUERY_EXPRESSION {
 			return common.PARSER_RULE_CONTEXT_QUERY_EXPRESSION
 		}
@@ -3774,15 +3774,15 @@ func (this *BallerinaParserErrorHandler) getNextRuleForKeywords(currentCtx commo
 	case common.PARSER_RULE_CONTEXT_SELECT_KEYWORD, common.PARSER_RULE_CONTEXT_COLLECT_KEYWORD:
 		return common.PARSER_RULE_CONTEXT_EXPRESSION
 	case common.PARSER_RULE_CONTEXT_WHERE_KEYWORD:
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		if parentCtx == common.PARSER_RULE_CONTEXT_LET_CLAUSE_LET_VAR_DECL {
-			this.EndContext()
+			b.EndContext()
 		}
 		return common.PARSER_RULE_CONTEXT_EXPRESSION
 	case common.PARSER_RULE_CONTEXT_ORDER_KEYWORD, common.PARSER_RULE_CONTEXT_GROUP_KEYWORD:
 		return common.PARSER_RULE_CONTEXT_BY_KEYWORD
 	case common.PARSER_RULE_CONTEXT_BY_KEYWORD:
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		if parentCtx == common.PARSER_RULE_CONTEXT_GROUP_BY_CLAUSE {
 			return common.PARSER_RULE_CONTEXT_GROUPING_KEY_LIST_ELEMENT
 		}
@@ -3790,9 +3790,9 @@ func (this *BallerinaParserErrorHandler) getNextRuleForKeywords(currentCtx commo
 	case common.PARSER_RULE_CONTEXT_ORDER_DIRECTION:
 		return common.PARSER_RULE_CONTEXT_ORDER_KEY_LIST_END
 	case common.PARSER_RULE_CONTEXT_FROM_KEYWORD:
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		if parentCtx == common.PARSER_RULE_CONTEXT_LET_CLAUSE_LET_VAR_DECL {
-			this.EndContext()
+			b.EndContext()
 		}
 		return common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN
 	case common.PARSER_RULE_CONTEXT_JOIN_KEYWORD:
@@ -3802,7 +3802,7 @@ func (this *BallerinaParserErrorHandler) getNextRuleForKeywords(currentCtx commo
 	case common.PARSER_RULE_CONTEXT_FLUSH_KEYWORD:
 		return common.PARSER_RULE_CONTEXT_OPTIONAL_PEER_WORKER
 	case common.PARSER_RULE_CONTEXT_PEER_WORKER_NAME:
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		switch parentCtx {
 		case common.PARSER_RULE_CONTEXT_MULTI_RECEIVE_WORKERS:
 			return common.PARSER_RULE_CONTEXT_RECEIVE_FIELD_END
@@ -3821,7 +3821,7 @@ func (this *BallerinaParserErrorHandler) getNextRuleForKeywords(currentCtx commo
 	case common.PARSER_RULE_CONTEXT_RETRY_KEYWORD:
 		return common.PARSER_RULE_CONTEXT_RETRY_KEYWORD_RHS
 	case common.PARSER_RULE_CONTEXT_TRANSACTIONAL_KEYWORD:
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		if parentCtx == common.PARSER_RULE_CONTEXT_NAMED_WORKER_DECL {
 			return common.PARSER_RULE_CONTEXT_WORKER_KEYWORD
 		}
@@ -3831,7 +3831,7 @@ func (this *BallerinaParserErrorHandler) getNextRuleForKeywords(currentCtx commo
 	case common.PARSER_RULE_CONTEXT_MATCH_KEYWORD:
 		return common.PARSER_RULE_CONTEXT_EXPRESSION
 	case common.PARSER_RULE_CONTEXT_READONLY_KEYWORD:
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		if ((parentCtx == common.PARSER_RULE_CONTEXT_MAPPING_CONSTRUCTOR) || (parentCtx == common.PARSER_RULE_CONTEXT_MAPPING_BP_OR_MAPPING_CONSTRUCTOR)) || (parentCtx == common.PARSER_RULE_CONTEXT_MAPPING_FIELD) {
 			return common.PARSER_RULE_CONTEXT_SPECIFIC_FIELD
 		}
@@ -3839,26 +3839,26 @@ func (this *BallerinaParserErrorHandler) getNextRuleForKeywords(currentCtx commo
 	case common.PARSER_RULE_CONTEXT_DISTINCT_KEYWORD:
 		return common.PARSER_RULE_CONTEXT_TYPE_DESCRIPTOR
 	case common.PARSER_RULE_CONTEXT_VAR_KEYWORD:
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		if ((parentCtx == common.PARSER_RULE_CONTEXT_REST_MATCH_PATTERN) || (parentCtx == common.PARSER_RULE_CONTEXT_ERROR_MATCH_PATTERN)) || (parentCtx == common.PARSER_RULE_CONTEXT_ERROR_ARG_LIST_MATCH_PATTERN_FIRST_ARG) {
 			return common.PARSER_RULE_CONTEXT_VARIABLE_NAME
 		}
 		return common.PARSER_RULE_CONTEXT_BINDING_PATTERN
 	case common.PARSER_RULE_CONTEXT_EQUALS_KEYWORD:
-		if this.GetParentContext() != common.PARSER_RULE_CONTEXT_ON_CLAUSE {
+		if b.GetParentContext() != common.PARSER_RULE_CONTEXT_ON_CLAUSE {
 			panic("assertion failed")
 		}
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_EXPRESSION
 	case common.PARSER_RULE_CONTEXT_CONFLICT_KEYWORD:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_EXPRESSION
 	case common.PARSER_RULE_CONTEXT_LIMIT_KEYWORD:
 		return common.PARSER_RULE_CONTEXT_EXPRESSION
 	case common.PARSER_RULE_CONTEXT_OUTER_KEYWORD:
 		return common.PARSER_RULE_CONTEXT_JOIN_KEYWORD
 	case common.PARSER_RULE_CONTEXT_MAP_KEYWORD:
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		if parentCtx == common.PARSER_RULE_CONTEXT_TABLE_CONSTRUCTOR_OR_QUERY_EXPRESSION {
 			return common.PARSER_RULE_CONTEXT_QUERY_EXPRESSION
 		}
@@ -3868,7 +3868,7 @@ func (this *BallerinaParserErrorHandler) getNextRuleForKeywords(currentCtx commo
 	}
 }
 
-func (this *BallerinaParserErrorHandler) startContextIfRequired(currentCtx common.ParserRuleContext) {
+func (b *BallerinaParserErrorHandler) startContextIfRequired(currentCtx common.ParserRuleContext) {
 	switch currentCtx {
 	case common.PARSER_RULE_CONTEXT_COMP_UNIT,
 		common.PARSER_RULE_CONTEXT_FUNC_DEF_OR_FUNC_TYPE,
@@ -3998,7 +3998,7 @@ func (this *BallerinaParserErrorHandler) startContextIfRequired(currentCtx commo
 		common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_SERVICE,
 		common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_PATH_PARAM,
 		common.PARSER_RULE_CONTEXT_TYPE_DESC_BEFORE_IDENTIFIER_IN_GROUPING_KEY:
-		this.StartContext(currentCtx)
+		b.StartContext(currentCtx)
 	default:
 		break
 	}
@@ -4007,81 +4007,81 @@ func (this *BallerinaParserErrorHandler) startContextIfRequired(currentCtx commo
 		common.PARSER_RULE_CONTEXT_QUERY_EXPRESSION,
 		common.PARSER_RULE_CONTEXT_ON_CONFLICT_CLAUSE,
 		common.PARSER_RULE_CONTEXT_ON_CLAUSE:
-		this.SwitchContext(currentCtx)
+		b.SwitchContext(currentCtx)
 	default:
 		break
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForCloseParenthesis() common.ParserRuleContext {
-	var parentCtx = this.GetParentContext()
+func (b *BallerinaParserErrorHandler) getNextRuleForCloseParenthesis() common.ParserRuleContext {
+	var parentCtx = b.GetParentContext()
 	if parentCtx == common.PARSER_RULE_CONTEXT_PARAM_LIST {
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_FUNC_OPTIONAL_RETURNS
-	} else if this.isParameter(parentCtx) {
-		this.EndContext()
-		this.EndContext()
+	} else if b.isParameter(parentCtx) {
+		b.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_FUNC_OPTIONAL_RETURNS
 	} else if parentCtx == common.PARSER_RULE_CONTEXT_NIL_LITERAL {
-		this.EndContext()
-		return this.getNextRuleForExpr()
+		b.EndContext()
+		return b.getNextRuleForExpr()
 	} else if parentCtx == common.PARSER_RULE_CONTEXT_KEY_SPECIFIER {
-		this.EndContext()
-		if this.isInTypeDescContext() {
+		b.EndContext()
+		if b.isInTypeDescContext() {
 			return common.PARSER_RULE_CONTEXT_TYPE_DESC_RHS
 		}
 		return common.PARSER_RULE_CONTEXT_TABLE_CONSTRUCTOR_OR_QUERY_RHS
 	} else if parentCtx == common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_PARENTHESIS {
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_TYPE_DESC_RHS
-	} else if this.isInTypeDescContext() {
+	} else if b.isInTypeDescContext() {
 		return common.PARSER_RULE_CONTEXT_TYPE_DESC_RHS
 	} else if parentCtx == common.PARSER_RULE_CONTEXT_BRACED_EXPR_OR_ANON_FUNC_PARAMS {
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_INFER_PARAM_END_OR_PARENTHESIS_END
 	} else if parentCtx == common.PARSER_RULE_CONTEXT_BRACED_EXPRESSION {
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_EXPRESSION_RHS
 	} else if parentCtx == common.PARSER_RULE_CONTEXT_ERROR_MATCH_PATTERN {
-		this.EndContext()
-		return this.getNextRuleForMatchPattern()
+		b.EndContext()
+		return b.getNextRuleForMatchPattern()
 	} else if parentCtx == common.PARSER_RULE_CONTEXT_NAMED_ARG_MATCH_PATTERN {
-		this.EndContext()
-		this.EndContext()
-		return this.getNextRuleForMatchPattern()
+		b.EndContext()
+		b.EndContext()
+		return b.getNextRuleForMatchPattern()
 	} else if parentCtx == common.PARSER_RULE_CONTEXT_ERROR_BINDING_PATTERN {
-		this.EndContext()
-		return this.getNextRuleForBindingPatternDefault()
+		b.EndContext()
+		return b.getNextRuleForBindingPatternDefault()
 	} else if parentCtx == common.PARSER_RULE_CONTEXT_ERROR_ARG_LIST_MATCH_PATTERN_FIRST_ARG {
-		this.EndContext()
-		this.EndContext()
-		return this.getNextRuleForBindingPatternDefault()
+		b.EndContext()
+		b.EndContext()
+		return b.getNextRuleForBindingPatternDefault()
 	}
 	return common.PARSER_RULE_CONTEXT_EXPRESSION_RHS
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForOpenParenthesis() common.ParserRuleContext {
-	parentCtx := this.GetParentContext()
+func (b *BallerinaParserErrorHandler) getNextRuleForOpenParenthesis() common.ParserRuleContext {
+	parentCtx := b.GetParentContext()
 	if parentCtx == common.PARSER_RULE_CONTEXT_EXPRESSION_STATEMENT {
 		return common.PARSER_RULE_CONTEXT_EXPRESSION_STATEMENT_START
-	} else if ((this.isStatement(parentCtx) || this.isExpressionContext(parentCtx)) || (parentCtx == common.PARSER_RULE_CONTEXT_ARRAY_TYPE_DESCRIPTOR)) || (parentCtx == common.PARSER_RULE_CONTEXT_BRACED_EXPRESSION) {
+	} else if ((b.isStatement(parentCtx) || b.isExpressionContext(parentCtx)) || (parentCtx == common.PARSER_RULE_CONTEXT_ARRAY_TYPE_DESCRIPTOR)) || (parentCtx == common.PARSER_RULE_CONTEXT_BRACED_EXPRESSION) {
 		return common.PARSER_RULE_CONTEXT_EXPRESSION
 	} else if ((((parentCtx == common.PARSER_RULE_CONTEXT_FUNC_DEF_OR_FUNC_TYPE) || (parentCtx == common.PARSER_RULE_CONTEXT_FUNC_TYPE_DESC)) || (parentCtx == common.PARSER_RULE_CONTEXT_FUNC_DEF)) || (parentCtx == common.PARSER_RULE_CONTEXT_ANON_FUNC_EXPRESSION)) || (parentCtx == common.PARSER_RULE_CONTEXT_FUNC_TYPE_DESC_OR_ANON_FUNC) {
-		this.StartContext(common.PARSER_RULE_CONTEXT_PARAM_LIST)
+		b.StartContext(common.PARSER_RULE_CONTEXT_PARAM_LIST)
 		return common.PARSER_RULE_CONTEXT_PARAM_LIST
 	} else if parentCtx == common.PARSER_RULE_CONTEXT_NIL_LITERAL {
 		return common.PARSER_RULE_CONTEXT_CLOSE_PARENTHESIS
 	} else if parentCtx == common.PARSER_RULE_CONTEXT_KEY_SPECIFIER {
 		return common.PARSER_RULE_CONTEXT_KEY_SPECIFIER_RHS
-	} else if this.isInTypeDescContext() {
-		this.StartContext(common.PARSER_RULE_CONTEXT_KEY_SPECIFIER)
+	} else if b.isInTypeDescContext() {
+		b.StartContext(common.PARSER_RULE_CONTEXT_KEY_SPECIFIER)
 		return common.PARSER_RULE_CONTEXT_KEY_SPECIFIER_RHS
-	} else if this.isParameter(parentCtx) {
+	} else if b.isParameter(parentCtx) {
 		return common.PARSER_RULE_CONTEXT_EXPRESSION
 	} else if parentCtx == common.PARSER_RULE_CONTEXT_ERROR_MATCH_PATTERN {
 		return common.PARSER_RULE_CONTEXT_ERROR_ARG_LIST_MATCH_PATTERN_FIRST_ARG
-	} else if this.isInMatchPatternCtx(parentCtx) {
-		this.StartContext(common.PARSER_RULE_CONTEXT_ERROR_MATCH_PATTERN)
+	} else if b.isInMatchPatternCtx(parentCtx) {
+		b.StartContext(common.PARSER_RULE_CONTEXT_ERROR_MATCH_PATTERN)
 		return common.PARSER_RULE_CONTEXT_ERROR_ARG_LIST_MATCH_PATTERN_FIRST_ARG
 	} else if parentCtx == common.PARSER_RULE_CONTEXT_ERROR_BINDING_PATTERN {
 		return common.PARSER_RULE_CONTEXT_ERROR_ARG_LIST_BINDING_PATTERN_START
@@ -4089,7 +4089,7 @@ func (this *BallerinaParserErrorHandler) getNextRuleForOpenParenthesis() common.
 	return common.PARSER_RULE_CONTEXT_EXPRESSION
 }
 
-func (this *BallerinaParserErrorHandler) isInMatchPatternCtx(context common.ParserRuleContext) bool {
+func (b *BallerinaParserErrorHandler) isInMatchPatternCtx(context common.ParserRuleContext) bool {
 	switch context {
 	case common.PARSER_RULE_CONTEXT_MATCH_PATTERN,
 		common.PARSER_RULE_CONTEXT_LIST_MATCH_PATTERN,
@@ -4102,8 +4102,8 @@ func (this *BallerinaParserErrorHandler) isInMatchPatternCtx(context common.Pars
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForOpenBrace() common.ParserRuleContext {
-	parentCtx := this.GetParentContext()
+func (b *BallerinaParserErrorHandler) getNextRuleForOpenBrace() common.ParserRuleContext {
+	parentCtx := b.GetParentContext()
 	switch parentCtx {
 	case common.PARSER_RULE_CONTEXT_OBJECT_TYPE_DESCRIPTOR:
 		return common.PARSER_RULE_CONTEXT_OBJECT_TYPE_MEMBER
@@ -4136,7 +4136,7 @@ func (this *BallerinaParserErrorHandler) getNextRuleForOpenBrace() common.Parser
 	}
 }
 
-func (this *BallerinaParserErrorHandler) isExpressionContext(ctx common.ParserRuleContext) bool {
+func (b *BallerinaParserErrorHandler) isExpressionContext(ctx common.ParserRuleContext) bool {
 	switch ctx {
 	case common.PARSER_RULE_CONTEXT_LISTENERS_LIST,
 		common.PARSER_RULE_CONTEXT_MAPPING_CONSTRUCTOR,
@@ -4161,11 +4161,11 @@ func (this *BallerinaParserErrorHandler) isExpressionContext(ctx common.ParserRu
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForParamType() common.ParserRuleContext {
-	var parentCtx = this.GetParentContext()
+func (b *BallerinaParserErrorHandler) getNextRuleForParamType() common.ParserRuleContext {
+	var parentCtx = b.GetParentContext()
 	switch parentCtx {
 	case common.PARSER_RULE_CONTEXT_REQUIRED_PARAM, common.PARSER_RULE_CONTEXT_DEFAULTABLE_PARAM:
-		if this.HasAncestorContext(common.PARSER_RULE_CONTEXT_FUNC_TYPE_DESC) {
+		if b.HasAncestorContext(common.PARSER_RULE_CONTEXT_FUNC_TYPE_DESC) {
 			return common.PARSER_RULE_CONTEXT_FUNC_TYPE_PARAM_RHS
 		}
 		return common.PARSER_RULE_CONTEXT_PARAM_RHS
@@ -4176,14 +4176,14 @@ func (this *BallerinaParserErrorHandler) getNextRuleForParamType() common.Parser
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForComma() common.ParserRuleContext {
-	parentCtx := this.GetParentContext()
+func (b *BallerinaParserErrorHandler) getNextRuleForComma() common.ParserRuleContext {
+	parentCtx := b.GetParentContext()
 	switch parentCtx {
 	case common.PARSER_RULE_CONTEXT_PARAM_LIST,
 		common.PARSER_RULE_CONTEXT_REQUIRED_PARAM,
 		common.PARSER_RULE_CONTEXT_DEFAULTABLE_PARAM,
 		common.PARSER_RULE_CONTEXT_REST_PARAM:
-		this.EndContext()
+		b.EndContext()
 		return parentCtx
 	case common.PARSER_RULE_CONTEXT_ARG_LIST:
 		return common.PARSER_RULE_CONTEXT_ARG_START
@@ -4236,66 +4236,66 @@ func (this *BallerinaParserErrorHandler) getNextRuleForComma() common.ParserRule
 	case common.PARSER_RULE_CONTEXT_ERROR_MATCH_PATTERN:
 		return common.PARSER_RULE_CONTEXT_ERROR_FIELD_MATCH_PATTERN
 	case common.PARSER_RULE_CONTEXT_NAMED_ARG_MATCH_PATTERN:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_NAMED_ARG_MATCH_PATTERN_RHS
 	default:
 		panic("getNextRuleForComma found: " + parentCtx.String())
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForTypeDescriptor() common.ParserRuleContext {
-	parentCtx := this.GetParentContext()
+func (b *BallerinaParserErrorHandler) getNextRuleForTypeDescriptor() common.ParserRuleContext {
+	parentCtx := b.GetParentContext()
 	switch parentCtx {
 	case common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_ANNOTATION_DECL:
-		this.EndContext()
-		if this.isInTypeDescContext() {
+		b.EndContext()
+		if b.isInTypeDescContext() {
 			return common.PARSER_RULE_CONTEXT_TYPE_DESC_RHS
 		}
 		return common.PARSER_RULE_CONTEXT_ANNOTATION_TAG
 	case common.PARSER_RULE_CONTEXT_TYPE_DESC_BEFORE_IDENTIFIER,
 		common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_RECORD_FIELD:
-		this.EndContext()
-		if this.isInTypeDescContext() {
+		b.EndContext()
+		if b.isInTypeDescContext() {
 			return common.PARSER_RULE_CONTEXT_TYPE_DESC_RHS
 		}
 		return common.PARSER_RULE_CONTEXT_VARIABLE_NAME
 	case common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN:
-		this.EndContext()
-		if this.isInTypeDescContext() {
+		b.EndContext()
+		if b.isInTypeDescContext() {
 			return common.PARSER_RULE_CONTEXT_TYPE_DESC_RHS
 		}
 		return common.PARSER_RULE_CONTEXT_BINDING_PATTERN
 	case common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_PARAM:
-		this.EndContext()
-		if this.isInTypeDescContext() {
+		b.EndContext()
+		if b.isInTypeDescContext() {
 			return common.PARSER_RULE_CONTEXT_TYPE_DESC_RHS
 		}
 		return common.PARSER_RULE_CONTEXT_AFTER_PARAMETER_TYPE
 	case common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_DEF:
-		this.EndContext()
-		if this.isInTypeDescContext() {
+		b.EndContext()
+		if b.isInTypeDescContext() {
 			return common.PARSER_RULE_CONTEXT_TYPE_DESC_RHS
 		}
 		return common.PARSER_RULE_CONTEXT_SEMICOLON
 	case common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_ANGLE_BRACKETS:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_GT
 	case common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_RETURN_TYPE_DESC:
-		this.EndContext()
-		if this.isInTypeDescContext() {
+		b.EndContext()
+		if b.isInTypeDescContext() {
 			return common.PARSER_RULE_CONTEXT_TYPE_DESC_RHS
 		}
-		parentCtx = this.GetParentContext()
+		parentCtx = b.GetParentContext()
 		switch parentCtx {
 		case common.PARSER_RULE_CONTEXT_FUNC_TYPE_DESC:
-			this.EndContext()
+			b.EndContext()
 			return common.PARSER_RULE_CONTEXT_TYPE_DESC_RHS
 		case common.PARSER_RULE_CONTEXT_FUNC_DEF_OR_FUNC_TYPE:
 			return common.PARSER_RULE_CONTEXT_FUNC_BODY_OR_TYPE_DESC_RHS
 		case common.PARSER_RULE_CONTEXT_FUNC_TYPE_DESC_OR_ANON_FUNC:
 			return common.PARSER_RULE_CONTEXT_FUNC_TYPE_DESC_RHS_OR_ANON_FUNC_BODY
 		case common.PARSER_RULE_CONTEXT_FUNC_DEF:
-			grandParentCtx := this.GetGrandParentContext()
+			grandParentCtx := b.GetGrandParentContext()
 			if grandParentCtx == common.PARSER_RULE_CONTEXT_OBJECT_TYPE_MEMBER {
 				return common.PARSER_RULE_CONTEXT_SEMICOLON
 			} else {
@@ -4309,13 +4309,13 @@ func (this *BallerinaParserErrorHandler) getNextRuleForTypeDescriptor() common.P
 			panic("next rule of type-desc-in-return-type found: " + parentCtx.String())
 		}
 	case common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_EXPRESSION:
-		this.EndContext()
-		if this.isInTypeDescContext() {
+		b.EndContext()
+		if b.isInTypeDescContext() {
 			return common.PARSER_RULE_CONTEXT_TYPE_DESC_RHS
 		}
 		return common.PARSER_RULE_CONTEXT_EXPRESSION_RHS
 	case common.PARSER_RULE_CONTEXT_COMP_UNIT:
-		this.StartContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+		b.StartContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
 		return common.PARSER_RULE_CONTEXT_VARIABLE_NAME
 	case common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR_MEMBER,
 		common.PARSER_RULE_CONTEXT_CLASS_MEMBER,
@@ -4328,29 +4328,29 @@ func (this *BallerinaParserErrorHandler) getNextRuleForTypeDescriptor() common.P
 	case common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_PARENTHESIS:
 		return common.PARSER_RULE_CONTEXT_CLOSE_PARENTHESIS
 	case common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE_RHS
 	case common.PARSER_RULE_CONTEXT_STMT_START_BRACKETED_LIST:
 		return common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE_RHS
 	case common.PARSER_RULE_CONTEXT_TYPE_REFERENCE_IN_TYPE_INCLUSION:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_SEMICOLON
 	case common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_SERVICE:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_OPTIONAL_ABSOLUTE_PATH
 	case common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_PATH_PARAM:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_PATH_PARAM_ELLIPSIS
 	case common.PARSER_RULE_CONTEXT_TYPE_DESC_BEFORE_IDENTIFIER_IN_GROUPING_KEY:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_BINDING_PATTERN_STARTING_IDENTIFIER
 	default:
 		return common.PARSER_RULE_CONTEXT_EXPRESSION_RHS
 	}
 }
 
-func (this *BallerinaParserErrorHandler) isInTypeDescContext() bool {
-	switch this.GetParentContext() {
+func (b *BallerinaParserErrorHandler) isInTypeDescContext() bool {
+	switch b.GetParentContext() {
 	case common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_ANNOTATION_DECL,
 		common.PARSER_RULE_CONTEXT_TYPE_DESC_BEFORE_IDENTIFIER,
 		common.PARSER_RULE_CONTEXT_TYPE_DESC_BEFORE_IDENTIFIER_IN_GROUPING_KEY,
@@ -4375,8 +4375,8 @@ func (this *BallerinaParserErrorHandler) isInTypeDescContext() bool {
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForEqualOp() common.ParserRuleContext {
-	parentCtx := this.GetParentContext()
+func (b *BallerinaParserErrorHandler) getNextRuleForEqualOp() common.ParserRuleContext {
+	parentCtx := b.GetParentContext()
 	switch parentCtx {
 	case common.PARSER_RULE_CONTEXT_EXTERNAL_FUNC_BODY:
 		return common.PARSER_RULE_CONTEXT_EXTERNAL_FUNC_BODY_OPTIONAL_ANNOTS
@@ -4395,78 +4395,78 @@ func (this *BallerinaParserErrorHandler) getNextRuleForEqualOp() common.ParserRu
 		common.PARSER_RULE_CONTEXT_GROUP_BY_CLAUSE:
 		return common.PARSER_RULE_CONTEXT_EXPRESSION
 	case common.PARSER_RULE_CONTEXT_FUNC_DEF_OR_FUNC_TYPE:
-		this.SwitchContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+		b.SwitchContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
 		return common.PARSER_RULE_CONTEXT_EXPRESSION
 	case common.PARSER_RULE_CONTEXT_NAMED_ARG_MATCH_PATTERN:
 		return common.PARSER_RULE_CONTEXT_MATCH_PATTERN
 	case common.PARSER_RULE_CONTEXT_ERROR_BINDING_PATTERN:
 		return common.PARSER_RULE_CONTEXT_BINDING_PATTERN
 	default:
-		if this.isStatement(parentCtx) {
+		if b.isStatement(parentCtx) {
 			return common.PARSER_RULE_CONTEXT_EXPRESSION
 		}
 		panic("getNextRuleForEqualOp found: " + parentCtx.String())
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForCloseBrace(nextLookahead int) common.ParserRuleContext {
-	parentCtx := this.GetParentContext()
+func (b *BallerinaParserErrorHandler) getNextRuleForCloseBrace(nextLookahead int) common.ParserRuleContext {
+	parentCtx := b.GetParentContext()
 	var nextToken tree.STToken
 	switch parentCtx {
 	case common.PARSER_RULE_CONTEXT_FUNC_BODY_BLOCK:
-		this.EndContext()
-		return this.getNextRuleForCloseBraceInFuncBody()
+		b.EndContext()
+		return b.getNextRuleForCloseBraceInFuncBody()
 	case common.PARSER_RULE_CONTEXT_CLASS_MEMBER:
-		this.EndContext()
+		b.EndContext()
 		fallthrough
 	case common.PARSER_RULE_CONTEXT_SERVICE_DECL, common.PARSER_RULE_CONTEXT_MODULE_CLASS_DEFINITION:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_OPTIONAL_TOP_LEVEL_SEMICOLON
 	case common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR_MEMBER:
-		this.EndContext()
-		parentCtx = this.GetParentContext()
+		b.EndContext()
+		parentCtx = b.GetParentContext()
 		if parentCtx == common.PARSER_RULE_CONTEXT_SERVICE_DECL {
-			this.EndContext()
+			b.EndContext()
 			return common.PARSER_RULE_CONTEXT_TOP_LEVEL_NODE
 		}
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_EXPRESSION_RHS
 	case common.PARSER_RULE_CONTEXT_OBJECT_TYPE_MEMBER:
-		this.EndContext()
+		b.EndContext()
 		fallthrough
 	case common.PARSER_RULE_CONTEXT_RECORD_TYPE_DESCRIPTOR,
 		common.PARSER_RULE_CONTEXT_OBJECT_TYPE_DESCRIPTOR:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_TYPE_DESC_RHS
 	case common.PARSER_RULE_CONTEXT_BLOCK_STMT, common.PARSER_RULE_CONTEXT_AMBIGUOUS_STMT:
-		this.EndContext()
-		parentCtx = this.GetParentContext()
+		b.EndContext()
+		parentCtx = b.GetParentContext()
 		switch parentCtx {
 		case common.PARSER_RULE_CONTEXT_LOCK_STMT,
 			common.PARSER_RULE_CONTEXT_FOREACH_STMT,
 			common.PARSER_RULE_CONTEXT_WHILE_BLOCK,
 			common.PARSER_RULE_CONTEXT_DO_BLOCK,
 			common.PARSER_RULE_CONTEXT_RETRY_STMT:
-			this.EndContext()
+			b.EndContext()
 			return common.PARSER_RULE_CONTEXT_REGULAR_COMPOUND_STMT_RHS
 		case common.PARSER_RULE_CONTEXT_ON_FAIL_CLAUSE:
-			this.EndContext()
+			b.EndContext()
 			return common.PARSER_RULE_CONTEXT_STATEMENT
 		case common.PARSER_RULE_CONTEXT_IF_BLOCK:
-			this.EndContext()
+			b.EndContext()
 			return common.PARSER_RULE_CONTEXT_ELSE_BLOCK
 		case common.PARSER_RULE_CONTEXT_TRANSACTION_STMT:
-			this.EndContext()
-			parentCtx = this.GetParentContext()
+			b.EndContext()
+			parentCtx = b.GetParentContext()
 			if parentCtx == common.PARSER_RULE_CONTEXT_RETRY_STMT {
-				this.EndContext()
+				b.EndContext()
 			}
 			return common.PARSER_RULE_CONTEXT_REGULAR_COMPOUND_STMT_RHS
 		case common.PARSER_RULE_CONTEXT_NAMED_WORKER_DECL:
-			this.EndContext()
-			parentCtx = this.GetParentContext()
+			b.EndContext()
+			parentCtx = b.GetParentContext()
 			if parentCtx == common.PARSER_RULE_CONTEXT_FORK_STMT {
-				nextToken = this.tokenReader.PeekN(nextLookahead)
+				nextToken = b.tokenReader.PeekN(nextLookahead)
 				switch nextToken.Kind() {
 				case common.CLOSE_BRACE_TOKEN:
 					return common.PARSER_RULE_CONTEXT_CLOSE_BRACE
@@ -4484,54 +4484,54 @@ func (this *BallerinaParserErrorHandler) getNextRuleForCloseBrace(nextLookahead 
 			return common.PARSER_RULE_CONTEXT_STATEMENT
 		}
 	case common.PARSER_RULE_CONTEXT_MAPPING_CONSTRUCTOR:
-		this.EndContext()
-		parentCtx = this.GetParentContext()
+		b.EndContext()
+		parentCtx = b.GetParentContext()
 		if parentCtx == common.PARSER_RULE_CONTEXT_TABLE_CONSTRUCTOR {
 			return common.PARSER_RULE_CONTEXT_TABLE_ROW_END
 		}
 		if parentCtx == common.PARSER_RULE_CONTEXT_ANNOTATIONS {
 			return common.PARSER_RULE_CONTEXT_ANNOTATION_END
 		}
-		return this.getNextRuleForExpr()
+		return b.getNextRuleForExpr()
 	case common.PARSER_RULE_CONTEXT_STMT_START_BRACKETED_LIST:
 		return common.PARSER_RULE_CONTEXT_BRACKETED_LIST_MEMBER_END
 	case common.PARSER_RULE_CONTEXT_MAPPING_BINDING_PATTERN,
 		common.PARSER_RULE_CONTEXT_MAPPING_BP_OR_MAPPING_CONSTRUCTOR:
-		this.EndContext()
-		return this.getNextRuleForBindingPatternDefault()
+		b.EndContext()
+		return b.getNextRuleForBindingPatternDefault()
 	case common.PARSER_RULE_CONTEXT_FORK_STMT:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_STATEMENT
 	case common.PARSER_RULE_CONTEXT_INTERPOLATION:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_TEMPLATE_MEMBER
 	case common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR,
 		common.PARSER_RULE_CONTEXT_MULTI_RECEIVE_WORKERS,
 		common.PARSER_RULE_CONTEXT_MULTI_WAIT_FIELDS,
 		common.PARSER_RULE_CONTEXT_NATURAL_EXPRESSION:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_EXPRESSION_RHS
 	case common.PARSER_RULE_CONTEXT_ENUM_MEMBER_LIST:
-		this.EndContext()
-		this.EndContext()
+		b.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_OPTIONAL_TOP_LEVEL_SEMICOLON
 	case common.PARSER_RULE_CONTEXT_MATCH_BODY:
-		this.EndContext()
-		this.EndContext()
+		b.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_REGULAR_COMPOUND_STMT_RHS
 	case common.PARSER_RULE_CONTEXT_MAPPING_MATCH_PATTERN:
-		this.EndContext()
-		return this.getNextRuleForMatchPattern()
+		b.EndContext()
+		return b.getNextRuleForMatchPattern()
 	case common.PARSER_RULE_CONTEXT_MATCH_STMT:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_REGULAR_COMPOUND_STMT_RHS
 	default:
 		panic("getNextRuleForCloseBrace found: " + parentCtx.String())
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForCloseBraceInFuncBody() common.ParserRuleContext {
-	var parentCtx = this.GetParentContext()
+func (b *BallerinaParserErrorHandler) getNextRuleForCloseBraceInFuncBody() common.ParserRuleContext {
+	var parentCtx = b.GetParentContext()
 	switch parentCtx {
 	case common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR_MEMBER:
 		return common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR_MEMBER_START
@@ -4540,22 +4540,22 @@ func (this *BallerinaParserErrorHandler) getNextRuleForCloseBraceInFuncBody() co
 	case common.PARSER_RULE_CONTEXT_COMP_UNIT:
 		return common.PARSER_RULE_CONTEXT_OPTIONAL_TOP_LEVEL_SEMICOLON
 	case common.PARSER_RULE_CONTEXT_FUNC_DEF, common.PARSER_RULE_CONTEXT_FUNC_DEF_OR_FUNC_TYPE:
-		this.EndContext()
-		return this.getNextRuleForCloseBraceInFuncBody()
+		b.EndContext()
+		return b.getNextRuleForCloseBraceInFuncBody()
 	default:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_EXPRESSION_RHS
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForAnnotationEnd(nextLookahead int) common.ParserRuleContext {
+func (b *BallerinaParserErrorHandler) getNextRuleForAnnotationEnd(nextLookahead int) common.ParserRuleContext {
 	var parentCtx common.ParserRuleContext
-	var nextToken = this.tokenReader.PeekN(nextLookahead)
+	var nextToken = b.tokenReader.PeekN(nextLookahead)
 	if nextToken.Kind() == common.AT_TOKEN {
 		return common.PARSER_RULE_CONTEXT_AT
 	}
-	this.EndContext()
-	parentCtx = this.GetParentContext()
+	b.EndContext()
+	parentCtx = b.GetParentContext()
 	switch parentCtx {
 	case common.PARSER_RULE_CONTEXT_COMP_UNIT:
 		return common.PARSER_RULE_CONTEXT_TOP_LEVEL_NODE_WITHOUT_METADATA
@@ -4587,15 +4587,15 @@ func (this *BallerinaParserErrorHandler) getNextRuleForAnnotationEnd(nextLookahe
 	case common.PARSER_RULE_CONTEXT_TUPLE_MEMBERS:
 		return common.PARSER_RULE_CONTEXT_TUPLE_MEMBER
 	default:
-		if this.isParameter(parentCtx) {
+		if b.isParameter(parentCtx) {
 			return common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_PARAM
 		}
 		return common.PARSER_RULE_CONTEXT_EXPRESSION
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForVarName() common.ParserRuleContext {
-	parentCtx := this.GetParentContext()
+func (b *BallerinaParserErrorHandler) getNextRuleForVarName() common.ParserRuleContext {
+	parentCtx := b.GetParentContext()
 	switch parentCtx {
 	case common.PARSER_RULE_CONTEXT_ASSIGNMENT_STMT:
 		return common.PARSER_RULE_CONTEXT_ASSIGNMENT_STMT_RHS
@@ -4610,7 +4610,7 @@ func (this *BallerinaParserErrorHandler) getNextRuleForVarName() common.ParserRu
 	case common.PARSER_RULE_CONTEXT_FOREACH_STMT:
 		return common.PARSER_RULE_CONTEXT_IN_KEYWORD
 	case common.PARSER_RULE_CONTEXT_BINDING_PATTERN_STARTING_IDENTIFIER:
-		return this.getNextRuleForBindingPatternWithCapture(true)
+		return b.getNextRuleForBindingPatternWithCapture(true)
 	case common.PARSER_RULE_CONTEXT_TYPED_BINDING_PATTERN,
 		common.PARSER_RULE_CONTEXT_LIST_BINDING_PATTERN,
 		common.PARSER_RULE_CONTEXT_STMT_START_BRACKETED_LIST_MEMBER,
@@ -4619,7 +4619,7 @@ func (this *BallerinaParserErrorHandler) getNextRuleForVarName() common.ParserRu
 		common.PARSER_RULE_CONTEXT_MAPPING_BINDING_PATTERN,
 		common.PARSER_RULE_CONTEXT_MAPPING_BP_OR_MAPPING_CONSTRUCTOR,
 		common.PARSER_RULE_CONTEXT_ERROR_BINDING_PATTERN:
-		return this.getNextRuleForBindingPatternDefault()
+		return b.getNextRuleForBindingPatternDefault()
 	case common.PARSER_RULE_CONTEXT_LISTENER_DECL, common.PARSER_RULE_CONTEXT_CONSTANT_DECL:
 		return common.PARSER_RULE_CONTEXT_VAR_DECL_STMT_RHS
 	case common.PARSER_RULE_CONTEXT_RECORD_FIELD:
@@ -4642,8 +4642,8 @@ func (this *BallerinaParserErrorHandler) getNextRuleForVarName() common.ParserRu
 	case common.PARSER_RULE_CONTEXT_QUERY_EXPRESSION, common.PARSER_RULE_CONTEXT_JOIN_CLAUSE:
 		return common.PARSER_RULE_CONTEXT_IN_KEYWORD
 	case common.PARSER_RULE_CONTEXT_REST_MATCH_PATTERN:
-		this.EndContext()
-		parentCtx = this.GetParentContext()
+		b.EndContext()
+		parentCtx = b.GetParentContext()
 		if parentCtx == common.PARSER_RULE_CONTEXT_MAPPING_MATCH_PATTERN {
 			return common.PARSER_RULE_CONTEXT_CLOSE_BRACE
 		}
@@ -4656,7 +4656,7 @@ func (this *BallerinaParserErrorHandler) getNextRuleForVarName() common.ParserRu
 	case common.PARSER_RULE_CONTEXT_ON_FAIL_CLAUSE:
 		return common.PARSER_RULE_CONTEXT_BLOCK_STMT
 	case common.PARSER_RULE_CONTEXT_ERROR_ARG_LIST_MATCH_PATTERN_FIRST_ARG:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_ERROR_MESSAGE_MATCH_PATTERN_END
 	case common.PARSER_RULE_CONTEXT_ERROR_MATCH_PATTERN:
 		return common.PARSER_RULE_CONTEXT_ERROR_FIELD_MATCH_PATTERN_RHS
@@ -4665,58 +4665,58 @@ func (this *BallerinaParserErrorHandler) getNextRuleForVarName() common.ParserRu
 	case common.PARSER_RULE_CONTEXT_GROUP_BY_CLAUSE:
 		return common.PARSER_RULE_CONTEXT_GROUPING_KEY_LIST_ELEMENT_END
 	default:
-		if this.isStatement(parentCtx) {
+		if b.isStatement(parentCtx) {
 			return common.PARSER_RULE_CONTEXT_VAR_DECL_STMT_RHS
 		}
 		panic("getNextRuleForVarName found: " + parentCtx.String())
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForSemicolon(nextLookahead int) common.ParserRuleContext {
+func (b *BallerinaParserErrorHandler) getNextRuleForSemicolon(nextLookahead int) common.ParserRuleContext {
 	var nextToken tree.STToken
-	parentCtx := this.GetParentContext()
+	parentCtx := b.GetParentContext()
 	if parentCtx == common.PARSER_RULE_CONTEXT_EXTERNAL_FUNC_BODY {
-		this.EndContext()
-		return this.getNextRuleForSemicolon(nextLookahead)
+		b.EndContext()
+		return b.getNextRuleForSemicolon(nextLookahead)
 	} else if parentCtx == common.PARSER_RULE_CONTEXT_QUERY_EXPRESSION {
-		this.EndContext()
-		return this.getNextRuleForSemicolon(nextLookahead)
-	} else if this.isExpressionContext(parentCtx) {
-		this.EndContext()
+		b.EndContext()
+		return b.getNextRuleForSemicolon(nextLookahead)
+	} else if b.isExpressionContext(parentCtx) {
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_STATEMENT
 	} else if parentCtx == common.PARSER_RULE_CONTEXT_VAR_DECL_STMT {
-		this.EndContext()
-		parentCtx = this.GetParentContext()
+		b.EndContext()
+		parentCtx = b.GetParentContext()
 		if parentCtx == common.PARSER_RULE_CONTEXT_COMP_UNIT {
 			return common.PARSER_RULE_CONTEXT_TOP_LEVEL_NODE
 		}
 		return common.PARSER_RULE_CONTEXT_STATEMENT
-	} else if this.isStatement(parentCtx) {
-		this.EndContext()
+	} else if b.isStatement(parentCtx) {
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_STATEMENT
 	} else if parentCtx == common.PARSER_RULE_CONTEXT_RECORD_FIELD {
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_RECORD_FIELD_OR_RECORD_END
 	} else if parentCtx == common.PARSER_RULE_CONTEXT_XML_NAMESPACE_DECLARATION {
-		this.EndContext()
-		parentCtx = this.GetParentContext()
+		b.EndContext()
+		parentCtx = b.GetParentContext()
 		if parentCtx == common.PARSER_RULE_CONTEXT_COMP_UNIT {
 			return common.PARSER_RULE_CONTEXT_TOP_LEVEL_NODE
 		}
 		return common.PARSER_RULE_CONTEXT_STATEMENT
 	} else if ((parentCtx == common.PARSER_RULE_CONTEXT_MODULE_TYPE_DEFINITION) || (parentCtx == common.PARSER_RULE_CONTEXT_LISTENER_DECL)) || (parentCtx == common.PARSER_RULE_CONTEXT_ANNOTATION_DECL) {
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_TOP_LEVEL_NODE
 	} else if parentCtx == common.PARSER_RULE_CONTEXT_CONSTANT_DECL {
-		this.EndContext()
-		parentCtx = this.GetParentContext()
+		b.EndContext()
+		parentCtx = b.GetParentContext()
 		if parentCtx == common.PARSER_RULE_CONTEXT_FUNC_BODY_BLOCK {
 			return common.PARSER_RULE_CONTEXT_STATEMENT
 		}
 		return common.PARSER_RULE_CONTEXT_TOP_LEVEL_NODE
 	} else if ((parentCtx == common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR_MEMBER) || (parentCtx == common.PARSER_RULE_CONTEXT_CLASS_MEMBER)) || (parentCtx == common.PARSER_RULE_CONTEXT_OBJECT_TYPE_MEMBER) {
-		if this.isEndOfObjectTypeNode(nextLookahead) {
-			this.EndContext()
+		if b.isEndOfObjectTypeNode(nextLookahead) {
+			b.EndContext()
 			return common.PARSER_RULE_CONTEXT_CLOSE_BRACE
 		}
 		if parentCtx == common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR_MEMBER {
@@ -4725,27 +4725,27 @@ func (this *BallerinaParserErrorHandler) getNextRuleForSemicolon(nextLookahead i
 			return common.PARSER_RULE_CONTEXT_CLASS_MEMBER_OR_OBJECT_MEMBER_START
 		}
 	} else if parentCtx == common.PARSER_RULE_CONTEXT_IMPORT_DECL {
-		this.EndContext()
-		nextToken = this.tokenReader.PeekN(nextLookahead)
+		b.EndContext()
+		nextToken = b.tokenReader.PeekN(nextLookahead)
 		if nextToken.Kind() == common.EOF_TOKEN {
 			return common.PARSER_RULE_CONTEXT_EOF
 		}
 		return common.PARSER_RULE_CONTEXT_TOP_LEVEL_NODE
 	} else if parentCtx == common.PARSER_RULE_CONTEXT_ANNOT_ATTACH_POINTS_LIST {
-		this.EndContext()
-		this.EndContext()
-		nextToken = this.tokenReader.PeekN(nextLookahead)
+		b.EndContext()
+		b.EndContext()
+		nextToken = b.tokenReader.PeekN(nextLookahead)
 		if nextToken.Kind() == common.EOF_TOKEN {
 			return common.PARSER_RULE_CONTEXT_EOF
 		}
 		return common.PARSER_RULE_CONTEXT_TOP_LEVEL_NODE
 	} else if (parentCtx == common.PARSER_RULE_CONTEXT_FUNC_DEF) || (parentCtx == common.PARSER_RULE_CONTEXT_FUNC_DEF_OR_FUNC_TYPE) {
-		this.EndContext()
-		nextToken = this.tokenReader.PeekN(nextLookahead)
+		b.EndContext()
+		nextToken = b.tokenReader.PeekN(nextLookahead)
 		if nextToken.Kind() == common.EOF_TOKEN {
 			return common.PARSER_RULE_CONTEXT_EOF
 		}
-		return this.getNextRuleForSemicolon(nextLookahead)
+		return b.getNextRuleForSemicolon(nextLookahead)
 	} else if parentCtx == common.PARSER_RULE_CONTEXT_MODULE_CLASS_DEFINITION {
 		return common.PARSER_RULE_CONTEXT_CLASS_MEMBER
 	} else if parentCtx == common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR {
@@ -4757,8 +4757,8 @@ func (this *BallerinaParserErrorHandler) getNextRuleForSemicolon(nextLookahead i
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForDot() common.ParserRuleContext {
-	parentCtx := this.GetParentContext()
+func (b *BallerinaParserErrorHandler) getNextRuleForDot() common.ParserRuleContext {
+	parentCtx := b.GetParentContext()
 	switch parentCtx {
 	case common.PARSER_RULE_CONTEXT_IMPORT_DECL:
 		return common.PARSER_RULE_CONTEXT_IMPORT_MODULE_NAME
@@ -4773,11 +4773,11 @@ func (this *BallerinaParserErrorHandler) getNextRuleForDot() common.ParserRuleCo
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForQuestionMark() common.ParserRuleContext {
-	parentCtx := this.GetParentContext()
+func (b *BallerinaParserErrorHandler) getNextRuleForQuestionMark() common.ParserRuleContext {
+	parentCtx := b.GetParentContext()
 	switch parentCtx {
 	case common.PARSER_RULE_CONTEXT_OPTIONAL_TYPE_DESCRIPTOR:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_TYPE_DESC_RHS
 	case common.PARSER_RULE_CONTEXT_CONDITIONAL_EXPRESSION:
 		return common.PARSER_RULE_CONTEXT_EXPRESSION
@@ -4786,8 +4786,8 @@ func (this *BallerinaParserErrorHandler) getNextRuleForQuestionMark() common.Par
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForOpenBracket() common.ParserRuleContext {
-	parentCtx := this.GetParentContext()
+func (b *BallerinaParserErrorHandler) getNextRuleForOpenBracket() common.ParserRuleContext {
+	parentCtx := b.GetParentContext()
 	switch parentCtx {
 	case common.PARSER_RULE_CONTEXT_ARRAY_TYPE_DESCRIPTOR:
 		return common.PARSER_RULE_CONTEXT_ARRAY_LENGTH
@@ -4804,86 +4804,86 @@ func (this *BallerinaParserErrorHandler) getNextRuleForOpenBracket() common.Pars
 	case common.PARSER_RULE_CONTEXT_CLIENT_RESOURCE_ACCESS_ACTION:
 		return common.PARSER_RULE_CONTEXT_COMPUTED_SEGMENT_OR_REST_SEGMENT
 	default:
-		if this.isInTypeDescContext() {
+		if b.isInTypeDescContext() {
 			return common.PARSER_RULE_CONTEXT_TUPLE_MEMBERS
 		}
 		return common.PARSER_RULE_CONTEXT_EXPRESSION
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForCloseBracket() common.ParserRuleContext {
-	parentCtx := this.GetParentContext()
+func (b *BallerinaParserErrorHandler) getNextRuleForCloseBracket() common.ParserRuleContext {
+	parentCtx := b.GetParentContext()
 	switch parentCtx {
 	case common.PARSER_RULE_CONTEXT_ARRAY_TYPE_DESCRIPTOR, common.PARSER_RULE_CONTEXT_TUPLE_MEMBERS:
-		this.EndContext()
-		parentCtx = this.GetParentContext()
+		b.EndContext()
+		parentCtx = b.GetParentContext()
 		if parentCtx == common.PARSER_RULE_CONTEXT_STMT_START_BRACKETED_LIST {
-			return this.getNextRuleForCloseBracket()
+			return b.getNextRuleForCloseBracket()
 		}
 		return common.PARSER_RULE_CONTEXT_TYPE_DESC_RHS
 	case common.PARSER_RULE_CONTEXT_COMPUTED_FIELD_NAME:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_COLON
 	case common.PARSER_RULE_CONTEXT_LIST_BINDING_PATTERN:
-		this.EndContext()
-		return this.getNextRuleForBindingPatternDefault()
+		b.EndContext()
+		return b.getNextRuleForBindingPatternDefault()
 	case common.PARSER_RULE_CONTEXT_LIST_CONSTRUCTOR,
 		common.PARSER_RULE_CONTEXT_TABLE_CONSTRUCTOR,
 		common.PARSER_RULE_CONTEXT_MEMBER_ACCESS_KEY_EXPR:
-		this.EndContext()
-		parentCtx = this.GetParentContext()
+		b.EndContext()
+		parentCtx = b.GetParentContext()
 		if parentCtx == common.PARSER_RULE_CONTEXT_XML_STEP_EXTENDS {
 			return common.PARSER_RULE_CONTEXT_XML_STEP_EXTEND
 		}
-		return this.getNextRuleForExpr()
+		return b.getNextRuleForExpr()
 	case common.PARSER_RULE_CONTEXT_STMT_START_BRACKETED_LIST:
-		this.EndContext()
-		parentCtx = this.GetParentContext()
+		b.EndContext()
+		parentCtx = b.GetParentContext()
 		if parentCtx == common.PARSER_RULE_CONTEXT_STMT_START_BRACKETED_LIST {
 			return common.PARSER_RULE_CONTEXT_BRACKETED_LIST_MEMBER_END
 		}
 		return common.PARSER_RULE_CONTEXT_STMT_START_BRACKETED_LIST_RHS
 	case common.PARSER_RULE_CONTEXT_BRACKETED_LIST:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_BRACKETED_LIST_RHS
 	case common.PARSER_RULE_CONTEXT_LIST_MATCH_PATTERN:
-		this.EndContext()
-		return this.getNextRuleForMatchPattern()
+		b.EndContext()
+		return b.getNextRuleForMatchPattern()
 	case common.PARSER_RULE_CONTEXT_RELATIVE_RESOURCE_PATH:
 		return common.PARSER_RULE_CONTEXT_RELATIVE_RESOURCE_PATH_END
 	case common.PARSER_RULE_CONTEXT_CLIENT_RESOURCE_ACCESS_ACTION:
 		return common.PARSER_RULE_CONTEXT_RESOURCE_ACCESS_SEGMENT_RHS
 	default:
-		return this.getNextRuleForExpr()
+		return b.getNextRuleForExpr()
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForDecimalIntegerLiteral() common.ParserRuleContext {
-	parentCtx := this.GetParentContext()
+func (b *BallerinaParserErrorHandler) getNextRuleForDecimalIntegerLiteral() common.ParserRuleContext {
+	parentCtx := b.GetParentContext()
 	switch parentCtx {
 	case common.PARSER_RULE_CONTEXT_CONSTANT_EXPRESSION:
-		this.EndContext()
-		return this.getNextRuleForConstExpr()
+		b.EndContext()
+		return b.getNextRuleForConstExpr()
 	default:
 		return common.PARSER_RULE_CONTEXT_CLOSE_BRACKET
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForExpr() common.ParserRuleContext {
-	var parentCtx = this.GetParentContext()
+func (b *BallerinaParserErrorHandler) getNextRuleForExpr() common.ParserRuleContext {
+	var parentCtx = b.GetParentContext()
 	if parentCtx == common.PARSER_RULE_CONTEXT_CONSTANT_EXPRESSION {
-		this.EndContext()
-		return this.getNextRuleForConstExpr()
+		b.EndContext()
+		return b.getNextRuleForConstExpr()
 	}
 	return common.PARSER_RULE_CONTEXT_EXPRESSION_RHS
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForExprStartsWithVarRef() common.ParserRuleContext {
-	var parentCtx = this.GetParentContext()
+func (b *BallerinaParserErrorHandler) getNextRuleForExprStartsWithVarRef() common.ParserRuleContext {
+	var parentCtx = b.GetParentContext()
 	switch parentCtx {
 	case common.PARSER_RULE_CONTEXT_CONSTANT_EXPRESSION:
-		this.EndContext()
-		return this.getNextRuleForConstExpr()
+		b.EndContext()
+		return b.getNextRuleForConstExpr()
 	case common.PARSER_RULE_CONTEXT_ARRAY_TYPE_DESCRIPTOR:
 		return common.PARSER_RULE_CONTEXT_CLOSE_BRACKET
 	case common.PARSER_RULE_CONTEXT_CALL_STMT:
@@ -4892,21 +4892,21 @@ func (this *BallerinaParserErrorHandler) getNextRuleForExprStartsWithVarRef() co
 	return common.PARSER_RULE_CONTEXT_VARIABLE_REF_RHS
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForConstExpr() common.ParserRuleContext {
-	parentCtx := this.GetParentContext()
+func (b *BallerinaParserErrorHandler) getNextRuleForConstExpr() common.ParserRuleContext {
+	parentCtx := b.GetParentContext()
 	switch parentCtx {
 	case common.PARSER_RULE_CONTEXT_XML_NAMESPACE_DECLARATION:
 		return common.PARSER_RULE_CONTEXT_XML_NAMESPACE_PREFIX_DECL
 	default:
-		if this.isInTypeDescContext() {
+		if b.isInTypeDescContext() {
 			return common.PARSER_RULE_CONTEXT_TYPE_DESC_RHS
 		}
-		return this.getNextRuleForMatchPattern()
+		return b.getNextRuleForMatchPattern()
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForLt() common.ParserRuleContext {
-	parentCtx := this.GetParentContext()
+func (b *BallerinaParserErrorHandler) getNextRuleForLt() common.ParserRuleContext {
+	parentCtx := b.GetParentContext()
 	switch parentCtx {
 	case common.PARSER_RULE_CONTEXT_TYPE_CAST:
 		return common.PARSER_RULE_CONTEXT_TYPE_CAST_PARAM
@@ -4915,50 +4915,50 @@ func (this *BallerinaParserErrorHandler) getNextRuleForLt() common.ParserRuleCon
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForGt() common.ParserRuleContext {
-	parentCtx := this.GetParentContext()
+func (b *BallerinaParserErrorHandler) getNextRuleForGt() common.ParserRuleContext {
+	parentCtx := b.GetParentContext()
 	if parentCtx == common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_STREAM_TYPE_DESC {
-		this.EndContext()
-		parentCtx = this.GetParentContext()
+		b.EndContext()
+		parentCtx = b.GetParentContext()
 		if parentCtx == common.PARSER_RULE_CONTEXT_CLASS_DESCRIPTOR_IN_NEW_EXPR {
-			this.EndContext()
+			b.EndContext()
 			return common.PARSER_RULE_CONTEXT_ARG_LIST_OPEN_PAREN
 		}
 		return common.PARSER_RULE_CONTEXT_TYPE_DESC_RHS
 	}
-	if this.isInTypeDescContext() {
+	if b.isInTypeDescContext() {
 		return common.PARSER_RULE_CONTEXT_TYPE_DESC_RHS
 	}
 	switch parentCtx {
 	case common.PARSER_RULE_CONTEXT_ROW_TYPE_PARAM:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_TABLE_TYPE_DESC_RHS
 	case common.PARSER_RULE_CONTEXT_RETRY_STMT:
 		return common.PARSER_RULE_CONTEXT_RETRY_TYPE_PARAM_RHS
 	}
 	if parentCtx == common.PARSER_RULE_CONTEXT_XML_NAME_PATTERN {
-		this.EndContext()
-		parentCtx = this.GetParentContext()
+		b.EndContext()
+		parentCtx = b.GetParentContext()
 		if parentCtx == common.PARSER_RULE_CONTEXT_XML_STEP_EXTENDS {
 			return common.PARSER_RULE_CONTEXT_XML_STEP_EXTEND
 		}
 		return common.PARSER_RULE_CONTEXT_XML_STEP_START_END
 	}
-	this.EndContext()
+	b.EndContext()
 	return common.PARSER_RULE_CONTEXT_EXPRESSION
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForBindingPatternDefault() common.ParserRuleContext {
-	return this.getNextRuleForBindingPatternWithCapture(false)
+func (b *BallerinaParserErrorHandler) getNextRuleForBindingPatternDefault() common.ParserRuleContext {
+	return b.getNextRuleForBindingPatternWithCapture(false)
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForBindingPatternWithCapture(isCaptureBP bool) common.ParserRuleContext {
-	parentCtx := this.GetParentContext()
+func (b *BallerinaParserErrorHandler) getNextRuleForBindingPatternWithCapture(isCaptureBP bool) common.ParserRuleContext {
+	parentCtx := b.GetParentContext()
 	switch parentCtx {
 	case common.PARSER_RULE_CONTEXT_BINDING_PATTERN_STARTING_IDENTIFIER,
 		common.PARSER_RULE_CONTEXT_TYPED_BINDING_PATTERN:
-		this.EndContext()
-		return this.getNextRuleForBindingPatternWithCapture(isCaptureBP)
+		b.EndContext()
+		return b.getNextRuleForBindingPatternWithCapture(isCaptureBP)
 	case common.PARSER_RULE_CONTEXT_FOREACH_STMT,
 		common.PARSER_RULE_CONTEXT_QUERY_EXPRESSION,
 		common.PARSER_RULE_CONTEXT_JOIN_CLAUSE:
@@ -4971,8 +4971,8 @@ func (this *BallerinaParserErrorHandler) getNextRuleForBindingPatternWithCapture
 		common.PARSER_RULE_CONTEXT_MAPPING_BP_OR_MAPPING_CONSTRUCTOR:
 		return common.PARSER_RULE_CONTEXT_MAPPING_BINDING_PATTERN_END
 	case common.PARSER_RULE_CONTEXT_REST_BINDING_PATTERN:
-		this.EndContext()
-		parentCtx = this.GetParentContext()
+		b.EndContext()
+		parentCtx = b.GetParentContext()
 		switch parentCtx {
 		case common.PARSER_RULE_CONTEXT_LIST_BINDING_PATTERN:
 			return common.PARSER_RULE_CONTEXT_CLOSE_BRACKET
@@ -4981,7 +4981,7 @@ func (this *BallerinaParserErrorHandler) getNextRuleForBindingPatternWithCapture
 		}
 		return common.PARSER_RULE_CONTEXT_CLOSE_BRACE
 	case common.PARSER_RULE_CONTEXT_AMBIGUOUS_STMT:
-		this.SwitchContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+		b.SwitchContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
 		if isCaptureBP {
 			return common.PARSER_RULE_CONTEXT_VAR_DECL_STMT_RHS
 		} else {
@@ -5006,45 +5006,45 @@ func (this *BallerinaParserErrorHandler) getNextRuleForBindingPatternWithCapture
 	case common.PARSER_RULE_CONTEXT_ERROR_BINDING_PATTERN:
 		return common.PARSER_RULE_CONTEXT_ERROR_FIELD_BINDING_PATTERN_END
 	case common.PARSER_RULE_CONTEXT_ERROR_ARG_LIST_MATCH_PATTERN_FIRST_ARG:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_ERROR_FIELD_MATCH_PATTERN_RHS
 	case common.PARSER_RULE_CONTEXT_ON_FAIL_CLAUSE:
 		return common.PARSER_RULE_CONTEXT_BLOCK_STMT
 	default:
-		return this.getNextRuleForMatchPattern()
+		return b.getNextRuleForMatchPattern()
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForWaitExprListEnd() common.ParserRuleContext {
-	this.EndContext()
+func (b *BallerinaParserErrorHandler) getNextRuleForWaitExprListEnd() common.ParserRuleContext {
+	b.EndContext()
 	return common.PARSER_RULE_CONTEXT_EXPRESSION_RHS
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForIdentifier() common.ParserRuleContext {
-	var parentCtx = this.GetParentContext()
+func (b *BallerinaParserErrorHandler) getNextRuleForIdentifier() common.ParserRuleContext {
+	var parentCtx = b.GetParentContext()
 	switch parentCtx {
 	case common.PARSER_RULE_CONTEXT_VARIABLE_REF:
-		this.EndContext()
-		return this.getNextRuleForExprStartsWithVarRef()
+		b.EndContext()
+		return b.getNextRuleForExprStartsWithVarRef()
 	case common.PARSER_RULE_CONTEXT_TYPE_REFERENCE:
-		this.EndContext()
-		return this.getNextRuleForTypeReference()
+		b.EndContext()
+		return b.getNextRuleForTypeReference()
 	case common.PARSER_RULE_CONTEXT_TYPE_REFERENCE_IN_TYPE_INCLUSION:
-		this.EndContext()
-		if this.isInTypeDescContext() {
+		b.EndContext()
+		if b.isInTypeDescContext() {
 			return common.PARSER_RULE_CONTEXT_TYPE_DESC_RHS
 		}
 		return common.PARSER_RULE_CONTEXT_SEMICOLON
 	case common.PARSER_RULE_CONTEXT_ANNOT_REFERENCE:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_ANNOTATION_REF_RHS
 	case common.PARSER_RULE_CONTEXT_ANNOTATION_DECL:
 		return common.PARSER_RULE_CONTEXT_ANNOT_OPTIONAL_ATTACH_POINTS
 	case common.PARSER_RULE_CONTEXT_FIELD_ACCESS_IDENTIFIER:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_VARIABLE_REF_RHS
 	case common.PARSER_RULE_CONTEXT_XML_ATOMIC_NAME_PATTERN:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_XML_NAME_PATTERN_RHS
 	case common.PARSER_RULE_CONTEXT_NAMED_ARG_MATCH_PATTERN:
 		return common.PARSER_RULE_CONTEXT_ASSIGN_OP
@@ -5063,15 +5063,15 @@ func (this *BallerinaParserErrorHandler) getNextRuleForIdentifier() common.Parse
 	case common.PARSER_RULE_CONTEXT_XML_STEP_EXTENDS:
 		return common.PARSER_RULE_CONTEXT_ARG_LIST_OPEN_PAREN
 	default:
-		if this.isInTypeDescContext() {
+		if b.isInTypeDescContext() {
 			return common.PARSER_RULE_CONTEXT_TYPE_DESC_RHS
 		}
 		panic("getNextRuleForIdentifier found: " + parentCtx.String())
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForColon() common.ParserRuleContext {
-	var parentCtx = this.GetParentContext()
+func (b *BallerinaParserErrorHandler) getNextRuleForColon() common.ParserRuleContext {
+	var parentCtx = b.GetParentContext()
 	switch parentCtx {
 	case common.PARSER_RULE_CONTEXT_MAPPING_CONSTRUCTOR:
 		return common.PARSER_RULE_CONTEXT_EXPRESSION
@@ -5080,13 +5080,13 @@ func (this *BallerinaParserErrorHandler) getNextRuleForColon() common.ParserRule
 	case common.PARSER_RULE_CONTEXT_MULTI_WAIT_FIELDS:
 		return common.PARSER_RULE_CONTEXT_EXPRESSION
 	case common.PARSER_RULE_CONTEXT_CONDITIONAL_EXPRESSION:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_EXPRESSION
 	case common.PARSER_RULE_CONTEXT_MAPPING_BINDING_PATTERN,
 		common.PARSER_RULE_CONTEXT_MAPPING_BP_OR_MAPPING_CONSTRUCTOR:
 		return common.PARSER_RULE_CONTEXT_VARIABLE_NAME
 	case common.PARSER_RULE_CONTEXT_FIELD_BINDING_PATTERN:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_VARIABLE_NAME
 	case common.PARSER_RULE_CONTEXT_XML_ATOMIC_NAME_PATTERN:
 		return common.PARSER_RULE_CONTEXT_XML_ATOMIC_NAME_IDENTIFIER_RHS
@@ -5097,8 +5097,8 @@ func (this *BallerinaParserErrorHandler) getNextRuleForColon() common.ParserRule
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForMatchPattern() common.ParserRuleContext {
-	parentCtx := this.GetParentContext()
+func (b *BallerinaParserErrorHandler) getNextRuleForMatchPattern() common.ParserRuleContext {
+	parentCtx := b.GetParentContext()
 	switch parentCtx {
 	case common.PARSER_RULE_CONTEXT_LIST_MATCH_PATTERN:
 		return common.PARSER_RULE_CONTEXT_LIST_MATCH_PATTERN_MEMBER_RHS
@@ -5110,15 +5110,15 @@ func (this *BallerinaParserErrorHandler) getNextRuleForMatchPattern() common.Par
 		common.PARSER_RULE_CONTEXT_NAMED_ARG_MATCH_PATTERN:
 		return common.PARSER_RULE_CONTEXT_ERROR_FIELD_MATCH_PATTERN_RHS
 	case common.PARSER_RULE_CONTEXT_ERROR_ARG_LIST_MATCH_PATTERN_FIRST_ARG:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_ERROR_MESSAGE_MATCH_PATTERN_END
 	default:
 		return common.PARSER_RULE_CONTEXT_OPTIONAL_MATCH_GUARD
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForTypeReference() common.ParserRuleContext {
-	parentCtx := this.GetParentContext()
+func (b *BallerinaParserErrorHandler) getNextRuleForTypeReference() common.ParserRuleContext {
+	parentCtx := b.GetParentContext()
 	switch parentCtx {
 	case common.PARSER_RULE_CONTEXT_ERROR_CONSTRUCTOR:
 		return common.PARSER_RULE_CONTEXT_ARG_LIST_OPEN_PAREN
@@ -5128,21 +5128,21 @@ func (this *BallerinaParserErrorHandler) getNextRuleForTypeReference() common.Pa
 		common.PARSER_RULE_CONTEXT_ERROR_BINDING_PATTERN:
 		return common.PARSER_RULE_CONTEXT_OPEN_PARENTHESIS
 	case common.PARSER_RULE_CONTEXT_CLASS_DESCRIPTOR_IN_NEW_EXPR:
-		this.EndContext()
+		b.EndContext()
 		return common.PARSER_RULE_CONTEXT_ARG_LIST_OPEN_PAREN
 	default:
-		if this.isInTypeDescContext() {
+		if b.isInTypeDescContext() {
 			return common.PARSER_RULE_CONTEXT_TYPE_DESC_RHS
 		}
 		panic("getNextRuleForTypeReference found: " + parentCtx.String())
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForErrorKeyword() common.ParserRuleContext {
-	if this.isInTypeDescContext() {
+func (b *BallerinaParserErrorHandler) getNextRuleForErrorKeyword() common.ParserRuleContext {
+	if b.isInTypeDescContext() {
 		return common.PARSER_RULE_CONTEXT_LT
 	}
-	parentCtx := this.GetParentContext()
+	parentCtx := b.GetParentContext()
 	switch parentCtx {
 	case common.PARSER_RULE_CONTEXT_ERROR_MATCH_PATTERN:
 		return common.PARSER_RULE_CONTEXT_ERROR_MATCH_PATTERN_ERROR_KEYWORD_RHS
@@ -5155,34 +5155,34 @@ func (this *BallerinaParserErrorHandler) getNextRuleForErrorKeyword() common.Par
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForFuncTypeFuncKeywordRhs() common.ParserRuleContext {
-	parentCtx := this.GetParentContext()
+func (b *BallerinaParserErrorHandler) getNextRuleForFuncTypeFuncKeywordRhs() common.ParserRuleContext {
+	parentCtx := b.GetParentContext()
 	if parentCtx == common.PARSER_RULE_CONTEXT_FUNC_DEF_OR_FUNC_TYPE {
-		this.EndContext()
-		parentCtx = this.GetParentContext()
+		b.EndContext()
+		parentCtx = b.GetParentContext()
 		switch parentCtx {
 		case common.PARSER_RULE_CONTEXT_OBJECT_TYPE_MEMBER,
 			common.PARSER_RULE_CONTEXT_CLASS_MEMBER,
 			common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR_MEMBER:
-			this.StartContext(common.PARSER_RULE_CONTEXT_TYPE_DESC_BEFORE_IDENTIFIER)
+			b.StartContext(common.PARSER_RULE_CONTEXT_TYPE_DESC_BEFORE_IDENTIFIER)
 		case common.PARSER_RULE_CONTEXT_COMP_UNIT:
 			fallthrough
 		default:
-			this.StartContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
-			this.StartContext(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN)
+			b.StartContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+			b.StartContext(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN)
 		}
-	} else if this.GetGrandParentContext() == common.PARSER_RULE_CONTEXT_OBJECT_TYPE_MEMBER {
-		this.SwitchContext(common.PARSER_RULE_CONTEXT_TYPE_DESC_BEFORE_IDENTIFIER)
+	} else if b.GetGrandParentContext() == common.PARSER_RULE_CONTEXT_OBJECT_TYPE_MEMBER {
+		b.SwitchContext(common.PARSER_RULE_CONTEXT_TYPE_DESC_BEFORE_IDENTIFIER)
 	}
-	if !this.isInTypeDescContext() {
+	if !b.isInTypeDescContext() {
 		panic("assertion failed")
 	}
-	this.StartContext(common.PARSER_RULE_CONTEXT_FUNC_TYPE_DESC)
+	b.StartContext(common.PARSER_RULE_CONTEXT_FUNC_TYPE_DESC)
 	return common.PARSER_RULE_CONTEXT_FUNC_TYPE_FUNC_KEYWORD_RHS_START
 }
 
-func (this *BallerinaParserErrorHandler) getNextRuleForAction() common.ParserRuleContext {
-	parentCtx := this.GetParentContext()
+func (b *BallerinaParserErrorHandler) getNextRuleForAction() common.ParserRuleContext {
+	parentCtx := b.GetParentContext()
 	switch parentCtx {
 	case common.PARSER_RULE_CONTEXT_MATCH_STMT:
 		return common.PARSER_RULE_CONTEXT_MATCH_BODY
@@ -5193,7 +5193,7 @@ func (this *BallerinaParserErrorHandler) getNextRuleForAction() common.ParserRul
 	}
 }
 
-func (this *BallerinaParserErrorHandler) isStatement(parentCtx common.ParserRuleContext) bool {
+func (b *BallerinaParserErrorHandler) isStatement(parentCtx common.ParserRuleContext) bool {
 	switch parentCtx {
 	case common.PARSER_RULE_CONTEXT_STATEMENT,
 		common.PARSER_RULE_CONTEXT_STATEMENT_WITHOUT_ANNOTS,
@@ -5226,7 +5226,7 @@ func (this *BallerinaParserErrorHandler) isStatement(parentCtx common.ParserRule
 	}
 }
 
-func (this *BallerinaParserErrorHandler) isBinaryOperator(token tree.STToken) bool {
+func (b *BallerinaParserErrorHandler) isBinaryOperator(token tree.STToken) bool {
 	switch token.Kind() {
 	case common.PLUS_TOKEN,
 		common.MINUS_TOKEN,
@@ -5260,7 +5260,7 @@ func (this *BallerinaParserErrorHandler) isBinaryOperator(token tree.STToken) bo
 	}
 }
 
-func (this *BallerinaParserErrorHandler) isParameter(ctx common.ParserRuleContext) bool {
+func (b *BallerinaParserErrorHandler) isParameter(ctx common.ParserRuleContext) bool {
 	switch ctx {
 	case common.PARSER_RULE_CONTEXT_REQUIRED_PARAM, common.PARSER_RULE_CONTEXT_DEFAULTABLE_PARAM, common.PARSER_RULE_CONTEXT_REST_PARAM, common.PARSER_RULE_CONTEXT_PARAM_LIST:
 		return true
@@ -5269,20 +5269,20 @@ func (this *BallerinaParserErrorHandler) isParameter(ctx common.ParserRuleContex
 	}
 }
 
-func (this *BallerinaParserErrorHandler) GetInsertSolution(ctx common.ParserRuleContext) *Solution {
-	kind := this.GetExpectedTokenKind(ctx)
+func (b *BallerinaParserErrorHandler) GetInsertSolution(ctx common.ParserRuleContext) *Solution {
+	kind := b.GetExpectedTokenKind(ctx)
 	if kind != common.NONE {
 		return NewSolution(ACTION_INSERT, ctx, kind, ctx.String())
 	}
-	if this.HasAlternativePaths(ctx) {
-		ctx = this.getShortestAlternative(ctx)
-		return this.GetInsertSolution(ctx)
+	if b.HasAlternativePaths(ctx) {
+		ctx = b.getShortestAlternative(ctx)
+		return b.GetInsertSolution(ctx)
 	}
-	ctx = this.GetNextRule(ctx, 1)
-	return this.GetInsertSolution(ctx)
+	ctx = b.GetNextRule(ctx, 1)
+	return b.GetInsertSolution(ctx)
 }
 
-func (this *BallerinaParserErrorHandler) GetExpectedTokenKind(ctx common.ParserRuleContext) common.SyntaxKind {
+func (b *BallerinaParserErrorHandler) GetExpectedTokenKind(ctx common.ParserRuleContext) common.SyntaxKind {
 	switch ctx {
 	case common.PARSER_RULE_CONTEXT_EXTERNAL_FUNC_BODY:
 		return common.EQUAL_TOKEN
@@ -5367,11 +5367,11 @@ func (this *BallerinaParserErrorHandler) GetExpectedTokenKind(ctx common.ParserR
 	case common.PARSER_RULE_CONTEXT_ERROR_MATCH_PATTERN, common.PARSER_RULE_CONTEXT_NIL_LITERAL:
 		return common.OPEN_PAREN_TOKEN
 	default:
-		return this.getExpectedSeperatorTokenKind(ctx)
+		return b.getExpectedSeperatorTokenKind(ctx)
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getExpectedSeperatorTokenKind(ctx common.ParserRuleContext) common.SyntaxKind {
+func (b *BallerinaParserErrorHandler) getExpectedSeperatorTokenKind(ctx common.ParserRuleContext) common.SyntaxKind {
 	switch ctx {
 	case common.PARSER_RULE_CONTEXT_BITWISE_AND_OPERATOR:
 		return common.BITWISE_AND_TOKEN
@@ -5467,11 +5467,11 @@ func (this *BallerinaParserErrorHandler) getExpectedSeperatorTokenKind(ctx commo
 		common.PARSER_RULE_CONTEXT_RIGHT_DOUBLE_ARROW:
 		return common.RIGHT_DOUBLE_ARROW_TOKEN
 	default:
-		return this.getExpectedKeywordKind(ctx)
+		return b.getExpectedKeywordKind(ctx)
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getExpectedKeywordKind(ctx common.ParserRuleContext) common.SyntaxKind {
+func (b *BallerinaParserErrorHandler) getExpectedKeywordKind(ctx common.ParserRuleContext) common.SyntaxKind {
 	switch ctx {
 	case common.PARSER_RULE_CONTEXT_EXTERNAL_KEYWORD:
 		return common.EXTERNAL_KEYWORD
@@ -5650,11 +5650,11 @@ func (this *BallerinaParserErrorHandler) getExpectedKeywordKind(ctx common.Parse
 	case common.PARSER_RULE_CONTEXT_NATURAL_KEYWORD:
 		return common.NATURAL_KEYWORD
 	default:
-		return this.getExpectedQualifierKind(ctx)
+		return b.getExpectedQualifierKind(ctx)
 	}
 }
 
-func (this *BallerinaParserErrorHandler) getExpectedQualifierKind(ctx common.ParserRuleContext) common.SyntaxKind {
+func (b *BallerinaParserErrorHandler) getExpectedQualifierKind(ctx common.ParserRuleContext) common.SyntaxKind {
 	switch ctx {
 	case common.PARSER_RULE_CONTEXT_FIRST_OBJECT_CONS_QUALIFIER,
 		common.PARSER_RULE_CONTEXT_SECOND_OBJECT_CONS_QUALIFIER,
@@ -5687,7 +5687,7 @@ func (this *BallerinaParserErrorHandler) getExpectedQualifierKind(ctx common.Par
 	}
 }
 
-func (this *BallerinaParserErrorHandler) isBasicLiteral(kind common.SyntaxKind) bool {
+func (b *BallerinaParserErrorHandler) isBasicLiteral(kind common.SyntaxKind) bool {
 	switch kind {
 	case common.DECIMAL_INTEGER_LITERAL_TOKEN,
 		common.HEX_INTEGER_LITERAL_TOKEN,
@@ -5703,7 +5703,7 @@ func (this *BallerinaParserErrorHandler) isBasicLiteral(kind common.SyntaxKind) 
 	}
 }
 
-func (this *BallerinaParserErrorHandler) isUnaryOperator(token tree.STToken) bool {
+func (b *BallerinaParserErrorHandler) isUnaryOperator(token tree.STToken) bool {
 	switch token.Kind() {
 	case common.PLUS_TOKEN,
 		common.MINUS_TOKEN,
@@ -5715,7 +5715,7 @@ func (this *BallerinaParserErrorHandler) isUnaryOperator(token tree.STToken) boo
 	}
 }
 
-func (this *BallerinaParserErrorHandler) isSingleKeywordAttachPointIdent(tokenKind common.SyntaxKind) bool {
+func (b *BallerinaParserErrorHandler) isSingleKeywordAttachPointIdent(tokenKind common.SyntaxKind) bool {
 	switch tokenKind {
 	case common.ANNOTATION_KEYWORD,
 		common.EXTERNAL_KEYWORD,

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -65,19 +65,19 @@ const (
 
 const DEFAULT_OP_PRECEDENCE OperatorPrecedence = OPERATOR_PRECEDENCE_DEFAULT
 
-func (this *OperatorPrecedence) isHigherThanOrEqual(other OperatorPrecedence, allowActions bool) bool {
+func (o *OperatorPrecedence) isHigherThanOrEqual(other OperatorPrecedence, allowActions bool) bool {
 	if allowActions {
-		if (*this == OPERATOR_PRECEDENCE_EXPRESSION_ACTION) && (other == OPERATOR_PRECEDENCE_REMOTE_CALL_ACTION) {
+		if (*o == OPERATOR_PRECEDENCE_EXPRESSION_ACTION) && (other == OPERATOR_PRECEDENCE_REMOTE_CALL_ACTION) {
 			return false
 		}
 	}
-	return uint8(*this) <= uint8(other)
+	return uint8(*o) <= uint8(other)
 }
 
 type TypePrecedence uint8
 
-func (this *TypePrecedence) isHigherThanOrEqual(other TypePrecedence) bool {
-	return uint8(*this) <= uint8(other)
+func (t *TypePrecedence) isHigherThanOrEqual(other TypePrecedence) bool {
+	return uint8(*t) <= uint8(other)
 }
 
 const (
@@ -150,100 +150,100 @@ func NewAbstractParserFromTokenReader(tokenReader *TokenReader) abstractParser {
 	return this
 }
 
-func (this *abstractParser) peek() tree.STToken {
-	if this.insertedToken != nil {
-		return this.insertedToken
+func (a *abstractParser) peek() tree.STToken {
+	if a.insertedToken != nil {
+		return a.insertedToken
 	}
-	return this.tokenReader.Peek()
+	return a.tokenReader.Peek()
 }
 
-func (this *abstractParser) peekN(n int) tree.STToken {
-	if this.insertedToken == nil {
-		return this.tokenReader.PeekN(n)
+func (a *abstractParser) peekN(n int) tree.STToken {
+	if a.insertedToken == nil {
+		return a.tokenReader.PeekN(n)
 	}
 	if n == 1 {
-		return this.insertedToken
+		return a.insertedToken
 	}
 	if n > 0 {
 		n = (n - 1)
 	}
-	return this.tokenReader.PeekN(n)
+	return a.tokenReader.PeekN(n)
 }
 
-func (this *abstractParser) consume() tree.STToken {
-	if this.insertedToken != nil {
-		nextToken := this.insertedToken
-		this.insertedToken = nil
-		return this.consumeWithInvalidNodesWithToken(nextToken)
+func (a *abstractParser) consume() tree.STToken {
+	if a.insertedToken != nil {
+		nextToken := a.insertedToken
+		a.insertedToken = nil
+		return a.consumeWithInvalidNodesWithToken(nextToken)
 	}
-	if len(this.invalidNodeInfoStack) == 0 {
-		return this.tokenReader.Read()
+	if len(a.invalidNodeInfoStack) == 0 {
+		return a.tokenReader.Read()
 	}
-	return this.consumeWithInvalidNodes()
+	return a.consumeWithInvalidNodes()
 }
 
-func (this *abstractParser) consumeWithInvalidNodes() tree.STToken {
-	token := this.tokenReader.Read()
-	return this.consumeWithInvalidNodesWithToken(token)
+func (a *abstractParser) consumeWithInvalidNodes() tree.STToken {
+	token := a.tokenReader.Read()
+	return a.consumeWithInvalidNodesWithToken(token)
 }
 
-func (this *abstractParser) consumeWithInvalidNodesWithToken(token tree.STToken) tree.STToken {
+func (a *abstractParser) consumeWithInvalidNodesWithToken(token tree.STToken) tree.STToken {
 	newToken := token
-	for len(this.invalidNodeInfoStack) > 0 {
-		invalidNodeInfo := this.invalidNodeInfoStack[len(this.invalidNodeInfoStack)-1]
-		this.invalidNodeInfoStack = this.invalidNodeInfoStack[:len(this.invalidNodeInfoStack)-1]
+	for len(a.invalidNodeInfoStack) > 0 {
+		invalidNodeInfo := a.invalidNodeInfoStack[len(a.invalidNodeInfoStack)-1]
+		a.invalidNodeInfoStack = a.invalidNodeInfoStack[:len(a.invalidNodeInfoStack)-1]
 		newToken = tree.ToToken(tree.CloneWithLeadingInvalidNodeMinutiae(newToken, invalidNodeInfo.node,
 			invalidNodeInfo.diagnosticCode, invalidNodeInfo.args))
 	}
 	return newToken
 }
 
-func (this *abstractParser) recover(token tree.STToken, currentCtx common.ParserRuleContext, isCompletion bool) *Solution {
+func (a *abstractParser) recover(token tree.STToken, currentCtx common.ParserRuleContext, isCompletion bool) *Solution {
 	isCompletion = isCompletion || token.Kind() == common.EOF_TOKEN
-	sol := this.errorHandler.Recover(currentCtx, token, isCompletion)
+	sol := a.errorHandler.Recover(currentCtx, token, isCompletion)
 	switch sol.Action {
 	case ACTION_REMOVE:
-		this.insertedToken = nil
-		this.addInvalidTokenToNextToken(sol.RemovedToken)
+		a.insertedToken = nil
+		a.addInvalidTokenToNextToken(sol.RemovedToken)
 	case ACTION_INSERT:
-		this.insertedToken = tree.ToToken(sol.RecoveredNode)
+		a.insertedToken = tree.ToToken(sol.RecoveredNode)
 	}
 	return sol
 }
 
-func (this *abstractParser) insertToken(kind common.SyntaxKind, context common.ParserRuleContext) {
-	this.insertedToken = tree.CreateMissingTokenWithDiagnosticsFromParserRules(kind, context)
+func (a *abstractParser) insertToken(kind common.SyntaxKind, context common.ParserRuleContext) {
+	a.insertedToken = tree.CreateMissingTokenWithDiagnosticsFromParserRules(kind, context)
 }
 
-func (this *abstractParser) removeInsertedToken() {
-	this.insertedToken = nil
+func (a *abstractParser) removeInsertedToken() {
+	a.insertedToken = nil
 }
 
-func (this *abstractParser) isInvalidNodeStackEmpty() bool {
-	return len(this.invalidNodeInfoStack) == 0
+func (a *abstractParser) isInvalidNodeStackEmpty() bool {
+	return len(a.invalidNodeInfoStack) == 0
 }
 
-func (this *abstractParser) startContext(context common.ParserRuleContext) {
-	this.errorHandler.StartContext(context)
+func (a *abstractParser) startContext(context common.ParserRuleContext) {
+	a.errorHandler.StartContext(context)
 }
 
-func (this *abstractParser) endContext() {
-	this.errorHandler.EndContext()
+func (a *abstractParser) endContext() {
+	a.errorHandler.EndContext()
 }
 
-func (this *abstractParser) getCurrentContext() common.ParserRuleContext {
-	return this.errorHandler.GetParentContext()
+func (a *abstractParser) getCurrentContext() common.ParserRuleContext {
+	return a.errorHandler.GetParentContext()
 }
 
-func (this *abstractParser) switchContext(context common.ParserRuleContext) {
-	this.errorHandler.SwitchContext(context)
+func (a *abstractParser) switchContext(context common.ParserRuleContext) {
+	a.errorHandler.SwitchContext(context)
 }
 
-func (this *abstractParser) getNextNextToken() tree.STToken {
-	return this.peekN(2)
+func (a *abstractParser) getNextNextToken() tree.STToken {
+	return a.peekN(2)
 }
 
-func (this *abstractParser) isNodeListEmpty(node tree.STNode) bool {
+func (a *abstractParser) isNodeListEmpty(node tree.STNode) bool {
 	nodeList, ok := node.(*tree.STNodeList)
 	if !ok {
 		panic("node is not a STNodeList")
@@ -251,14 +251,14 @@ func (this *abstractParser) isNodeListEmpty(node tree.STNode) bool {
 	return nodeList.IsEmpty()
 }
 
-func (this *abstractParser) cloneWithDiagnosticIfListEmpty(nodeList tree.STNode, target tree.STNode, diagnosticCode diagnostics.DiagnosticCode) tree.STNode {
-	if this.isNodeListEmpty(nodeList) {
+func (a *abstractParser) cloneWithDiagnosticIfListEmpty(nodeList tree.STNode, target tree.STNode, diagnosticCode diagnostics.DiagnosticCode) tree.STNode {
+	if a.isNodeListEmpty(nodeList) {
 		return tree.AddDiagnostic(target, diagnosticCode)
 	}
 	return target
 }
 
-func (this *abstractParser) updateLastNodeInListWithInvalidNode(nodeList []tree.STNode, invalidParam tree.STNode, diagnosticCode diagnostics.DiagnosticCode, args ...any) []tree.STNode {
+func (a *abstractParser) updateLastNodeInListWithInvalidNode(nodeList []tree.STNode, invalidParam tree.STNode, diagnosticCode diagnostics.DiagnosticCode, args ...any) []tree.STNode {
 	prevNode := nodeList[len(nodeList)-1]
 	nodeList = nodeList[:len(nodeList)-1]
 	newNode := tree.CloneWithTrailingInvalidNodeMinutiae(prevNode, invalidParam, diagnosticCode, args)
@@ -266,41 +266,41 @@ func (this *abstractParser) updateLastNodeInListWithInvalidNode(nodeList []tree.
 	return nodeList
 }
 
-func (this *abstractParser) updateFirstNodeInListWithLeadingInvalidNode(nodeList []tree.STNode, invalidParam tree.STNode, diagnosticCode diagnostics.DiagnosticCode, args ...any) []tree.STNode {
-	return this.updateANodeInListWithLeadingInvalidNode(nodeList, 0, invalidParam, diagnosticCode, args)
+func (a *abstractParser) updateFirstNodeInListWithLeadingInvalidNode(nodeList []tree.STNode, invalidParam tree.STNode, diagnosticCode diagnostics.DiagnosticCode, args ...any) []tree.STNode {
+	return a.updateANodeInListWithLeadingInvalidNode(nodeList, 0, invalidParam, diagnosticCode, args)
 }
 
-func (this *abstractParser) updateANodeInListWithLeadingInvalidNode(nodeList []tree.STNode, indexOfTheNode int, invalidParam tree.STNode, diagnosticCode diagnostics.DiagnosticCode, args ...any) []tree.STNode {
+func (a *abstractParser) updateANodeInListWithLeadingInvalidNode(nodeList []tree.STNode, indexOfTheNode int, invalidParam tree.STNode, diagnosticCode diagnostics.DiagnosticCode, args ...any) []tree.STNode {
 	node := nodeList[indexOfTheNode]
 	newNode := tree.CloneWithLeadingInvalidNodeMinutiae(node, invalidParam, diagnosticCode, args)
 	nodeList[indexOfTheNode] = newNode
 	return nodeList
 }
 
-func (this *abstractParser) invalidateRestAndAddToTrailingMinutiae(node tree.STNode) tree.STNode {
-	node = this.addInvalidNodeStackToTrailingMinutiae(node)
-	for this.peek().Kind() != common.EOF_TOKEN {
-		invalidToken := this.consume()
+func (a *abstractParser) invalidateRestAndAddToTrailingMinutiae(node tree.STNode) tree.STNode {
+	node = a.addInvalidNodeStackToTrailingMinutiae(node)
+	for a.peek().Kind() != common.EOF_TOKEN {
+		invalidToken := a.consume()
 		node = tree.CloneWithTrailingInvalidNodeMinutiae(node, invalidToken, &common.ERROR_INVALID_TOKEN, invalidToken.Text())
 	}
 	return node
 }
 
-func (this *abstractParser) addInvalidNodeStackToTrailingMinutiae(node tree.STNode) tree.STNode {
-	for len(this.invalidNodeInfoStack) != 0 {
-		invalidNodeInfo := this.invalidNodeInfoStack[len(this.invalidNodeInfoStack)-1]
-		this.invalidNodeInfoStack = this.invalidNodeInfoStack[:len(this.invalidNodeInfoStack)-1]
+func (a *abstractParser) addInvalidNodeStackToTrailingMinutiae(node tree.STNode) tree.STNode {
+	for len(a.invalidNodeInfoStack) != 0 {
+		invalidNodeInfo := a.invalidNodeInfoStack[len(a.invalidNodeInfoStack)-1]
+		a.invalidNodeInfoStack = a.invalidNodeInfoStack[:len(a.invalidNodeInfoStack)-1]
 		node = tree.CloneWithTrailingInvalidNodeMinutiae(node, invalidNodeInfo.node, invalidNodeInfo.diagnosticCode, invalidNodeInfo.args)
 	}
 	return node
 }
 
-func (this *abstractParser) addInvalidNodeToNextToken(invalidNode tree.STNode, diagnosticCode diagnostics.DiagnosticCode, args ...any) {
-	this.invalidNodeInfoStack = append(this.invalidNodeInfoStack, invalidNodeInfo{node: invalidNode, diagnosticCode: diagnosticCode, args: args})
+func (a *abstractParser) addInvalidNodeToNextToken(invalidNode tree.STNode, diagnosticCode diagnostics.DiagnosticCode, args ...any) {
+	a.invalidNodeInfoStack = append(a.invalidNodeInfoStack, invalidNodeInfo{node: invalidNode, diagnosticCode: diagnosticCode, args: args})
 }
 
-func (this *abstractParser) addInvalidTokenToNextToken(invalidNode tree.STToken) {
-	this.invalidNodeInfoStack = append(this.invalidNodeInfoStack, invalidNodeInfo{node: invalidNode, diagnosticCode: &common.ERROR_INVALID_TOKEN, args: []any{invalidNode.Text()}})
+func (a *abstractParser) addInvalidTokenToNextToken(invalidNode tree.STToken) {
+	a.invalidNodeInfoStack = append(a.invalidNodeInfoStack, invalidNodeInfo{node: invalidNode, diagnosticCode: &common.ERROR_INVALID_TOKEN, args: []any{invalidNode.Text()}})
 }
 
 type BallerinaParser struct {
@@ -600,46 +600,46 @@ func isDigit(c byte) bool {
 	return (('0' <= c) && (c <= '9'))
 }
 
-func (this *BallerinaParser) Parse() tree.STNode {
-	ast := this.parseCompUnit()
+func (b *BallerinaParser) Parse() tree.STNode {
+	ast := b.parseCompUnit()
 	debugcommon.DebugWriteLazy(debugcommon.DUMP_ST, func() string { return tree.GenerateJSON(ast) })
 	return ast
 }
 
-func (this *BallerinaParser) ParseAsStatement() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
-	this.startContext(common.PARSER_RULE_CONTEXT_FUNC_DEF)
-	this.startContext(common.PARSER_RULE_CONTEXT_FUNC_BODY_BLOCK)
-	stmt := this.parseStatement()
-	if (stmt == nil) || this.validateStatement(stmt) {
-		stmt = this.createMissingSimpleVarDecl(false)
-		stmt = this.invalidateRestAndAddToTrailingMinutiae(stmt)
+func (b *BallerinaParser) ParseAsStatement() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
+	b.startContext(common.PARSER_RULE_CONTEXT_FUNC_DEF)
+	b.startContext(common.PARSER_RULE_CONTEXT_FUNC_BODY_BLOCK)
+	stmt := b.parseStatement()
+	if (stmt == nil) || b.validateStatement(stmt) {
+		stmt = b.createMissingSimpleVarDecl(false)
+		stmt = b.invalidateRestAndAddToTrailingMinutiae(stmt)
 		return stmt
 	}
 	if stmt.Kind() == common.NAMED_WORKER_DECLARATION {
-		this.addInvalidNodeToNextToken(stmt, &common.ERROR_NAMED_WORKER_NOT_ALLOWED_HERE)
-		stmt = this.createMissingSimpleVarDecl(false)
-		stmt = this.invalidateRestAndAddToTrailingMinutiae(stmt)
+		b.addInvalidNodeToNextToken(stmt, &common.ERROR_NAMED_WORKER_NOT_ALLOWED_HERE)
+		stmt = b.createMissingSimpleVarDecl(false)
+		stmt = b.invalidateRestAndAddToTrailingMinutiae(stmt)
 		return stmt
 	}
-	stmt = this.invalidateRestAndAddToTrailingMinutiae(stmt)
+	stmt = b.invalidateRestAndAddToTrailingMinutiae(stmt)
 	return stmt
 }
 
-func (this *BallerinaParser) ParseAsBlockStatement() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
-	this.startContext(common.PARSER_RULE_CONTEXT_FUNC_DEF)
-	this.startContext(common.PARSER_RULE_CONTEXT_FUNC_BODY_BLOCK)
-	this.startContext(common.PARSER_RULE_CONTEXT_WHILE_BLOCK)
-	blockStmtNode := this.parseBlockNode()
-	blockStmtNode = this.invalidateRestAndAddToTrailingMinutiae(blockStmtNode)
+func (b *BallerinaParser) ParseAsBlockStatement() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
+	b.startContext(common.PARSER_RULE_CONTEXT_FUNC_DEF)
+	b.startContext(common.PARSER_RULE_CONTEXT_FUNC_BODY_BLOCK)
+	b.startContext(common.PARSER_RULE_CONTEXT_WHILE_BLOCK)
+	blockStmtNode := b.parseBlockNode()
+	blockStmtNode = b.invalidateRestAndAddToTrailingMinutiae(blockStmtNode)
 	return blockStmtNode
 }
 
-func (this *BallerinaParser) ParseAsStatements() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
-	this.startContext(common.PARSER_RULE_CONTEXT_FUNC_BODY_BLOCK)
-	stmtsNode := this.parseStatements()
+func (b *BallerinaParser) ParseAsStatements() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
+	b.startContext(common.PARSER_RULE_CONTEXT_FUNC_BODY_BLOCK)
+	stmtsNode := b.parseStatements()
 	stmtNodeList, ok := stmtsNode.(*tree.STNodeList)
 	if !ok {
 		panic("stmtsNode is not a STNodeList")
@@ -650,134 +650,134 @@ func (this *BallerinaParser) ParseAsStatements() tree.STNode {
 	}
 	var lastStmt tree.STNode
 	if stmtNodeList.Size() == 0 {
-		lastStmt = this.createMissingSimpleVarDecl(false)
+		lastStmt = b.createMissingSimpleVarDecl(false)
 	} else {
 		lastStmt = stmtNodeList.Get(stmtNodeList.Size() - 1)
 	}
-	lastStmt = this.invalidateRestAndAddToTrailingMinutiae(lastStmt)
+	lastStmt = b.invalidateRestAndAddToTrailingMinutiae(lastStmt)
 	stmts = append(stmts, lastStmt)
 	return tree.CreateNodeList(stmts...)
 }
 
-func (this *BallerinaParser) ParseAsExpression() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
-	this.startContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
-	expr := this.parseExpression()
-	expr = this.invalidateRestAndAddToTrailingMinutiae(expr)
+func (b *BallerinaParser) ParseAsExpression() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
+	b.startContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+	expr := b.parseExpression()
+	expr = b.invalidateRestAndAddToTrailingMinutiae(expr)
 	return expr
 }
 
-func (this *BallerinaParser) ParseAsActionOrExpression() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
-	this.startContext(common.PARSER_RULE_CONTEXT_FUNC_DEF)
-	this.startContext(common.PARSER_RULE_CONTEXT_FUNC_BODY_BLOCK)
-	this.startContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
-	actionOrExpr := this.parseActionOrExpression()
-	actionOrExpr = this.invalidateRestAndAddToTrailingMinutiae(actionOrExpr)
+func (b *BallerinaParser) ParseAsActionOrExpression() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
+	b.startContext(common.PARSER_RULE_CONTEXT_FUNC_DEF)
+	b.startContext(common.PARSER_RULE_CONTEXT_FUNC_BODY_BLOCK)
+	b.startContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+	actionOrExpr := b.parseActionOrExpression()
+	actionOrExpr = b.invalidateRestAndAddToTrailingMinutiae(actionOrExpr)
 	return actionOrExpr
 }
 
-func (this *BallerinaParser) ParseAsModuleMemberDeclaration() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
-	topLevelNode := this.parseTopLevelNode()
+func (b *BallerinaParser) ParseAsModuleMemberDeclaration() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
+	topLevelNode := b.parseTopLevelNode()
 	if topLevelNode == nil {
-		topLevelNode = this.createMissingSimpleVarDecl(true)
+		topLevelNode = b.createMissingSimpleVarDecl(true)
 	}
 	if topLevelNode.Kind() == common.IMPORT_DECLARATION {
 		temp := topLevelNode
-		topLevelNode = this.createMissingSimpleVarDecl(true)
+		topLevelNode = b.createMissingSimpleVarDecl(true)
 		topLevelNode = tree.CloneWithTrailingInvalidNodeMinutiaeWithoutDiagnostics(topLevelNode, temp)
 	}
-	topLevelNode = this.invalidateRestAndAddToTrailingMinutiae(topLevelNode)
+	topLevelNode = b.invalidateRestAndAddToTrailingMinutiae(topLevelNode)
 	return topLevelNode
 }
 
-func (this *BallerinaParser) ParseAsImportDeclaration() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
-	importDecl := this.parseImportDecl()
-	importDecl = this.invalidateRestAndAddToTrailingMinutiae(importDecl)
+func (b *BallerinaParser) ParseAsImportDeclaration() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
+	importDecl := b.parseImportDecl()
+	importDecl = b.invalidateRestAndAddToTrailingMinutiae(importDecl)
 	return importDecl
 }
 
-func (this *BallerinaParser) ParseAsTypeDescriptor() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
-	this.startContext(common.PARSER_RULE_CONTEXT_MODULE_TYPE_DEFINITION)
-	typeDesc := this.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_DEF)
-	typeDesc = this.invalidateRestAndAddToTrailingMinutiae(typeDesc)
+func (b *BallerinaParser) ParseAsTypeDescriptor() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
+	b.startContext(common.PARSER_RULE_CONTEXT_MODULE_TYPE_DEFINITION)
+	typeDesc := b.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_DEF)
+	typeDesc = b.invalidateRestAndAddToTrailingMinutiae(typeDesc)
 	return typeDesc
 }
 
-func (this *BallerinaParser) ParseAsBindingPattern() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
-	this.startContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
-	bindingPattern := this.parseBindingPattern()
-	bindingPattern = this.invalidateRestAndAddToTrailingMinutiae(bindingPattern)
+func (b *BallerinaParser) ParseAsBindingPattern() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
+	b.startContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+	bindingPattern := b.parseBindingPattern()
+	bindingPattern = b.invalidateRestAndAddToTrailingMinutiae(bindingPattern)
 	return bindingPattern
 }
 
-func (this *BallerinaParser) ParseAsFunctionBodyBlock() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
-	this.startContext(common.PARSER_RULE_CONTEXT_FUNC_DEF)
-	funcBodyBlock := this.parseFunctionBodyBlock(false)
-	funcBodyBlock = this.invalidateRestAndAddToTrailingMinutiae(funcBodyBlock)
+func (b *BallerinaParser) ParseAsFunctionBodyBlock() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
+	b.startContext(common.PARSER_RULE_CONTEXT_FUNC_DEF)
+	funcBodyBlock := b.parseFunctionBodyBlock(false)
+	funcBodyBlock = b.invalidateRestAndAddToTrailingMinutiae(funcBodyBlock)
 	return funcBodyBlock
 }
 
-func (this *BallerinaParser) ParseAsObjectMember() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
-	this.startContext(common.PARSER_RULE_CONTEXT_SERVICE_DECL)
-	this.startContext(common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR_MEMBER)
-	objectMember := this.parseObjectMember(common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR_MEMBER)
+func (b *BallerinaParser) ParseAsObjectMember() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
+	b.startContext(common.PARSER_RULE_CONTEXT_SERVICE_DECL)
+	b.startContext(common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR_MEMBER)
+	objectMember := b.parseObjectMember(common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR_MEMBER)
 	if objectMember == nil {
-		objectMember = this.createMissingSimpleObjectField()
+		objectMember = b.createMissingSimpleObjectField()
 	}
-	objectMember = this.invalidateRestAndAddToTrailingMinutiae(objectMember)
+	objectMember = b.invalidateRestAndAddToTrailingMinutiae(objectMember)
 	return objectMember
 }
 
-func (this *BallerinaParser) ParseAsIntermediateClause(allowActions bool) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
-	this.startContext(common.PARSER_RULE_CONTEXT_FUNC_DEF)
-	this.startContext(common.PARSER_RULE_CONTEXT_FUNC_BODY_BLOCK)
-	this.startContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
-	this.startContext(common.PARSER_RULE_CONTEXT_QUERY_EXPRESSION)
+func (b *BallerinaParser) ParseAsIntermediateClause(allowActions bool) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
+	b.startContext(common.PARSER_RULE_CONTEXT_FUNC_DEF)
+	b.startContext(common.PARSER_RULE_CONTEXT_FUNC_BODY_BLOCK)
+	b.startContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+	b.startContext(common.PARSER_RULE_CONTEXT_QUERY_EXPRESSION)
 	var intermediateClause tree.STNode
-	if !this.isEndOfIntermediateClause(this.peek().Kind()) {
-		intermediateClause = this.parseIntermediateClause(true, allowActions)
+	if !b.isEndOfIntermediateClause(b.peek().Kind()) {
+		intermediateClause = b.parseIntermediateClause(true, allowActions)
 	}
 	if intermediateClause == nil {
-		intermediateClause = this.createMissingWhereClause()
+		intermediateClause = b.createMissingWhereClause()
 	}
 	if intermediateClause.Kind() == common.SELECT_CLAUSE {
 		temp := intermediateClause
-		intermediateClause = this.createMissingWhereClause()
+		intermediateClause = b.createMissingWhereClause()
 		intermediateClause = tree.CloneWithTrailingInvalidNodeMinutiaeWithoutDiagnostics(intermediateClause, temp)
 	}
-	intermediateClause = this.invalidateRestAndAddToTrailingMinutiae(intermediateClause)
+	intermediateClause = b.invalidateRestAndAddToTrailingMinutiae(intermediateClause)
 	return intermediateClause
 }
 
-func (this *BallerinaParser) ParseAsLetVarDeclaration(allowActions bool) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
-	this.startContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
-	this.switchContext(common.PARSER_RULE_CONTEXT_QUERY_EXPRESSION)
-	this.switchContext(common.PARSER_RULE_CONTEXT_LET_CLAUSE_LET_VAR_DECL)
-	letVarDeclaration := this.parseLetVarDecl(common.PARSER_RULE_CONTEXT_LET_CLAUSE_LET_VAR_DECL, true, allowActions)
-	letVarDeclaration = this.invalidateRestAndAddToTrailingMinutiae(letVarDeclaration)
+func (b *BallerinaParser) ParseAsLetVarDeclaration(allowActions bool) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
+	b.startContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+	b.switchContext(common.PARSER_RULE_CONTEXT_QUERY_EXPRESSION)
+	b.switchContext(common.PARSER_RULE_CONTEXT_LET_CLAUSE_LET_VAR_DECL)
+	letVarDeclaration := b.parseLetVarDecl(common.PARSER_RULE_CONTEXT_LET_CLAUSE_LET_VAR_DECL, true, allowActions)
+	letVarDeclaration = b.invalidateRestAndAddToTrailingMinutiae(letVarDeclaration)
 	return letVarDeclaration
 }
 
-func (this *BallerinaParser) ParseAsAnnotation() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
-	this.startContext(common.PARSER_RULE_CONTEXT_ANNOTATIONS)
-	annotation := this.parseAnnotation()
-	annotation = this.invalidateRestAndAddToTrailingMinutiae(annotation)
+func (b *BallerinaParser) ParseAsAnnotation() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
+	b.startContext(common.PARSER_RULE_CONTEXT_ANNOTATIONS)
+	annotation := b.parseAnnotation()
+	annotation = b.invalidateRestAndAddToTrailingMinutiae(annotation)
 	return annotation
 }
 
-func (this *BallerinaParser) ParseAsMarkdownDocumentation() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
-	markdownDoc := this.parseMarkdownDocumentation()
+func (b *BallerinaParser) ParseAsMarkdownDocumentation() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
+	markdownDoc := b.parseMarkdownDocumentation()
 	if tree.ToSourceCode(markdownDoc) == "" {
 		missingHash := tree.CreateMissingTokenWithDiagnostics(common.HASH_TOKEN,
 			&common.WARNING_MISSING_HASH_TOKEN)
@@ -785,38 +785,38 @@ func (this *BallerinaParser) ParseAsMarkdownDocumentation() tree.STNode {
 			missingHash, tree.CreateEmptyNodeList())
 		markdownDoc = tree.CreateMarkdownDocumentationNode(tree.CreateNodeListFromNodes(docLine))
 	}
-	markdownDoc = this.invalidateRestAndAddToTrailingMinutiae(markdownDoc)
+	markdownDoc = b.invalidateRestAndAddToTrailingMinutiae(markdownDoc)
 	return markdownDoc
 }
 
-func (this *BallerinaParser) ParseWithContext(context common.ParserRuleContext) tree.STNode {
+func (b *BallerinaParser) ParseWithContext(context common.ParserRuleContext) tree.STNode {
 	switch context {
 	case common.PARSER_RULE_CONTEXT_COMP_UNIT:
-		return this.parseCompUnit()
+		return b.parseCompUnit()
 	case common.PARSER_RULE_CONTEXT_TOP_LEVEL_NODE:
-		this.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
-		return this.parseTopLevelNode()
+		b.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
+		return b.parseTopLevelNode()
 	case common.PARSER_RULE_CONTEXT_STATEMENT:
-		this.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
-		this.startContext(common.PARSER_RULE_CONTEXT_FUNC_BODY_BLOCK)
-		return this.parseStatement()
+		b.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
+		b.startContext(common.PARSER_RULE_CONTEXT_FUNC_BODY_BLOCK)
+		return b.parseStatement()
 	case common.PARSER_RULE_CONTEXT_EXPRESSION:
-		this.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
-		this.startContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
-		return this.parseExpression()
+		b.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
+		b.startContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+		return b.parseExpression()
 	default:
 		panic("Cannot start parsing from: " + context.String())
 	}
 }
 
-func (this *BallerinaParser) parseCompUnit() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
+func (b *BallerinaParser) parseCompUnit() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_COMP_UNIT)
 	var otherDecls []tree.STNode
 	var importDecls []tree.STNode
 	processImports := true
-	token := this.peek()
+	token := b.peek()
 	for token.Kind() != common.EOF_TOKEN {
-		decl := this.parseTopLevelNode()
+		decl := b.parseTopLevelNode()
 		if decl == nil {
 			break
 		}
@@ -824,7 +824,7 @@ func (this *BallerinaParser) parseCompUnit() tree.STNode {
 			if processImports {
 				importDecls = append(importDecls, decl)
 			} else {
-				this.updateLastNodeInListWithInvalidNode(otherDecls, decl,
+				b.updateLastNodeInListWithInvalidNode(otherDecls, decl,
 					&common.ERROR_IMPORT_DECLARATION_AFTER_OTHER_DECLARATIONS)
 			}
 		} else {
@@ -833,22 +833,22 @@ func (this *BallerinaParser) parseCompUnit() tree.STNode {
 			}
 			otherDecls = append(otherDecls, decl)
 		}
-		token = this.peek()
+		token = b.peek()
 	}
-	eof := this.consume()
-	this.endContext()
+	eof := b.consume()
+	b.endContext()
 	return tree.CreateModulePartNode(tree.CreateNodeList(importDecls...), tree.CreateNodeList(otherDecls...), eof)
 }
 
-func (this *BallerinaParser) parseTopLevelNode() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseTopLevelNode() tree.STNode {
+	nextToken := b.peek()
 	var metadata tree.STNode
 	switch nextToken.Kind() {
 	case common.EOF_TOKEN:
 		return nil
 	case common.DOCUMENTATION_STRING, common.AT_TOKEN:
-		metadata = this.parseMetaData()
-		return this.parseTopLevelNodeWithMetadata(metadata)
+		metadata = b.parseMetaData()
+		return b.parseTopLevelNodeWithMetadata(metadata)
 	case common.IMPORT_KEYWORD,
 		common.FINAL_KEYWORD,
 		common.PUBLIC_KEYWORD,
@@ -869,31 +869,31 @@ func (this *BallerinaParser) parseTopLevelNode() tree.STNode {
 		common.SERVICE_KEYWORD:
 		metadata = tree.CreateEmptyNode()
 	case common.RESOURCE_KEYWORD, common.REMOTE_KEYWORD:
-		this.reportInvalidQualifier(this.consume())
-		return this.parseTopLevelNode()
+		b.reportInvalidQualifier(b.consume())
+		return b.parseTopLevelNode()
 	case common.IDENTIFIER_TOKEN:
-		if this.isModuleVarDeclStart(1) || nextToken.IsMissing() {
-			return this.parseModuleVarDecl(tree.CreateEmptyNode())
+		if b.isModuleVarDeclStart(1) || nextToken.IsMissing() {
+			return b.parseModuleVarDecl(tree.CreateEmptyNode())
 		}
 		fallthrough
 	default:
-		if isTypeStartingToken(nextToken.Kind(), this.getNextNextToken()) && (nextToken.Kind() != common.IDENTIFIER_TOKEN) {
+		if isTypeStartingToken(nextToken.Kind(), b.getNextNextToken()) && (nextToken.Kind() != common.IDENTIFIER_TOKEN) {
 			metadata = tree.CreateEmptyNode()
 			break
 		}
-		token := this.peek()
-		solution := this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_TOP_LEVEL_NODE)
+		token := b.peek()
+		solution := b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_TOP_LEVEL_NODE)
 		if solution.Action == ACTION_KEEP {
 			metadata = tree.CreateEmptyNode()
 			break
 		}
-		return this.parseTopLevelNode()
+		return b.parseTopLevelNode()
 	}
-	return this.parseTopLevelNodeWithMetadata(metadata)
+	return b.parseTopLevelNodeWithMetadata(metadata)
 }
 
-func (this *BallerinaParser) parseTopLevelNodeWithMetadata(metadata tree.STNode) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseTopLevelNodeWithMetadata(metadata tree.STNode) tree.STNode {
+	nextToken := b.peek()
 	var publicQualifier tree.STNode
 	switch nextToken.Kind() {
 	case common.EOF_TOKEN:
@@ -902,12 +902,12 @@ func (this *BallerinaParser) parseTopLevelNodeWithMetadata(metadata tree.STNode)
 			if !ok {
 				panic("metadata is not a STMetadataNode")
 			}
-			metadata = this.addMetadataNotAttachedDiagnostic(*metadaNode)
-			return this.createMissingSimpleVarDeclInner(metadata, true)
+			metadata = b.addMetadataNotAttachedDiagnostic(*metadaNode)
+			return b.createMissingSimpleVarDeclInner(metadata, true)
 		}
 		return nil
 	case common.PUBLIC_KEYWORD:
-		publicQualifier = this.consume()
+		publicQualifier = b.consume()
 	case common.FUNCTION_KEYWORD,
 		common.TYPE_KEYWORD,
 		common.LISTENER_KEYWORD,
@@ -927,29 +927,29 @@ func (this *BallerinaParser) parseTopLevelNodeWithMetadata(metadata tree.STNode)
 		common.CONFIGURABLE_KEYWORD:
 		break
 	case common.RESOURCE_KEYWORD, common.REMOTE_KEYWORD:
-		this.reportInvalidQualifier(this.consume())
-		return this.parseTopLevelNodeWithMetadata(metadata)
+		b.reportInvalidQualifier(b.consume())
+		return b.parseTopLevelNodeWithMetadata(metadata)
 	case common.IDENTIFIER_TOKEN:
-		if this.isModuleVarDeclStart(1) {
-			return this.parseModuleVarDecl(metadata)
+		if b.isModuleVarDeclStart(1) {
+			return b.parseModuleVarDecl(metadata)
 		}
 		fallthrough
 	default:
-		if this.isTypeStartingToken(nextToken.Kind()) && (nextToken.Kind() != common.IDENTIFIER_TOKEN) {
+		if b.isTypeStartingToken(nextToken.Kind()) && (nextToken.Kind() != common.IDENTIFIER_TOKEN) {
 			break
 		}
-		token := this.peek()
-		solution := this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_TOP_LEVEL_NODE_WITHOUT_METADATA)
+		token := b.peek()
+		solution := b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_TOP_LEVEL_NODE_WITHOUT_METADATA)
 		if solution.Action == ACTION_KEEP {
 			publicQualifier = tree.CreateEmptyNode()
 			break
 		}
-		return this.parseTopLevelNodeWithMetadata(metadata)
+		return b.parseTopLevelNodeWithMetadata(metadata)
 	}
-	return this.parseTopLevelNodeWithQualifiers(metadata, publicQualifier)
+	return b.parseTopLevelNodeWithQualifiers(metadata, publicQualifier)
 }
 
-func (this *BallerinaParser) addMetadataNotAttachedDiagnostic(metadata tree.STMetadataNode) tree.STNode {
+func (b *BallerinaParser) addMetadataNotAttachedDiagnostic(metadata tree.STMetadataNode) tree.STNode {
 	docString := metadata.DocumentationString
 	if docString != nil {
 		docString = tree.AddDiagnostic(docString, &common.ERROR_DOCUMENTATION_NOT_ATTACHED_TO_A_CONSTRUCT)
@@ -958,17 +958,17 @@ func (this *BallerinaParser) addMetadataNotAttachedDiagnostic(metadata tree.STMe
 	if !ok {
 		panic("annotations is not a STNodeList")
 	}
-	annotations := this.addAnnotNotAttachedDiagnostic(annotList)
+	annotations := b.addAnnotNotAttachedDiagnostic(annotList)
 	return tree.CreateMetadataNode(docString, annotations)
 }
 
-func (this *BallerinaParser) addAnnotNotAttachedDiagnostic(annotList *tree.STNodeList) tree.STNode {
+func (b *BallerinaParser) addAnnotNotAttachedDiagnostic(annotList *tree.STNodeList) tree.STNode {
 	annotations := tree.UpdateAllNodesInNodeListWithDiagnostic(annotList, &common.ERROR_ANNOTATION_NOT_ATTACHED_TO_A_CONSTRUCT)
 	return annotations
 }
 
-func (this *BallerinaParser) isModuleVarDeclStart(lookahead int) bool {
-	nextToken := this.peekN(lookahead + 1)
+func (b *BallerinaParser) isModuleVarDeclStart(lookahead int) bool {
+	nextToken := b.peekN(lookahead + 1)
 	switch nextToken.Kind() {
 	case common.EQUAL_TOKEN, // Scenario: foo = . Even though this is not valid, consider this as a var-decl and
 		// continue;
@@ -981,7 +981,7 @@ func (this *BallerinaParser) isModuleVarDeclStart(lookahead int) bool {
 		common.EOF_TOKEN:
 		return true
 	case common.IDENTIFIER_TOKEN:
-		switch this.peekN(lookahead + 2).Kind() {
+		switch b.peekN(lookahead + 2).Kind() {
 		case common.EQUAL_TOKEN,
 			// Scenario: foo bar =
 			common.SEMICOLON_TOKEN,
@@ -995,9 +995,9 @@ func (this *BallerinaParser) isModuleVarDeclStart(lookahead int) bool {
 		if lookahead > 1 {
 			return false
 		}
-		switch this.peekN(lookahead + 2).Kind() {
+		switch b.peekN(lookahead + 2).Kind() {
 		case common.IDENTIFIER_TOKEN:
-			return this.isModuleVarDeclStart(lookahead + 2)
+			return b.isModuleVarDeclStart(lookahead + 2)
 		case common.EOF_TOKEN:
 			return true
 		default:
@@ -1008,123 +1008,123 @@ func (this *BallerinaParser) isModuleVarDeclStart(lookahead int) bool {
 	}
 }
 
-func (this *BallerinaParser) parseImportDecl() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_IMPORT_DECL)
-	this.tokenReader.StartMode(PARSER_MODE_IMPORT_MODE)
-	importKeyword := this.parseImportKeyword()
-	identifier := this.parseIdentifier(common.PARSER_RULE_CONTEXT_IMPORT_ORG_OR_MODULE_NAME)
-	importDecl := this.parseImportDeclWithIdentifier(importKeyword, identifier)
-	this.tokenReader.EndMode()
-	this.endContext()
+func (b *BallerinaParser) parseImportDecl() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_IMPORT_DECL)
+	b.tokenReader.StartMode(PARSER_MODE_IMPORT_MODE)
+	importKeyword := b.parseImportKeyword()
+	identifier := b.parseIdentifier(common.PARSER_RULE_CONTEXT_IMPORT_ORG_OR_MODULE_NAME)
+	importDecl := b.parseImportDeclWithIdentifier(importKeyword, identifier)
+	b.tokenReader.EndMode()
+	b.endContext()
 	return importDecl
 }
 
-func (this *BallerinaParser) parseImportKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseImportKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.IMPORT_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_IMPORT_KEYWORD)
-		return this.parseImportKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_IMPORT_KEYWORD)
+		return b.parseImportKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseIdentifier(currentCtx common.ParserRuleContext) tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseIdentifier(currentCtx common.ParserRuleContext) tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.IDENTIFIER_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else if token.Kind() == common.MAP_KEYWORD {
-		mapKeyword := this.consume()
+		mapKeyword := b.consume()
 		return tree.CreateIdentifierTokenWithDiagnostics(mapKeyword.Text(), mapKeyword.LeadingMinutiae(), mapKeyword.TrailingMinutiae(),
 			mapKeyword.Diagnostics())
 	} else {
-		this.recoverWithBlockContext(token, currentCtx)
-		return this.parseIdentifier(currentCtx)
+		b.recoverWithBlockContext(token, currentCtx)
+		return b.parseIdentifier(currentCtx)
 	}
 }
 
-func (this *BallerinaParser) parseImportDeclWithIdentifier(importKeyword tree.STNode, identifier tree.STNode) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseImportDeclWithIdentifier(importKeyword tree.STNode, identifier tree.STNode) tree.STNode {
+	nextToken := b.peek()
 	var orgName tree.STNode
 	var moduleName tree.STNode
 	var alias tree.STNode
 	switch nextToken.Kind() {
 	case common.SLASH_TOKEN:
-		slash := this.parseSlashToken()
+		slash := b.parseSlashToken()
 		orgName = tree.CreateImportOrgNameNode(identifier, slash)
-		moduleName = this.parseModuleName()
-		alias = this.parseImportPrefixDecl()
+		moduleName = b.parseModuleName()
+		alias = b.parseImportPrefixDecl()
 	case common.DOT_TOKEN, common.AS_KEYWORD:
 		orgName = tree.CreateEmptyNode()
-		moduleName = this.parseModuleNameInner(identifier)
-		alias = this.parseImportPrefixDecl()
+		moduleName = b.parseModuleNameInner(identifier)
+		alias = b.parseImportPrefixDecl()
 	case common.SEMICOLON_TOKEN:
 		orgName = tree.CreateEmptyNode()
-		moduleName = this.parseModuleNameInner(identifier)
+		moduleName = b.parseModuleNameInner(identifier)
 		alias = tree.CreateEmptyNode()
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_IMPORT_DECL_ORG_OR_MODULE_NAME_RHS)
-		return this.parseImportDeclWithIdentifier(importKeyword, identifier)
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_IMPORT_DECL_ORG_OR_MODULE_NAME_RHS)
+		return b.parseImportDeclWithIdentifier(importKeyword, identifier)
 	}
-	semicolon := this.parseSemicolon()
+	semicolon := b.parseSemicolon()
 	return tree.CreateImportDeclarationNode(importKeyword, orgName, moduleName, alias, semicolon)
 }
 
-func (this *BallerinaParser) parseSlashToken() tree.STToken {
-	token := this.peek()
+func (b *BallerinaParser) parseSlashToken() tree.STToken {
+	token := b.peek()
 	if token.Kind() == common.SLASH_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_SLASH)
-		return this.parseSlashToken()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_SLASH)
+		return b.parseSlashToken()
 	}
 }
 
-func (this *BallerinaParser) parseDotToken() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseDotToken() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.DOT_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_DOT)
-		return this.parseDotToken()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_DOT)
+		return b.parseDotToken()
 	}
 }
 
-func (this *BallerinaParser) parseModuleName() tree.STNode {
-	moduleNameStart := this.parseIdentifier(common.PARSER_RULE_CONTEXT_IMPORT_MODULE_NAME)
-	return this.parseModuleNameInner(moduleNameStart)
+func (b *BallerinaParser) parseModuleName() tree.STNode {
+	moduleNameStart := b.parseIdentifier(common.PARSER_RULE_CONTEXT_IMPORT_MODULE_NAME)
+	return b.parseModuleNameInner(moduleNameStart)
 }
 
-func (this *BallerinaParser) parseModuleNameInner(moduleNameStart tree.STNode) tree.STNode {
+func (b *BallerinaParser) parseModuleNameInner(moduleNameStart tree.STNode) tree.STNode {
 	var moduleNameParts []tree.STNode
 	moduleNameParts = append(moduleNameParts, moduleNameStart)
-	nextToken := this.peek()
-	for !this.isEndOfImportDecl(nextToken) {
-		moduleNameSeparator := this.parseModuleNameRhs()
+	nextToken := b.peek()
+	for !b.isEndOfImportDecl(nextToken) {
+		moduleNameSeparator := b.parseModuleNameRhs()
 		if moduleNameSeparator == nil {
 			break
 		}
 
 		moduleNameParts = append(moduleNameParts, moduleNameSeparator)
-		moduleNameParts = append(moduleNameParts, this.parseIdentifier(common.PARSER_RULE_CONTEXT_IMPORT_MODULE_NAME))
-		nextToken = this.peek()
+		moduleNameParts = append(moduleNameParts, b.parseIdentifier(common.PARSER_RULE_CONTEXT_IMPORT_MODULE_NAME))
+		nextToken = b.peek()
 	}
 	return tree.CreateNodeList(moduleNameParts...)
 }
 
-func (this *BallerinaParser) parseModuleNameRhs() tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseModuleNameRhs() tree.STNode {
+	switch b.peek().Kind() {
 	case common.DOT_TOKEN:
-		return this.consume()
+		return b.consume()
 	case common.AS_KEYWORD, common.SEMICOLON_TOKEN:
 		return nil
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_AFTER_IMPORT_MODULE_NAME)
-		return this.parseModuleNameRhs()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_AFTER_IMPORT_MODULE_NAME)
+		return b.parseModuleNameRhs()
 	}
 }
 
-func (this *BallerinaParser) isEndOfImportDecl(nextToken tree.STToken) bool {
+func (b *BallerinaParser) isEndOfImportDecl(nextToken tree.STToken) bool {
 	switch nextToken.Kind() {
 	case common.SEMICOLON_TOKEN,
 		common.PUBLIC_KEYWORD,
@@ -1144,148 +1144,148 @@ func (this *BallerinaParser) isEndOfImportDecl(nextToken tree.STToken) bool {
 	}
 }
 
-func (this *BallerinaParser) parseDecimalIntLiteral(context common.ParserRuleContext) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseDecimalIntLiteral(context common.ParserRuleContext) tree.STNode {
+	nextToken := b.peek()
 	if nextToken.Kind() == common.DECIMAL_INTEGER_LITERAL_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(this.peek(), context)
-		return this.parseDecimalIntLiteral(context)
+		b.recoverWithBlockContext(b.peek(), context)
+		return b.parseDecimalIntLiteral(context)
 	}
 }
 
-func (this *BallerinaParser) parseImportPrefixDecl() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseImportPrefixDecl() tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.AS_KEYWORD:
-		asKeyword := this.parseAsKeyword()
-		prefix := this.parseImportPrefix()
+		asKeyword := b.parseAsKeyword()
+		prefix := b.parseImportPrefix()
 		return tree.CreateImportPrefixNode(asKeyword, prefix)
 	case common.SEMICOLON_TOKEN:
 		return tree.CreateEmptyNode()
 	default:
-		if this.isEndOfImportDecl(nextToken) {
+		if b.isEndOfImportDecl(nextToken) {
 			return tree.CreateEmptyNode()
 		}
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_IMPORT_PREFIX_DECL)
-		return this.parseImportPrefixDecl()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_IMPORT_PREFIX_DECL)
+		return b.parseImportPrefixDecl()
 	}
 }
 
-func (this *BallerinaParser) parseAsKeyword() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseAsKeyword() tree.STNode {
+	nextToken := b.peek()
 	if nextToken.Kind() == common.AS_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_AS_KEYWORD)
-		return this.parseAsKeyword()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_AS_KEYWORD)
+		return b.parseAsKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseImportPrefix() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseImportPrefix() tree.STNode {
+	nextToken := b.peek()
 	if nextToken.Kind() == common.IDENTIFIER_TOKEN {
-		identifier := this.consume()
-		if this.isUnderscoreToken(identifier) {
-			return this.getUnderscoreKeyword(identifier)
+		identifier := b.consume()
+		if b.isUnderscoreToken(identifier) {
+			return b.getUnderscoreKeyword(identifier)
 		}
 		return identifier
 	} else if isPredeclaredPrefix(nextToken.Kind()) {
-		preDeclaredPrefix := this.consume()
+		preDeclaredPrefix := b.consume()
 		return tree.CreateIdentifierToken(preDeclaredPrefix.Text(), preDeclaredPrefix.LeadingMinutiae(),
 			preDeclaredPrefix.TrailingMinutiae())
 	} else {
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_IMPORT_PREFIX)
-		return this.parseImportPrefix()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_IMPORT_PREFIX)
+		return b.parseImportPrefix()
 	}
 }
 
-func (this *BallerinaParser) parseTopLevelNodeWithQualifiers(metadata, publicQualifier tree.STNode) tree.STNode {
-	res, _ := this.parseTopLevelNodeInner(metadata, publicQualifier, nil)
+func (b *BallerinaParser) parseTopLevelNodeWithQualifiers(metadata, publicQualifier tree.STNode) tree.STNode {
+	res, _ := b.parseTopLevelNodeInner(metadata, publicQualifier, nil)
 	return res
 }
 
-func (this *BallerinaParser) parseTopLevelNodeInner(metadata, publicQualifier tree.STNode, qualifiers []tree.STNode) (tree.STNode, []tree.STNode) {
-	qualifiers = this.parseTopLevelQualifiers(qualifiers)
-	nextToken := this.peek()
+func (b *BallerinaParser) parseTopLevelNodeInner(metadata, publicQualifier tree.STNode, qualifiers []tree.STNode) (tree.STNode, []tree.STNode) {
+	qualifiers = b.parseTopLevelQualifiers(qualifiers)
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.EOF_TOKEN:
-		return this.createMissingSimpleVarDeclInnerWithQualifiers(metadata, publicQualifier, qualifiers, true), qualifiers
+		return b.createMissingSimpleVarDeclInnerWithQualifiers(metadata, publicQualifier, qualifiers, true), qualifiers
 	case common.FUNCTION_KEYWORD:
-		return this.parseFuncDefOrFuncTypeDesc(metadata, publicQualifier, qualifiers, false, false), qualifiers
+		return b.parseFuncDefOrFuncTypeDesc(metadata, publicQualifier, qualifiers, false, false), qualifiers
 	case common.TYPE_KEYWORD:
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseModuleTypeDefinition(metadata, publicQualifier), qualifiers
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseModuleTypeDefinition(metadata, publicQualifier), qualifiers
 	case common.CLASS_KEYWORD:
-		return this.parseClassDefinition(metadata, publicQualifier, qualifiers), qualifiers
+		return b.parseClassDefinition(metadata, publicQualifier, qualifiers), qualifiers
 	case common.LISTENER_KEYWORD:
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseListenerDeclaration(metadata, publicQualifier), qualifiers
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseListenerDeclaration(metadata, publicQualifier), qualifiers
 	case common.CONST_KEYWORD:
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseConstantDeclaration(metadata, publicQualifier), qualifiers
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseConstantDeclaration(metadata, publicQualifier), qualifiers
 	case common.ANNOTATION_KEYWORD:
-		this.reportInvalidQualifierList(qualifiers)
+		b.reportInvalidQualifierList(qualifiers)
 		constKeyword := tree.CreateEmptyNode()
-		return this.parseAnnotationDeclaration(metadata, publicQualifier, constKeyword), qualifiers
+		return b.parseAnnotationDeclaration(metadata, publicQualifier, constKeyword), qualifiers
 	case common.IMPORT_KEYWORD:
-		this.reportInvalidMetaData(metadata, "import declaration")
-		this.reportInvalidQualifier(publicQualifier)
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseImportDecl(), qualifiers
+		b.reportInvalidMetaData(metadata, "import declaration")
+		b.reportInvalidQualifier(publicQualifier)
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseImportDecl(), qualifiers
 	case common.XMLNS_KEYWORD:
-		this.reportInvalidMetaData(metadata, "XML namespace declaration")
-		this.reportInvalidQualifier(publicQualifier)
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseXMLNamespaceDeclaration(true), qualifiers
+		b.reportInvalidMetaData(metadata, "XML namespace declaration")
+		b.reportInvalidQualifier(publicQualifier)
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseXMLNamespaceDeclaration(true), qualifiers
 	case common.ENUM_KEYWORD:
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseEnumDeclaration(metadata, publicQualifier), qualifiers
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseEnumDeclaration(metadata, publicQualifier), qualifiers
 	case common.RESOURCE_KEYWORD, common.REMOTE_KEYWORD:
-		this.reportInvalidQualifier(this.consume())
-		return this.parseTopLevelNodeInner(metadata, publicQualifier, qualifiers)
+		b.reportInvalidQualifier(b.consume())
+		return b.parseTopLevelNodeInner(metadata, publicQualifier, qualifiers)
 	case common.IDENTIFIER_TOKEN:
-		if this.isModuleVarDeclStart(1) {
-			return this.parseModuleVarDeclInner(metadata, publicQualifier, qualifiers)
+		if b.isModuleVarDeclStart(1) {
+			return b.parseModuleVarDeclInner(metadata, publicQualifier, qualifiers)
 		}
 		fallthrough
 	default:
-		if this.isPossibleServiceDecl(qualifiers) {
-			return this.parseServiceDeclOrVarDecl(metadata, publicQualifier, qualifiers), qualifiers
+		if b.isPossibleServiceDecl(qualifiers) {
+			return b.parseServiceDeclOrVarDecl(metadata, publicQualifier, qualifiers), qualifiers
 		}
-		if this.isTypeStartingToken(nextToken.Kind()) && (nextToken.Kind() != common.IDENTIFIER_TOKEN) {
-			return this.parseModuleVarDeclInner(metadata, publicQualifier, qualifiers)
+		if b.isTypeStartingToken(nextToken.Kind()) && (nextToken.Kind() != common.IDENTIFIER_TOKEN) {
+			return b.parseModuleVarDeclInner(metadata, publicQualifier, qualifiers)
 		}
-		token := this.peek()
-		solution := this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_TOP_LEVEL_NODE_WITHOUT_MODIFIER)
+		token := b.peek()
+		solution := b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_TOP_LEVEL_NODE_WITHOUT_MODIFIER)
 		if solution.Action == ACTION_KEEP {
-			return this.parseModuleVarDeclInner(metadata, publicQualifier, qualifiers)
+			return b.parseModuleVarDeclInner(metadata, publicQualifier, qualifiers)
 		}
-		return this.parseTopLevelNodeInner(metadata, publicQualifier, qualifiers)
+		return b.parseTopLevelNodeInner(metadata, publicQualifier, qualifiers)
 	}
 }
 
-func (this *BallerinaParser) parseModuleVarDecl(metadata tree.STNode) tree.STNode {
+func (b *BallerinaParser) parseModuleVarDecl(metadata tree.STNode) tree.STNode {
 	var emptyList []tree.STNode
 	publicQualifier := tree.CreateEmptyNode()
-	res, _ := this.parseVariableDeclInner(metadata, publicQualifier, emptyList, emptyList, true)
+	res, _ := b.parseVariableDeclInner(metadata, publicQualifier, emptyList, emptyList, true)
 	return res
 }
 
-func (this *BallerinaParser) parseModuleVarDeclInner(metadata tree.STNode, publicQualifier tree.STNode, topLevelQualifiers []tree.STNode) (tree.STNode, []tree.STNode) {
-	varDeclQuals, topLevelQualifiers := this.extractVarDeclQualifiers(topLevelQualifiers, true)
-	res, _ := this.parseVariableDeclInner(metadata, publicQualifier, varDeclQuals, topLevelQualifiers, true)
+func (b *BallerinaParser) parseModuleVarDeclInner(metadata tree.STNode, publicQualifier tree.STNode, topLevelQualifiers []tree.STNode) (tree.STNode, []tree.STNode) {
+	varDeclQuals, topLevelQualifiers := b.extractVarDeclQualifiers(topLevelQualifiers, true)
+	res, _ := b.parseVariableDeclInner(metadata, publicQualifier, varDeclQuals, topLevelQualifiers, true)
 	return res, topLevelQualifiers
 }
 
-func (this *BallerinaParser) extractVarDeclQualifiers(qualifiers []tree.STNode, isModuleVar bool) ([]tree.STNode, []tree.STNode) {
+func (b *BallerinaParser) extractVarDeclQualifiers(qualifiers []tree.STNode, isModuleVar bool) ([]tree.STNode, []tree.STNode) {
 	var varDeclQualList []tree.STNode
 	initialListSize := len(qualifiers)
 	configurableQualIndex := (-1)
 	i := 0
 	for ; (i < 2) && (i < initialListSize); i++ {
 		qualifierKind := qualifiers[0].Kind()
-		if (!this.isSyntaxKindInList(varDeclQualList, qualifierKind)) && this.isModuleVarDeclQualifier(qualifierKind) {
+		if (!b.isSyntaxKindInList(varDeclQualList, qualifierKind)) && b.isModuleVarDeclQualifier(qualifierKind) {
 			varDeclQualList = append(varDeclQualList, qualifiers[0])
 			qualifiers = qualifiers[1:]
 			if qualifierKind == common.CONFIGURABLE_KEYWORD {
@@ -1302,11 +1302,11 @@ func (this *BallerinaParser) extractVarDeclQualifiers(qualifiers []tree.STNode, 
 			if i < configurableQualIndex {
 				invalidQual := tree.ToToken(varDeclQualList[i])
 				configurableQual = tree.CloneWithLeadingInvalidNodeMinutiae(configurableQual, invalidQual,
-					this.getInvalidQualifierError(invalidQual.Kind()), (invalidQual).Text())
+					b.getInvalidQualifierError(invalidQual.Kind()), (invalidQual).Text())
 			} else if i > configurableQualIndex {
 				invalidQual := tree.ToToken(varDeclQualList[i])
 				configurableQual = tree.CloneWithTrailingInvalidNodeMinutiae(configurableQual, invalidQual,
-					this.getInvalidQualifierError(invalidQual.Kind()), (invalidQual).Text())
+					b.getInvalidQualifierError(invalidQual.Kind()), (invalidQual).Text())
 			}
 		}
 		varDeclQualList = []tree.STNode{configurableQual}
@@ -1314,14 +1314,14 @@ func (this *BallerinaParser) extractVarDeclQualifiers(qualifiers []tree.STNode, 
 	return varDeclQualList, qualifiers
 }
 
-func (this *BallerinaParser) getInvalidQualifierError(qualifierKind common.SyntaxKind) *common.DiagnosticErrorCode {
+func (b *BallerinaParser) getInvalidQualifierError(qualifierKind common.SyntaxKind) *common.DiagnosticErrorCode {
 	if qualifierKind == common.FINAL_KEYWORD {
 		return &common.ERROR_CONFIGURABLE_VAR_IMPLICITLY_FINAL
 	}
 	return &common.ERROR_QUALIFIER_NOT_ALLOWED
 }
 
-func (this *BallerinaParser) isModuleVarDeclQualifier(tokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isModuleVarDeclQualifier(tokenKind common.SyntaxKind) bool {
 	switch tokenKind {
 	case common.FINAL_KEYWORD, common.ISOLATED_KEYWORD, common.CONFIGURABLE_KEYWORD:
 		return true
@@ -1330,54 +1330,54 @@ func (this *BallerinaParser) isModuleVarDeclQualifier(tokenKind common.SyntaxKin
 	}
 }
 
-func (this *BallerinaParser) reportInvalidQualifier(qualifier tree.STNode) {
+func (b *BallerinaParser) reportInvalidQualifier(qualifier tree.STNode) {
 	if (qualifier != nil) && (qualifier.Kind() != common.NONE) {
-		this.addInvalidNodeToNextToken(qualifier, &common.ERROR_INVALID_QUALIFIER,
+		b.addInvalidNodeToNextToken(qualifier, &common.ERROR_INVALID_QUALIFIER,
 			tree.ToToken(qualifier).Text())
 	}
 }
 
-func (this *BallerinaParser) reportInvalidMetaData(metadata tree.STNode, constructName string) {
+func (b *BallerinaParser) reportInvalidMetaData(metadata tree.STNode, constructName string) {
 	if (metadata != nil) && (metadata.Kind() != common.NONE) {
-		this.addInvalidNodeToNextToken(metadata, &common.ERROR_INVALID_METADATA, constructName)
+		b.addInvalidNodeToNextToken(metadata, &common.ERROR_INVALID_METADATA, constructName)
 	}
 }
 
-func (this *BallerinaParser) reportInvalidQualifierList(qualifiers []tree.STNode) {
+func (b *BallerinaParser) reportInvalidQualifierList(qualifiers []tree.STNode) {
 	for _, qual := range qualifiers {
-		this.addInvalidNodeToNextToken(qual, &common.ERROR_QUALIFIER_NOT_ALLOWED, tree.ToToken(qual).Text())
+		b.addInvalidNodeToNextToken(qual, &common.ERROR_QUALIFIER_NOT_ALLOWED, tree.ToToken(qual).Text())
 	}
 }
 
-func (this *BallerinaParser) reportInvalidStatementAnnots(annots tree.STNode, qualifiers []tree.STNode) {
+func (b *BallerinaParser) reportInvalidStatementAnnots(annots tree.STNode, qualifiers []tree.STNode) {
 	diagnosticErrorCode := common.ERROR_ANNOTATIONS_ATTACHED_TO_STATEMENT
-	this.reportInvalidAnnotations(annots, qualifiers, diagnosticErrorCode)
+	b.reportInvalidAnnotations(annots, qualifiers, diagnosticErrorCode)
 }
 
-func (this *BallerinaParser) reportInvalidExpressionAnnots(annots tree.STNode, qualifiers []tree.STNode) {
+func (b *BallerinaParser) reportInvalidExpressionAnnots(annots tree.STNode, qualifiers []tree.STNode) {
 	diagnosticErrorCode := common.ERROR_ANNOTATIONS_ATTACHED_TO_EXPRESSION
-	this.reportInvalidAnnotations(annots, qualifiers, diagnosticErrorCode)
+	b.reportInvalidAnnotations(annots, qualifiers, diagnosticErrorCode)
 }
 
-func (this *BallerinaParser) reportInvalidAnnotations(annots tree.STNode, qualifiers []tree.STNode, errorCode common.DiagnosticErrorCode) {
-	if this.isNodeListEmpty(annots) {
+func (b *BallerinaParser) reportInvalidAnnotations(annots tree.STNode, qualifiers []tree.STNode, errorCode common.DiagnosticErrorCode) {
+	if b.isNodeListEmpty(annots) {
 		return
 	}
 	if len(qualifiers) == 0 {
-		this.addInvalidNodeToNextToken(annots, &errorCode)
+		b.addInvalidNodeToNextToken(annots, &errorCode)
 	} else {
-		this.updateFirstNodeInListWithLeadingInvalidNode(qualifiers, annots, &errorCode)
+		b.updateFirstNodeInListWithLeadingInvalidNode(qualifiers, annots, &errorCode)
 	}
 }
 
-func (this *BallerinaParser) isTopLevelQualifier(tokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isTopLevelQualifier(tokenKind common.SyntaxKind) bool {
 	var nextNextToken tree.STToken
 	switch tokenKind {
 	case common.FINAL_KEYWORD, // final-qualifier
 		common.CONFIGURABLE_KEYWORD:
 		return true
 	case common.READONLY_KEYWORD:
-		nextNextToken = this.getNextNextToken()
+		nextNextToken = b.getNextNextToken()
 		switch nextNextToken.Kind() {
 		case common.CLIENT_KEYWORD,
 			common.SERVICE_KEYWORD,
@@ -1389,7 +1389,7 @@ func (this *BallerinaParser) isTopLevelQualifier(tokenKind common.SyntaxKind) bo
 			return false
 		}
 	case common.DISTINCT_KEYWORD:
-		nextNextToken = this.getNextNextToken()
+		nextNextToken = b.getNextNextToken()
 		switch nextNextToken.Kind() {
 		case common.CLIENT_KEYWORD,
 			common.SERVICE_KEYWORD,
@@ -1401,11 +1401,11 @@ func (this *BallerinaParser) isTopLevelQualifier(tokenKind common.SyntaxKind) bo
 			return false
 		}
 	default:
-		return this.isTypeDescQualifier(tokenKind)
+		return b.isTypeDescQualifier(tokenKind)
 	}
 }
 
-func (this *BallerinaParser) isTypeDescQualifier(tokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isTypeDescQualifier(tokenKind common.SyntaxKind) bool {
 	switch tokenKind {
 	case common.TRANSACTIONAL_KEYWORD, // func-type-dec, func-def
 		common.ISOLATED_KEYWORD, // func-type-dec, object-type-desc, func-def, class-def, isolated-final-qual
@@ -1418,21 +1418,21 @@ func (this *BallerinaParser) isTypeDescQualifier(tokenKind common.SyntaxKind) bo
 	}
 }
 
-func (this *BallerinaParser) isObjectMemberQualifier(tokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isObjectMemberQualifier(tokenKind common.SyntaxKind) bool {
 	switch tokenKind {
 	case common.REMOTE_KEYWORD, // method-def, method-decl
 		common.RESOURCE_KEYWORD, // resource-method-def
 		common.FINAL_KEYWORD:
 		return true
 	default:
-		return this.isTypeDescQualifier(tokenKind)
+		return b.isTypeDescQualifier(tokenKind)
 	}
 }
 
-func (this *BallerinaParser) isExprQualifier(tokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isExprQualifier(tokenKind common.SyntaxKind) bool {
 	switch tokenKind {
 	case common.TRANSACTIONAL_KEYWORD:
-		nextNextToken := this.getNextNextToken()
+		nextNextToken := b.getNextNextToken()
 		switch nextNextToken.Kind() {
 		case common.CLIENT_KEYWORD,
 			common.ABSTRACT_KEYWORD,
@@ -1444,146 +1444,146 @@ func (this *BallerinaParser) isExprQualifier(tokenKind common.SyntaxKind) bool {
 			return false
 		}
 	default:
-		return this.isTypeDescQualifier(tokenKind)
+		return b.isTypeDescQualifier(tokenKind)
 	}
 }
 
-func (this *BallerinaParser) parseTopLevelQualifiers(qualifiers []tree.STNode) []tree.STNode {
-	for this.isTopLevelQualifier(this.peek().Kind()) {
-		qualifier := this.consume()
+func (b *BallerinaParser) parseTopLevelQualifiers(qualifiers []tree.STNode) []tree.STNode {
+	for b.isTopLevelQualifier(b.peek().Kind()) {
+		qualifier := b.consume()
 		qualifiers = append(qualifiers, qualifier)
 	}
 	return qualifiers
 }
 
-func (this *BallerinaParser) parseTypeDescQualifiers(qualifiers []tree.STNode) []tree.STNode {
-	for this.isTypeDescQualifier(this.peek().Kind()) {
-		qualifier := this.consume()
+func (b *BallerinaParser) parseTypeDescQualifiers(qualifiers []tree.STNode) []tree.STNode {
+	for b.isTypeDescQualifier(b.peek().Kind()) {
+		qualifier := b.consume()
 		qualifiers = append(qualifiers, qualifier)
 	}
 	return qualifiers
 }
 
-func (this *BallerinaParser) parseObjectMemberQualifiers(qualifiers []tree.STNode) []tree.STNode {
-	for this.isObjectMemberQualifier(this.peek().Kind()) {
-		qualifier := this.consume()
+func (b *BallerinaParser) parseObjectMemberQualifiers(qualifiers []tree.STNode) []tree.STNode {
+	for b.isObjectMemberQualifier(b.peek().Kind()) {
+		qualifier := b.consume()
 		qualifiers = append(qualifiers, qualifier)
 	}
 	return qualifiers
 }
 
-func (this *BallerinaParser) parseExprQualifiers(qualifiers []tree.STNode) []tree.STNode {
-	for this.isExprQualifier(this.peek().Kind()) {
-		qualifier := this.consume()
+func (b *BallerinaParser) parseExprQualifiers(qualifiers []tree.STNode) []tree.STNode {
+	for b.isExprQualifier(b.peek().Kind()) {
+		qualifier := b.consume()
 		qualifiers = append(qualifiers, qualifier)
 	}
 	return qualifiers
 }
 
-func (this *BallerinaParser) parseOptionalRelativePath(isObjectMember bool) tree.STNode {
+func (b *BallerinaParser) parseOptionalRelativePath(isObjectMember bool) tree.STNode {
 	var resourcePath tree.STNode
-	nextToken := this.peek()
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.DOT_TOKEN, common.IDENTIFIER_TOKEN, common.OPEN_BRACKET_TOKEN:
-		resourcePath = this.parseRelativeResourcePath()
+		resourcePath = b.parseRelativeResourcePath()
 	case common.OPEN_PAREN_TOKEN:
 		return tree.CreateEmptyNodeList()
 	default:
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_OPTIONAL_RELATIVE_PATH)
-		return this.parseOptionalRelativePath(isObjectMember)
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_OPTIONAL_RELATIVE_PATH)
+		return b.parseOptionalRelativePath(isObjectMember)
 	}
 	if !isObjectMember {
-		this.addInvalidNodeToNextToken(resourcePath, &common.ERROR_RESOURCE_PATH_IN_FUNCTION_DEFINITION)
+		b.addInvalidNodeToNextToken(resourcePath, &common.ERROR_RESOURCE_PATH_IN_FUNCTION_DEFINITION)
 		return tree.CreateEmptyNodeList()
 	}
 	return resourcePath
 }
 
-func (this *BallerinaParser) parseFuncDefOrFuncTypeDesc(metadata tree.STNode, visibilityQualifier tree.STNode, qualifiers []tree.STNode, isObjectMember bool, isObjectTypeDesc bool) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_FUNC_DEF_OR_FUNC_TYPE)
-	functionKeyword := this.parseFunctionKeyword()
-	funcDefOrType := this.parseFunctionKeywordRhs(metadata, visibilityQualifier, qualifiers, functionKeyword,
+func (b *BallerinaParser) parseFuncDefOrFuncTypeDesc(metadata tree.STNode, visibilityQualifier tree.STNode, qualifiers []tree.STNode, isObjectMember bool, isObjectTypeDesc bool) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_FUNC_DEF_OR_FUNC_TYPE)
+	functionKeyword := b.parseFunctionKeyword()
+	funcDefOrType := b.parseFunctionKeywordRhs(metadata, visibilityQualifier, qualifiers, functionKeyword,
 		isObjectMember, isObjectTypeDesc)
 	return funcDefOrType
 }
 
-func (this *BallerinaParser) parseFunctionDefinition(metadata tree.STNode, visibilityQualifier tree.STNode, resourcePath tree.STNode, qualifiers []tree.STNode, functionKeyword tree.STNode, name tree.STNode, isObjectMember bool, isObjectTypeDesc bool) tree.STNode {
-	this.switchContext(common.PARSER_RULE_CONTEXT_FUNC_DEF)
-	funcSignature := this.parseFuncSignature(false)
-	funcDef := this.parseFuncDefOrMethodDeclEnd(metadata, visibilityQualifier, qualifiers, functionKeyword, name,
+func (b *BallerinaParser) parseFunctionDefinition(metadata tree.STNode, visibilityQualifier tree.STNode, resourcePath tree.STNode, qualifiers []tree.STNode, functionKeyword tree.STNode, name tree.STNode, isObjectMember bool, isObjectTypeDesc bool) tree.STNode {
+	b.switchContext(common.PARSER_RULE_CONTEXT_FUNC_DEF)
+	funcSignature := b.parseFuncSignature(false)
+	funcDef := b.parseFuncDefOrMethodDeclEnd(metadata, visibilityQualifier, qualifiers, functionKeyword, name,
 		resourcePath, funcSignature, isObjectMember, isObjectTypeDesc)
-	this.endContext()
+	b.endContext()
 	return funcDef
 }
 
-func (this *BallerinaParser) parseFuncDefOrFuncTypeDescRhs(metadata tree.STNode, visibilityQualifier tree.STNode, qualifiers []tree.STNode, functionKeyword tree.STNode, name tree.STNode, isObjectMember bool, isObjectTypeDesc bool) tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseFuncDefOrFuncTypeDescRhs(metadata tree.STNode, visibilityQualifier tree.STNode, qualifiers []tree.STNode, functionKeyword tree.STNode, name tree.STNode, isObjectMember bool, isObjectTypeDesc bool) tree.STNode {
+	switch b.peek().Kind() {
 	case common.OPEN_PAREN_TOKEN,
 		common.DOT_TOKEN,
 		common.IDENTIFIER_TOKEN,
 		common.OPEN_BRACKET_TOKEN:
-		resourcePath := this.parseOptionalRelativePath(isObjectMember)
-		return this.parseFunctionDefinition(metadata, visibilityQualifier, resourcePath, qualifiers, functionKeyword,
+		resourcePath := b.parseOptionalRelativePath(isObjectMember)
+		return b.parseFunctionDefinition(metadata, visibilityQualifier, resourcePath, qualifiers, functionKeyword,
 			name, isObjectMember, isObjectTypeDesc)
 	case common.EQUAL_TOKEN,
 		common.SEMICOLON_TOKEN:
-		this.endContext()
-		extractQualifiersList, qualifiers := this.extractVarDeclOrObjectFieldQualifiers(qualifiers, isObjectMember,
+		b.endContext()
+		extractQualifiersList, qualifiers := b.extractVarDeclOrObjectFieldQualifiers(qualifiers, isObjectMember,
 			isObjectTypeDesc)
-		typeDesc := this.createFunctionTypeDescriptor(qualifiers, functionKeyword,
+		typeDesc := b.createFunctionTypeDescriptor(qualifiers, functionKeyword,
 			tree.CreateEmptyNode(), false)
 		if isObjectMember {
 			objectFieldQualNodeList := tree.CreateNodeList(extractQualifiersList...)
-			return this.parseObjectFieldRhs(metadata, visibilityQualifier, objectFieldQualNodeList, typeDesc, name,
+			return b.parseObjectFieldRhs(metadata, visibilityQualifier, objectFieldQualNodeList, typeDesc, name,
 				isObjectTypeDesc)
 		}
-		this.startContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+		b.startContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
 		funcTypeName := tree.CreateSimpleNameReferenceNode(name)
 		refNode, ok := funcTypeName.(*tree.STSimpleNameReferenceNode)
 		if !ok {
 			panic("expected STSimpleNameReferenceNode")
 		}
-		bindingPattern := this.createCaptureOrWildcardBP(refNode.Name)
+		bindingPattern := b.createCaptureOrWildcardBP(refNode.Name)
 		typedBindingPattern := tree.CreateTypedBindingPatternNode(typeDesc, bindingPattern)
-		res, _ := this.parseVarDeclRhsInner(metadata, visibilityQualifier, extractQualifiersList, typedBindingPattern, true)
+		res, _ := b.parseVarDeclRhsInner(metadata, visibilityQualifier, extractQualifiersList, typedBindingPattern, true)
 		return res
 	default:
-		token := this.peek()
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_FUNC_DEF_OR_TYPE_DESC_RHS)
-		return this.parseFuncDefOrFuncTypeDescRhs(metadata, visibilityQualifier, qualifiers, functionKeyword, name,
+		token := b.peek()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_FUNC_DEF_OR_TYPE_DESC_RHS)
+		return b.parseFuncDefOrFuncTypeDescRhs(metadata, visibilityQualifier, qualifiers, functionKeyword, name,
 			isObjectMember, isObjectTypeDesc)
 	}
 }
 
-func (this *BallerinaParser) parseFunctionKeywordRhs(metadata tree.STNode, visibilityQualifier tree.STNode, qualifiers []tree.STNode, functionKeyword tree.STNode, isObjectMember bool, isObjectTypeDesc bool) tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseFunctionKeywordRhs(metadata tree.STNode, visibilityQualifier tree.STNode, qualifiers []tree.STNode, functionKeyword tree.STNode, isObjectMember bool, isObjectTypeDesc bool) tree.STNode {
+	switch b.peek().Kind() {
 	case common.IDENTIFIER_TOKEN:
-		name := this.consume()
-		return this.parseFuncDefOrFuncTypeDescRhs(metadata, visibilityQualifier, qualifiers, functionKeyword, name,
+		name := b.consume()
+		return b.parseFuncDefOrFuncTypeDescRhs(metadata, visibilityQualifier, qualifiers, functionKeyword, name,
 			isObjectMember, isObjectTypeDesc)
 	case common.OPEN_PAREN_TOKEN:
-		this.switchContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
-		this.startContext(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN)
-		this.startContext(common.PARSER_RULE_CONTEXT_FUNC_TYPE_DESC)
-		funcSignature := this.parseFuncSignature(true)
-		this.endContext()
-		this.endContext()
-		return this.parseFunctionTypeDescRhs(metadata, visibilityQualifier, qualifiers, functionKeyword,
+		b.switchContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+		b.startContext(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN)
+		b.startContext(common.PARSER_RULE_CONTEXT_FUNC_TYPE_DESC)
+		funcSignature := b.parseFuncSignature(true)
+		b.endContext()
+		b.endContext()
+		return b.parseFunctionTypeDescRhs(metadata, visibilityQualifier, qualifiers, functionKeyword,
 			funcSignature, isObjectMember, isObjectTypeDesc)
 	default:
-		token := this.peek()
-		if this.isValidTypeContinuationToken(token) || this.isBindingPatternsStartToken(token.Kind()) {
-			return this.parseVarDeclWithFunctionType(metadata, visibilityQualifier, qualifiers, functionKeyword,
+		token := b.peek()
+		if b.isValidTypeContinuationToken(token) || b.isBindingPatternsStartToken(token.Kind()) {
+			return b.parseVarDeclWithFunctionType(metadata, visibilityQualifier, qualifiers, functionKeyword,
 				tree.CreateEmptyNode(), isObjectMember,
 				isObjectTypeDesc, false)
 		}
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_FUNCTION_KEYWORD_RHS)
-		return this.parseFunctionKeywordRhs(metadata, visibilityQualifier, qualifiers, functionKeyword,
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_FUNCTION_KEYWORD_RHS)
+		return b.parseFunctionKeywordRhs(metadata, visibilityQualifier, qualifiers, functionKeyword,
 			isObjectMember, isObjectTypeDesc)
 	}
 }
 
-func (this *BallerinaParser) isBindingPatternsStartToken(tokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isBindingPatternsStartToken(tokenKind common.SyntaxKind) bool {
 	switch tokenKind {
 	case common.IDENTIFIER_TOKEN,
 		common.OPEN_BRACKET_TOKEN,
@@ -1595,13 +1595,13 @@ func (this *BallerinaParser) isBindingPatternsStartToken(tokenKind common.Syntax
 	}
 }
 
-func (this *BallerinaParser) parseFuncDefOrMethodDeclEnd(metadata tree.STNode, visibilityQualifier tree.STNode, qualifierList []tree.STNode, functionKeyword tree.STNode, name tree.STNode, resourcePath tree.STNode, funcSignature tree.STNode, isObjectMember bool, isObjectTypeDesc bool) tree.STNode {
+func (b *BallerinaParser) parseFuncDefOrMethodDeclEnd(metadata tree.STNode, visibilityQualifier tree.STNode, qualifierList []tree.STNode, functionKeyword tree.STNode, name tree.STNode, resourcePath tree.STNode, funcSignature tree.STNode, isObjectMember bool, isObjectTypeDesc bool) tree.STNode {
 	if !isObjectMember {
-		return this.createFunctionDefinition(metadata, visibilityQualifier, qualifierList, functionKeyword, name,
+		return b.createFunctionDefinition(metadata, visibilityQualifier, qualifierList, functionKeyword, name,
 			funcSignature)
 	}
-	hasResourcePath := (!this.isNodeListEmpty(resourcePath))
-	hasResourceQual := this.isSyntaxKindInList(qualifierList, common.RESOURCE_KEYWORD)
+	hasResourcePath := (!b.isNodeListEmpty(resourcePath))
+	hasResourceQual := b.isSyntaxKindInList(qualifierList, common.RESOURCE_KEYWORD)
 	if hasResourceQual && (!hasResourcePath) {
 		var relativePath []tree.STNode
 		relativePath = append(relativePath, tree.CreateMissingToken(common.DOT_TOKEN, nil))
@@ -1616,30 +1616,30 @@ func (this *BallerinaParser) parseFuncDefOrMethodDeclEnd(metadata tree.STNode, v
 		hasResourcePath = true
 	}
 	if hasResourcePath {
-		return this.createResourceAccessorDefnOrDecl(metadata, visibilityQualifier, qualifierList, functionKeyword, name,
+		return b.createResourceAccessorDefnOrDecl(metadata, visibilityQualifier, qualifierList, functionKeyword, name,
 			resourcePath, funcSignature, isObjectTypeDesc)
 	}
 	if isObjectTypeDesc {
-		return this.createMethodDeclaration(metadata, visibilityQualifier, qualifierList, functionKeyword, name,
+		return b.createMethodDeclaration(metadata, visibilityQualifier, qualifierList, functionKeyword, name,
 			funcSignature)
 	} else {
-		return this.createMethodDefinition(metadata, visibilityQualifier, qualifierList, functionKeyword, name,
+		return b.createMethodDefinition(metadata, visibilityQualifier, qualifierList, functionKeyword, name,
 			funcSignature)
 	}
 }
 
-func (this *BallerinaParser) createFunctionDefinition(metadata tree.STNode, visibilityQualifier tree.STNode, qualifierList []tree.STNode, functionKeyword tree.STNode, name tree.STNode, funcSignature tree.STNode) tree.STNode {
+func (b *BallerinaParser) createFunctionDefinition(metadata tree.STNode, visibilityQualifier tree.STNode, qualifierList []tree.STNode, functionKeyword tree.STNode, name tree.STNode, funcSignature tree.STNode) tree.STNode {
 	var validatedList []tree.STNode
 	i := 0
 	for ; i < len(qualifierList); i++ {
 		qualifier := qualifierList[i]
 		nextIndex := (i + 1)
-		if this.isSyntaxKindInList(validatedList, qualifier.Kind()) {
-			this.updateLastNodeInListWithInvalidNode(validatedList, qualifier,
+		if b.isSyntaxKindInList(validatedList, qualifier.Kind()) {
+			b.updateLastNodeInListWithInvalidNode(validatedList, qualifier,
 				&common.ERROR_DUPLICATE_QUALIFIER, tree.ToToken(qualifier).Text())
 			continue
 		}
-		if this.isRegularFuncQual(qualifier.Kind()) {
+		if b.isRegularFuncQual(qualifier.Kind()) {
 			validatedList = append(validatedList, qualifier)
 			continue
 		}
@@ -1647,7 +1647,7 @@ func (this *BallerinaParser) createFunctionDefinition(metadata tree.STNode, visi
 			functionKeyword = tree.CloneWithLeadingInvalidNodeMinutiae(functionKeyword, qualifier,
 				&common.ERROR_QUALIFIER_NOT_ALLOWED, tree.ToToken(qualifier).Text())
 		} else {
-			this.updateANodeInListWithLeadingInvalidNode(qualifierList, nextIndex, qualifier,
+			b.updateANodeInListWithLeadingInvalidNode(qualifierList, nextIndex, qualifier,
 				&common.ERROR_QUALIFIER_NOT_ALLOWED, tree.ToToken(qualifier).Text())
 		}
 	}
@@ -1656,20 +1656,20 @@ func (this *BallerinaParser) createFunctionDefinition(metadata tree.STNode, visi
 	}
 	qualifiers := tree.CreateNodeList(validatedList...)
 	resourcePath := tree.CreateEmptyNodeList()
-	body := this.parseFunctionBody()
+	body := b.parseFunctionBody()
 	return tree.CreateFunctionDefinitionNode(common.FUNCTION_DEFINITION, metadata, qualifiers,
 		functionKeyword, name, resourcePath, funcSignature, body)
 }
 
-func (this *BallerinaParser) createMethodDefinition(metadata tree.STNode, visibilityQualifier tree.STNode, qualifierList []tree.STNode, functionKeyword tree.STNode, name tree.STNode, funcSignature tree.STNode) tree.STNode {
+func (b *BallerinaParser) createMethodDefinition(metadata tree.STNode, visibilityQualifier tree.STNode, qualifierList []tree.STNode, functionKeyword tree.STNode, name tree.STNode, funcSignature tree.STNode) tree.STNode {
 	var validatedList []tree.STNode
 	hasRemoteQual := false
 	i := 0
 	for ; i < len(qualifierList); i++ {
 		qualifier := qualifierList[i]
 		nextIndex := (i + 1)
-		if this.isSyntaxKindInList(validatedList, qualifier.Kind()) {
-			this.updateLastNodeInListWithInvalidNode(validatedList, qualifier,
+		if b.isSyntaxKindInList(validatedList, qualifier.Kind()) {
+			b.updateLastNodeInListWithInvalidNode(validatedList, qualifier,
 				&common.ERROR_DUPLICATE_QUALIFIER, tree.ToToken(qualifier).Text())
 			continue
 		}
@@ -1678,7 +1678,7 @@ func (this *BallerinaParser) createMethodDefinition(metadata tree.STNode, visibi
 			validatedList = append(validatedList, qualifier)
 			continue
 		}
-		if this.isRegularFuncQual(qualifier.Kind()) {
+		if b.isRegularFuncQual(qualifier.Kind()) {
 			validatedList = append(validatedList, qualifier)
 			continue
 		}
@@ -1686,13 +1686,13 @@ func (this *BallerinaParser) createMethodDefinition(metadata tree.STNode, visibi
 			functionKeyword = tree.CloneWithLeadingInvalidNodeMinutiae(functionKeyword, qualifier,
 				&common.ERROR_QUALIFIER_NOT_ALLOWED, tree.ToToken(qualifier).Text())
 		} else {
-			this.updateANodeInListWithLeadingInvalidNode(qualifierList, nextIndex, qualifier,
+			b.updateANodeInListWithLeadingInvalidNode(qualifierList, nextIndex, qualifier,
 				&common.ERROR_QUALIFIER_NOT_ALLOWED, tree.ToToken(qualifier).Text())
 		}
 	}
 	if visibilityQualifier != nil {
 		if hasRemoteQual {
-			this.updateFirstNodeInListWithLeadingInvalidNode(validatedList, visibilityQualifier,
+			b.updateFirstNodeInListWithLeadingInvalidNode(validatedList, visibilityQualifier,
 				&common.ERROR_REMOTE_METHOD_HAS_A_VISIBILITY_QUALIFIER)
 		} else {
 			validatedList = append([]tree.STNode{visibilityQualifier}, validatedList...)
@@ -1700,20 +1700,20 @@ func (this *BallerinaParser) createMethodDefinition(metadata tree.STNode, visibi
 	}
 	qualifiers := tree.CreateNodeList(validatedList...)
 	resourcePath := tree.CreateEmptyNodeList()
-	body := this.parseFunctionBody()
+	body := b.parseFunctionBody()
 	return tree.CreateFunctionDefinitionNode(common.OBJECT_METHOD_DEFINITION, metadata, qualifiers,
 		functionKeyword, name, resourcePath, funcSignature, body)
 }
 
-func (this *BallerinaParser) createMethodDeclaration(metadata tree.STNode, visibilityQualifier tree.STNode, qualifierList []tree.STNode, functionKeyword tree.STNode, name tree.STNode, funcSignature tree.STNode) tree.STNode {
+func (b *BallerinaParser) createMethodDeclaration(metadata tree.STNode, visibilityQualifier tree.STNode, qualifierList []tree.STNode, functionKeyword tree.STNode, name tree.STNode, funcSignature tree.STNode) tree.STNode {
 	var validatedList []tree.STNode
 	hasRemoteQual := false
 	i := 0
 	for ; i < len(qualifierList); i++ {
 		qualifier := qualifierList[i]
 		nextIndex := (i + 1)
-		if this.isSyntaxKindInList(validatedList, qualifier.Kind()) {
-			this.updateLastNodeInListWithInvalidNode(validatedList, qualifier,
+		if b.isSyntaxKindInList(validatedList, qualifier.Kind()) {
+			b.updateLastNodeInListWithInvalidNode(validatedList, qualifier,
 				&common.ERROR_DUPLICATE_QUALIFIER, tree.ToToken(qualifier).Text())
 			continue
 		}
@@ -1722,7 +1722,7 @@ func (this *BallerinaParser) createMethodDeclaration(metadata tree.STNode, visib
 			validatedList = append(validatedList, qualifier)
 			continue
 		}
-		if this.isRegularFuncQual(qualifier.Kind()) {
+		if b.isRegularFuncQual(qualifier.Kind()) {
 			validatedList = append(validatedList, qualifier)
 			continue
 		}
@@ -1730,13 +1730,13 @@ func (this *BallerinaParser) createMethodDeclaration(metadata tree.STNode, visib
 			functionKeyword = tree.CloneWithLeadingInvalidNodeMinutiae(functionKeyword, qualifier,
 				&common.ERROR_QUALIFIER_NOT_ALLOWED, tree.ToToken(qualifier).Text())
 		} else {
-			this.updateANodeInListWithLeadingInvalidNode(qualifierList, nextIndex, qualifier,
+			b.updateANodeInListWithLeadingInvalidNode(qualifierList, nextIndex, qualifier,
 				&common.ERROR_QUALIFIER_NOT_ALLOWED, tree.ToToken(qualifier).Text())
 		}
 	}
 	if visibilityQualifier != nil {
 		if hasRemoteQual {
-			this.updateFirstNodeInListWithLeadingInvalidNode(validatedList, visibilityQualifier,
+			b.updateFirstNodeInListWithLeadingInvalidNode(validatedList, visibilityQualifier,
 				&common.ERROR_REMOTE_METHOD_HAS_A_VISIBILITY_QUALIFIER)
 		} else {
 			validatedList = append([]tree.STNode{visibilityQualifier}, validatedList...)
@@ -1744,20 +1744,20 @@ func (this *BallerinaParser) createMethodDeclaration(metadata tree.STNode, visib
 	}
 	qualifiers := tree.CreateNodeList(validatedList...)
 	resourcePath := tree.CreateEmptyNodeList()
-	semicolon := this.parseSemicolon()
+	semicolon := b.parseSemicolon()
 	return tree.CreateMethodDeclarationNode(common.METHOD_DECLARATION, metadata, qualifiers,
 		functionKeyword, name, resourcePath, funcSignature, semicolon)
 }
 
-func (this *BallerinaParser) createResourceAccessorDefnOrDecl(metadata tree.STNode, visibilityQualifier tree.STNode, qualifierList []tree.STNode, functionKeyword tree.STNode, name tree.STNode, resourcePath tree.STNode, funcSignature tree.STNode, isObjectTypeDesc bool) tree.STNode {
+func (b *BallerinaParser) createResourceAccessorDefnOrDecl(metadata tree.STNode, visibilityQualifier tree.STNode, qualifierList []tree.STNode, functionKeyword tree.STNode, name tree.STNode, resourcePath tree.STNode, funcSignature tree.STNode, isObjectTypeDesc bool) tree.STNode {
 	var validatedList []tree.STNode
 	hasResourceQual := false
 	i := 0
 	for ; i < len(qualifierList); i++ {
 		qualifier := qualifierList[i]
 		nextIndex := (i + 1)
-		if this.isSyntaxKindInList(validatedList, qualifier.Kind()) {
-			this.updateLastNodeInListWithInvalidNode(validatedList, qualifier,
+		if b.isSyntaxKindInList(validatedList, qualifier.Kind()) {
+			b.updateLastNodeInListWithInvalidNode(validatedList, qualifier,
 				&common.ERROR_DUPLICATE_QUALIFIER, tree.ToToken(qualifier).Text())
 			continue
 		}
@@ -1766,7 +1766,7 @@ func (this *BallerinaParser) createResourceAccessorDefnOrDecl(metadata tree.STNo
 			validatedList = append(validatedList, qualifier)
 			continue
 		}
-		if this.isRegularFuncQual(qualifier.Kind()) {
+		if b.isRegularFuncQual(qualifier.Kind()) {
 			validatedList = append(validatedList, qualifier)
 			continue
 		}
@@ -1774,7 +1774,7 @@ func (this *BallerinaParser) createResourceAccessorDefnOrDecl(metadata tree.STNo
 			functionKeyword = tree.CloneWithLeadingInvalidNodeMinutiae(functionKeyword, qualifier,
 				&common.ERROR_QUALIFIER_NOT_ALLOWED, tree.ToToken(qualifier).Text())
 		} else {
-			this.updateANodeInListWithLeadingInvalidNode(qualifierList, nextIndex, qualifier,
+			b.updateANodeInListWithLeadingInvalidNode(qualifierList, nextIndex, qualifier,
 				&common.ERROR_QUALIFIER_NOT_ALLOWED, tree.ToToken(qualifier).Text())
 		}
 	}
@@ -1783,90 +1783,90 @@ func (this *BallerinaParser) createResourceAccessorDefnOrDecl(metadata tree.STNo
 		functionKeyword = tree.AddDiagnostic(functionKeyword, &common.ERROR_MISSING_RESOURCE_KEYWORD)
 	}
 	if visibilityQualifier != nil {
-		this.updateFirstNodeInListWithLeadingInvalidNode(validatedList, visibilityQualifier,
+		b.updateFirstNodeInListWithLeadingInvalidNode(validatedList, visibilityQualifier,
 			&common.ERROR_QUALIFIER_NOT_ALLOWED, tree.ToToken(visibilityQualifier).Text())
 	}
 	qualifiers := tree.CreateNodeList(validatedList...)
 	if isObjectTypeDesc {
-		semicolon := this.parseSemicolon()
+		semicolon := b.parseSemicolon()
 		return tree.CreateMethodDeclarationNode(common.RESOURCE_ACCESSOR_DECLARATION, metadata,
 			qualifiers, functionKeyword, name, resourcePath, funcSignature, semicolon)
 	} else {
-		body := this.parseFunctionBody()
+		body := b.parseFunctionBody()
 		return tree.CreateFunctionDefinitionNode(common.RESOURCE_ACCESSOR_DEFINITION, metadata,
 			qualifiers, functionKeyword, name, resourcePath, funcSignature, body)
 	}
 }
 
-func (this *BallerinaParser) parseFuncSignature(isParamNameOptional bool) tree.STNode {
-	openParenthesis := this.parseOpenParenthesis()
-	parameters := this.parseParamList(isParamNameOptional)
-	closeParenthesis := this.parseCloseParenthesis()
-	this.endContext()
-	returnTypeDesc := this.parseFuncReturnTypeDescriptor(isParamNameOptional)
+func (b *BallerinaParser) parseFuncSignature(isParamNameOptional bool) tree.STNode {
+	openParenthesis := b.parseOpenParenthesis()
+	parameters := b.parseParamList(isParamNameOptional)
+	closeParenthesis := b.parseCloseParenthesis()
+	b.endContext()
+	returnTypeDesc := b.parseFuncReturnTypeDescriptor(isParamNameOptional)
 	return tree.CreateFunctionSignatureNode(openParenthesis, parameters, closeParenthesis, returnTypeDesc)
 }
 
-func (this *BallerinaParser) parseFunctionTypeDescRhs(metadata tree.STNode, visibilityQualifier tree.STNode, qualifiers []tree.STNode, functionKeyword tree.STNode, funcSignature tree.STNode, isObjectMember bool, isObjectTypeDesc bool) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseFunctionTypeDescRhs(metadata tree.STNode, visibilityQualifier tree.STNode, qualifiers []tree.STNode, functionKeyword tree.STNode, funcSignature tree.STNode, isObjectMember bool, isObjectTypeDesc bool) tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.OPEN_BRACE_TOKEN, common.EQUAL_TOKEN:
 		break
 	case common.SEMICOLON_TOKEN, common.IDENTIFIER_TOKEN, common.OPEN_BRACKET_TOKEN:
 		fallthrough
 	default:
-		return this.parseVarDeclWithFunctionType(metadata, visibilityQualifier, qualifiers, functionKeyword,
+		return b.parseVarDeclWithFunctionType(metadata, visibilityQualifier, qualifiers, functionKeyword,
 			funcSignature, isObjectMember, isObjectTypeDesc, true)
 	}
-	this.switchContext(common.PARSER_RULE_CONTEXT_FUNC_DEF)
+	b.switchContext(common.PARSER_RULE_CONTEXT_FUNC_DEF)
 	name := tree.CreateMissingTokenWithDiagnostics(common.IDENTIFIER_TOKEN,
 		&common.ERROR_MISSING_FUNCTION_NAME)
 	fnSig, ok := funcSignature.(*tree.STFunctionSignatureNode)
 	if !ok {
 		panic("expected STFunctionSignatureNode")
 	}
-	funcSignature = this.validateAndGetFuncParams(*fnSig)
+	funcSignature = b.validateAndGetFuncParams(*fnSig)
 	resourcePath := tree.CreateEmptyNodeList()
-	funcDef := this.parseFuncDefOrMethodDeclEnd(metadata, visibilityQualifier, qualifiers, functionKeyword,
+	funcDef := b.parseFuncDefOrMethodDeclEnd(metadata, visibilityQualifier, qualifiers, functionKeyword,
 		name, resourcePath, funcSignature, isObjectMember, isObjectTypeDesc)
-	this.endContext()
+	b.endContext()
 	return funcDef
 }
 
-func (this *BallerinaParser) extractVarDeclOrObjectFieldQualifiers(qualifierList []tree.STNode, isObjectMember bool, isObjectTypeDesc bool) ([]tree.STNode, []tree.STNode) {
+func (b *BallerinaParser) extractVarDeclOrObjectFieldQualifiers(qualifierList []tree.STNode, isObjectMember bool, isObjectTypeDesc bool) ([]tree.STNode, []tree.STNode) {
 	if isObjectMember {
-		return this.extractObjectFieldQualifiers(qualifierList, isObjectTypeDesc)
+		return b.extractObjectFieldQualifiers(qualifierList, isObjectTypeDesc)
 	}
-	return this.extractVarDeclQualifiers(qualifierList, false)
+	return b.extractVarDeclQualifiers(qualifierList, false)
 }
 
-func (this *BallerinaParser) createFunctionTypeDescriptor(qualifierList []tree.STNode, functionKeyword tree.STNode, funcSignature tree.STNode, hasFuncSignature bool) tree.STNode {
-	nodes := this.createFuncTypeQualNodeList(qualifierList, functionKeyword, hasFuncSignature)
+func (b *BallerinaParser) createFunctionTypeDescriptor(qualifierList []tree.STNode, functionKeyword tree.STNode, funcSignature tree.STNode, hasFuncSignature bool) tree.STNode {
+	nodes := b.createFuncTypeQualNodeList(qualifierList, functionKeyword, hasFuncSignature)
 	qualifierNodeList := nodes[0]
 	functionKeyword = nodes[1]
 	return tree.CreateFunctionTypeDescriptorNode(qualifierNodeList, functionKeyword, funcSignature)
 }
 
-func (this *BallerinaParser) parseVarDeclWithFunctionType(metadata tree.STNode, visibilityQualifier tree.STNode, qualifierList []tree.STNode, functionKeyword tree.STNode, funcSignature tree.STNode, isObjectMember bool, isObjectTypeDesc bool, hasFuncSignature bool) tree.STNode {
-	this.switchContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
-	extractQualifiersList, qualifierList := this.extractVarDeclOrObjectFieldQualifiers(qualifierList, isObjectMember,
+func (b *BallerinaParser) parseVarDeclWithFunctionType(metadata tree.STNode, visibilityQualifier tree.STNode, qualifierList []tree.STNode, functionKeyword tree.STNode, funcSignature tree.STNode, isObjectMember bool, isObjectTypeDesc bool, hasFuncSignature bool) tree.STNode {
+	b.switchContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+	extractQualifiersList, qualifierList := b.extractVarDeclOrObjectFieldQualifiers(qualifierList, isObjectMember,
 		isObjectTypeDesc)
-	typeDesc := this.createFunctionTypeDescriptor(qualifierList, functionKeyword, funcSignature, hasFuncSignature)
-	typeDesc = this.parseComplexTypeDescriptor(typeDesc,
+	typeDesc := b.createFunctionTypeDescriptor(qualifierList, functionKeyword, funcSignature, hasFuncSignature)
+	typeDesc = b.parseComplexTypeDescriptor(typeDesc,
 		common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN, true)
 	if isObjectMember {
-		this.endContext()
+		b.endContext()
 		objectFieldQualNodeList := tree.CreateNodeList(extractQualifiersList...)
-		fieldName := this.parseVariableName()
-		return this.parseObjectFieldRhs(metadata, visibilityQualifier, objectFieldQualNodeList, typeDesc, fieldName,
+		fieldName := b.parseVariableName()
+		return b.parseObjectFieldRhs(metadata, visibilityQualifier, objectFieldQualNodeList, typeDesc, fieldName,
 			isObjectTypeDesc)
 	}
-	typedBindingPattern := this.parseTypedBindingPatternTypeRhs(typeDesc, common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
-	res, _ := this.parseVarDeclRhsInner(metadata, visibilityQualifier, extractQualifiersList, typedBindingPattern, true)
+	typedBindingPattern := b.parseTypedBindingPatternTypeRhs(typeDesc, common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+	res, _ := b.parseVarDeclRhsInner(metadata, visibilityQualifier, extractQualifiersList, typedBindingPattern, true)
 	return res
 }
 
-func (this *BallerinaParser) validateAndGetFuncParams(signature tree.STFunctionSignatureNode) tree.STNode {
+func (b *BallerinaParser) validateAndGetFuncParams(signature tree.STFunctionSignatureNode) tree.STNode {
 	parameters := signature.Parameters
 	paramCount := parameters.BucketCount()
 	index := 0
@@ -1878,7 +1878,7 @@ func (this *BallerinaParser) validateAndGetFuncParams(signature tree.STFunctionS
 			if !ok {
 				panic("expected STRequiredParameterNode")
 			}
-			if this.isEmpty(requiredParam.ParamName) {
+			if b.isEmpty(requiredParam.ParamName) {
 				break
 			}
 			continue
@@ -1887,7 +1887,7 @@ func (this *BallerinaParser) validateAndGetFuncParams(signature tree.STFunctionS
 			if !ok {
 				panic("expected STDefaultableParameterNode")
 			}
-			if this.isEmpty(defaultableParam.ParamName) {
+			if b.isEmpty(defaultableParam.ParamName) {
 				break
 			}
 			continue
@@ -1896,7 +1896,7 @@ func (this *BallerinaParser) validateAndGetFuncParams(signature tree.STFunctionS
 			if !ok {
 				panic("STRestParameterNode")
 			}
-			if this.isEmpty(restParam.ParamName) {
+			if b.isEmpty(restParam.ParamName) {
 				break
 			}
 			continue
@@ -1908,12 +1908,12 @@ func (this *BallerinaParser) validateAndGetFuncParams(signature tree.STFunctionS
 	if index == paramCount {
 		return &signature
 	}
-	updatedParams := this.getUpdatedParamList(parameters, index)
+	updatedParams := b.getUpdatedParamList(parameters, index)
 	return tree.CreateFunctionSignatureNode(signature.OpenParenToken, updatedParams,
 		signature.CloseParenToken, signature.ReturnTypeDesc)
 }
 
-func (this *BallerinaParser) getUpdatedParamList(parameters tree.STNode, index int) tree.STNode {
+func (b *BallerinaParser) getUpdatedParamList(parameters tree.STNode, index int) tree.STNode {
 	paramCount := parameters.BucketCount()
 	newIndex := 0
 	var newParams []tree.STNode
@@ -1929,7 +1929,7 @@ func (this *BallerinaParser) getUpdatedParamList(parameters tree.STNode, index i
 			if !ok {
 				panic("expected STRequiredParameterNode")
 			}
-			if this.isEmpty(requiredParam.ParamName) {
+			if b.isEmpty(requiredParam.ParamName) {
 				param = tree.CreateRequiredParameterNode(requiredParam.Annotations,
 					requiredParam.TypeName, paramName)
 			}
@@ -1938,7 +1938,7 @@ func (this *BallerinaParser) getUpdatedParamList(parameters tree.STNode, index i
 			if !ok {
 				panic("expected STDefaultableParameterNode")
 			}
-			if this.isEmpty(defaultableParam.ParamName) {
+			if b.isEmpty(defaultableParam.ParamName) {
 				param = tree.CreateDefaultableParameterNode(defaultableParam.Annotations, defaultableParam.TypeName,
 					paramName, defaultableParam.EqualsToken, defaultableParam.Expression)
 			}
@@ -1947,7 +1947,7 @@ func (this *BallerinaParser) getUpdatedParamList(parameters tree.STNode, index i
 			if !ok {
 				panic("expected STRestParameterNode")
 			}
-			if this.isEmpty(restParam.ParamName) {
+			if b.isEmpty(restParam.ParamName) {
 				param = tree.CreateRestParameterNode(restParam.Annotations, restParam.TypeName,
 					restParam.EllipsisToken, paramName)
 			}
@@ -1958,113 +1958,113 @@ func (this *BallerinaParser) getUpdatedParamList(parameters tree.STNode, index i
 	return tree.CreateNodeList(newParams...)
 }
 
-func (this *BallerinaParser) isEmpty(node tree.STNode) bool {
+func (b *BallerinaParser) isEmpty(node tree.STNode) bool {
 	return (!tree.IsSTNodePresent(node))
 }
 
-func (this *BallerinaParser) parseFunctionKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseFunctionKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.FUNCTION_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_FUNCTION_KEYWORD)
-		return this.parseFunctionKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_FUNCTION_KEYWORD)
+		return b.parseFunctionKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseFunctionName() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseFunctionName() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.IDENTIFIER_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_FUNC_NAME)
-		return this.parseFunctionName()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_FUNC_NAME)
+		return b.parseFunctionName()
 	}
 }
 
-func (this *BallerinaParser) parseArgListOpenParenthesis() tree.STNode {
-	return this.parseOpenParenthesisInner(common.PARSER_RULE_CONTEXT_ARG_LIST_OPEN_PAREN)
+func (b *BallerinaParser) parseArgListOpenParenthesis() tree.STNode {
+	return b.parseOpenParenthesisInner(common.PARSER_RULE_CONTEXT_ARG_LIST_OPEN_PAREN)
 }
 
-func (this *BallerinaParser) parseOpenParenthesis() tree.STNode {
-	return this.parseOpenParenthesisInner(common.PARSER_RULE_CONTEXT_OPEN_PARENTHESIS)
+func (b *BallerinaParser) parseOpenParenthesis() tree.STNode {
+	return b.parseOpenParenthesisInner(common.PARSER_RULE_CONTEXT_OPEN_PARENTHESIS)
 }
 
-func (this *BallerinaParser) parseOpenParenthesisInner(ctx common.ParserRuleContext) tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseOpenParenthesisInner(ctx common.ParserRuleContext) tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.OPEN_PAREN_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, ctx)
-		return this.parseOpenParenthesisInner(ctx)
+		b.recoverWithBlockContext(token, ctx)
+		return b.parseOpenParenthesisInner(ctx)
 	}
 }
 
-func (this *BallerinaParser) parseArgListCloseParenthesis() tree.STNode {
-	return this.parseCloseParenthesisInner(common.PARSER_RULE_CONTEXT_ARG_LIST_CLOSE_PAREN)
+func (b *BallerinaParser) parseArgListCloseParenthesis() tree.STNode {
+	return b.parseCloseParenthesisInner(common.PARSER_RULE_CONTEXT_ARG_LIST_CLOSE_PAREN)
 }
 
-func (this *BallerinaParser) parseCloseParenthesis() tree.STNode {
-	return this.parseCloseParenthesisInner(common.PARSER_RULE_CONTEXT_CLOSE_PARENTHESIS)
+func (b *BallerinaParser) parseCloseParenthesis() tree.STNode {
+	return b.parseCloseParenthesisInner(common.PARSER_RULE_CONTEXT_CLOSE_PARENTHESIS)
 }
 
-func (this *BallerinaParser) parseCloseParenthesisInner(ctx common.ParserRuleContext) tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseCloseParenthesisInner(ctx common.ParserRuleContext) tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.CLOSE_PAREN_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, ctx)
-		return this.parseCloseParenthesisInner(ctx)
+		b.recoverWithBlockContext(token, ctx)
+		return b.parseCloseParenthesisInner(ctx)
 	}
 }
 
-func (this *BallerinaParser) parseParamList(isParamNameOptional bool) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_PARAM_LIST)
-	token := this.peek()
-	if this.isEndOfParametersList(token.Kind()) {
+func (b *BallerinaParser) parseParamList(isParamNameOptional bool) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_PARAM_LIST)
+	token := b.peek()
+	if b.isEndOfParametersList(token.Kind()) {
 		return tree.CreateEmptyNodeList()
 	}
 	var paramsList []tree.STNode
-	this.startContext(common.PARSER_RULE_CONTEXT_REQUIRED_PARAM)
-	firstParam := this.parseParameterInner(common.REQUIRED_PARAM, isParamNameOptional)
+	b.startContext(common.PARSER_RULE_CONTEXT_REQUIRED_PARAM)
+	firstParam := b.parseParameterInner(common.REQUIRED_PARAM, isParamNameOptional)
 	prevParamKind := firstParam.Kind()
 	paramsList = append(paramsList, firstParam)
 	paramOrderErrorPresent := false
-	token = this.peek()
-	for !this.isEndOfParametersList(token.Kind()) {
-		paramEnd := this.parseParameterRhs()
+	token = b.peek()
+	for !b.isEndOfParametersList(token.Kind()) {
+		paramEnd := b.parseParameterRhs()
 		if paramEnd == nil {
 			break
 		}
-		this.endContext()
+		b.endContext()
 		if prevParamKind == common.DEFAULTABLE_PARAM {
-			this.startContext(common.PARSER_RULE_CONTEXT_DEFAULTABLE_PARAM)
+			b.startContext(common.PARSER_RULE_CONTEXT_DEFAULTABLE_PARAM)
 		} else {
-			this.startContext(common.PARSER_RULE_CONTEXT_REQUIRED_PARAM)
+			b.startContext(common.PARSER_RULE_CONTEXT_REQUIRED_PARAM)
 		}
-		param := this.parseParameterInner(prevParamKind, isParamNameOptional)
+		param := b.parseParameterInner(prevParamKind, isParamNameOptional)
 		if paramOrderErrorPresent {
-			this.updateLastNodeInListWithInvalidNode(paramsList, paramEnd, nil)
-			this.updateLastNodeInListWithInvalidNode(paramsList, param, nil)
+			b.updateLastNodeInListWithInvalidNode(paramsList, paramEnd, nil)
+			b.updateLastNodeInListWithInvalidNode(paramsList, param, nil)
 		} else {
-			paramOrderError := this.validateParamOrder(param, prevParamKind)
+			paramOrderError := b.validateParamOrder(param, prevParamKind)
 			if paramOrderError == nil {
 				paramsList = append(paramsList, paramEnd)
 				paramsList = append(paramsList, param)
 			} else {
 				paramOrderErrorPresent = true
-				this.updateLastNodeInListWithInvalidNode(paramsList, paramEnd, nil)
-				this.updateLastNodeInListWithInvalidNode(paramsList, param, paramOrderError)
+				b.updateLastNodeInListWithInvalidNode(paramsList, paramEnd, nil)
+				b.updateLastNodeInListWithInvalidNode(paramsList, param, paramOrderError)
 			}
 		}
 		prevParamKind = param.Kind()
-		token = this.peek()
+		token = b.peek()
 	}
-	this.endContext()
+	b.endContext()
 	return tree.CreateNodeList(paramsList...)
 }
 
-func (this *BallerinaParser) validateParamOrder(param tree.STNode, prevParamKind common.SyntaxKind) diagnostics.DiagnosticCode {
+func (b *BallerinaParser) validateParamOrder(param tree.STNode, prevParamKind common.SyntaxKind) diagnostics.DiagnosticCode {
 	if prevParamKind == common.REST_PARAM {
 		return &common.ERROR_PARAMETER_AFTER_THE_REST_PARAMETER
 	} else if (prevParamKind == common.DEFAULTABLE_PARAM) && (param.Kind() == common.REQUIRED_PARAM) {
@@ -2073,7 +2073,7 @@ func (this *BallerinaParser) validateParamOrder(param tree.STNode, prevParamKind
 	return nil
 }
 
-func (this *BallerinaParser) isSyntaxKindInList(nodeList []tree.STNode, kind common.SyntaxKind) bool {
+func (b *BallerinaParser) isSyntaxKindInList(nodeList []tree.STNode, kind common.SyntaxKind) bool {
 	for _, node := range nodeList {
 		if node.Kind() == kind {
 			return true
@@ -2082,7 +2082,7 @@ func (this *BallerinaParser) isSyntaxKindInList(nodeList []tree.STNode, kind com
 	return false
 }
 
-func (this *BallerinaParser) isPossibleServiceDecl(nodeList []tree.STNode) bool {
+func (b *BallerinaParser) isPossibleServiceDecl(nodeList []tree.STNode) bool {
 	if len(nodeList) == 0 {
 		return false
 	}
@@ -2097,121 +2097,121 @@ func (this *BallerinaParser) isPossibleServiceDecl(nodeList []tree.STNode) bool 
 	}
 }
 
-func (this *BallerinaParser) parseParameterRhs() tree.STNode {
-	return this.parseParameterRhsInner(this.peek().Kind())
+func (b *BallerinaParser) parseParameterRhs() tree.STNode {
+	return b.parseParameterRhsInner(b.peek().Kind())
 }
 
-func (this *BallerinaParser) parseParameterRhsInner(tokenKind common.SyntaxKind) tree.STNode {
+func (b *BallerinaParser) parseParameterRhsInner(tokenKind common.SyntaxKind) tree.STNode {
 	switch tokenKind {
 	case common.COMMA_TOKEN:
-		return this.consume()
+		return b.consume()
 	case common.CLOSE_PAREN_TOKEN:
 		return nil
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_PARAM_END)
-		return this.parseParameterRhs()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_PARAM_END)
+		return b.parseParameterRhs()
 	}
 }
 
-func (this *BallerinaParser) parseParameter(annots tree.STNode, prevParamKind common.SyntaxKind, isParamNameOptional bool) tree.STNode {
+func (b *BallerinaParser) parseParameter(annots tree.STNode, prevParamKind common.SyntaxKind, isParamNameOptional bool) tree.STNode {
 	var inclusionSymbol tree.STNode
-	nextToken := this.peek()
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.ASTERISK_TOKEN:
-		inclusionSymbol = this.consume()
+		inclusionSymbol = b.consume()
 	case common.IDENTIFIER_TOKEN:
 		inclusionSymbol = tree.CreateEmptyNode()
 	default:
-		if this.isTypeStartingToken(nextToken.Kind()) {
+		if b.isTypeStartingToken(nextToken.Kind()) {
 			inclusionSymbol = tree.CreateEmptyNode()
 			break
 		}
-		token := this.peek()
-		solution := this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_PARAMETER_START_WITHOUT_ANNOTATION)
+		token := b.peek()
+		solution := b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_PARAMETER_START_WITHOUT_ANNOTATION)
 		if solution.Action == ACTION_KEEP {
 			inclusionSymbol = tree.CreateEmptyNodeList()
 			break
 		}
-		return this.parseParameter(annots, prevParamKind, isParamNameOptional)
+		return b.parseParameter(annots, prevParamKind, isParamNameOptional)
 	}
-	ty := this.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_BEFORE_IDENTIFIER)
-	return this.parseAfterParamType(prevParamKind, annots, inclusionSymbol, ty, isParamNameOptional)
+	ty := b.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_BEFORE_IDENTIFIER)
+	return b.parseAfterParamType(prevParamKind, annots, inclusionSymbol, ty, isParamNameOptional)
 }
 
-func (this *BallerinaParser) parseParameterInner(prevParamKind common.SyntaxKind, isParamNameOptional bool) tree.STNode {
+func (b *BallerinaParser) parseParameterInner(prevParamKind common.SyntaxKind, isParamNameOptional bool) tree.STNode {
 	var annots tree.STNode
-	nextToken := this.peek()
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.AT_TOKEN:
-		annots = this.parseOptionalAnnotations()
+		annots = b.parseOptionalAnnotations()
 	case common.ASTERISK_TOKEN, common.IDENTIFIER_TOKEN:
 		annots = tree.CreateEmptyNodeList()
 	default:
-		if this.isTypeStartingToken(nextToken.Kind()) {
+		if b.isTypeStartingToken(nextToken.Kind()) {
 			annots = tree.CreateEmptyNodeList()
 			break
 		}
-		token := this.peek()
-		solution := this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_PARAMETER_START)
+		token := b.peek()
+		solution := b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_PARAMETER_START)
 		if solution.Action == ACTION_KEEP {
 			annots = tree.CreateEmptyNodeList()
 			break
 		}
-		return this.parseParameterInner(prevParamKind, isParamNameOptional)
+		return b.parseParameterInner(prevParamKind, isParamNameOptional)
 	}
-	return this.parseParameter(annots, prevParamKind, isParamNameOptional)
+	return b.parseParameter(annots, prevParamKind, isParamNameOptional)
 }
 
-func (this *BallerinaParser) parseAfterParamType(prevParamKind common.SyntaxKind, annots tree.STNode, inclusionSymbol tree.STNode, ty tree.STNode, isParamNameOptional bool) tree.STNode {
+func (b *BallerinaParser) parseAfterParamType(prevParamKind common.SyntaxKind, annots tree.STNode, inclusionSymbol tree.STNode, ty tree.STNode, isParamNameOptional bool) tree.STNode {
 	var paramName tree.STNode
-	token := this.peek()
+	token := b.peek()
 	switch token.Kind() {
 	case common.ELLIPSIS_TOKEN:
 		if inclusionSymbol != nil {
 			ty = tree.CloneWithLeadingInvalidNodeMinutiae(ty, inclusionSymbol,
 				&common.REST_PARAMETER_CANNOT_BE_INCLUDED_RECORD_PARAMETER)
 		}
-		this.switchContext(common.PARSER_RULE_CONTEXT_REST_PARAM)
-		ellipsis := this.parseEllipsis()
-		if isParamNameOptional && (this.peek().Kind() != common.IDENTIFIER_TOKEN) {
+		b.switchContext(common.PARSER_RULE_CONTEXT_REST_PARAM)
+		ellipsis := b.parseEllipsis()
+		if isParamNameOptional && (b.peek().Kind() != common.IDENTIFIER_TOKEN) {
 			paramName = tree.CreateEmptyNode()
 		} else {
-			paramName = this.parseVariableName()
+			paramName = b.parseVariableName()
 		}
 		return tree.CreateRestParameterNode(annots, ty, ellipsis, paramName)
 	case common.IDENTIFIER_TOKEN:
-		paramName = this.parseVariableName()
-		return this.parseParameterRhsWithAnnots(prevParamKind, annots, inclusionSymbol, ty, paramName)
+		paramName = b.parseVariableName()
+		return b.parseParameterRhsWithAnnots(prevParamKind, annots, inclusionSymbol, ty, paramName)
 	case common.EQUAL_TOKEN:
 		if !isParamNameOptional {
 			break
 		}
 		paramName = tree.CreateEmptyNode()
-		return this.parseParameterRhsWithAnnots(prevParamKind, annots, inclusionSymbol, ty, paramName)
+		return b.parseParameterRhsWithAnnots(prevParamKind, annots, inclusionSymbol, ty, paramName)
 	default:
 		if !isParamNameOptional {
 			break
 		}
 		paramName = tree.CreateEmptyNode()
-		return this.parseParameterRhsWithAnnots(prevParamKind, annots, inclusionSymbol, ty, paramName)
+		return b.parseParameterRhsWithAnnots(prevParamKind, annots, inclusionSymbol, ty, paramName)
 	}
-	this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_AFTER_PARAMETER_TYPE)
-	return this.parseAfterParamType(prevParamKind, annots, inclusionSymbol, ty, false)
+	b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_AFTER_PARAMETER_TYPE)
+	return b.parseAfterParamType(prevParamKind, annots, inclusionSymbol, ty, false)
 }
 
-func (this *BallerinaParser) parseEllipsis() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseEllipsis() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.ELLIPSIS_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_ELLIPSIS)
-		return this.parseEllipsis()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_ELLIPSIS)
+		return b.parseEllipsis()
 	}
 }
 
-func (this *BallerinaParser) parseParameterRhsWithAnnots(prevParamKind common.SyntaxKind, annots tree.STNode, inclusionSymbol tree.STNode, ty tree.STNode, paramName tree.STNode) tree.STNode {
-	nextToken := this.peek()
-	if this.isEndOfParameter(nextToken.Kind()) {
+func (b *BallerinaParser) parseParameterRhsWithAnnots(prevParamKind common.SyntaxKind, annots tree.STNode, inclusionSymbol tree.STNode, ty tree.STNode, paramName tree.STNode) tree.STNode {
+	nextToken := b.peek()
+	if b.isEndOfParameter(nextToken.Kind()) {
 		if inclusionSymbol != nil {
 			return tree.CreateIncludedRecordParameterNode(annots, inclusionSymbol, ty, paramName)
 		} else {
@@ -2219,33 +2219,33 @@ func (this *BallerinaParser) parseParameterRhsWithAnnots(prevParamKind common.Sy
 		}
 	} else if nextToken.Kind() == common.EQUAL_TOKEN {
 		if prevParamKind == common.REQUIRED_PARAM {
-			this.switchContext(common.PARSER_RULE_CONTEXT_DEFAULTABLE_PARAM)
+			b.switchContext(common.PARSER_RULE_CONTEXT_DEFAULTABLE_PARAM)
 		}
-		equal := this.parseAssignOp()
-		expr := this.parseInferredTypeDescDefaultOrExpression()
+		equal := b.parseAssignOp()
+		expr := b.parseInferredTypeDescDefaultOrExpression()
 		if inclusionSymbol != nil {
 			ty = tree.CloneWithLeadingInvalidNodeMinutiae(ty, inclusionSymbol,
 				&common.ERROR_DEFAULTABLE_PARAMETER_CANNOT_BE_INCLUDED_RECORD_PARAMETER)
 		}
 		return tree.CreateDefaultableParameterNode(annots, ty, paramName, equal, expr)
 	} else {
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_PARAMETER_NAME_RHS)
-		return this.parseParameterRhsWithAnnots(prevParamKind, annots, inclusionSymbol, ty, paramName)
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_PARAMETER_NAME_RHS)
+		return b.parseParameterRhsWithAnnots(prevParamKind, annots, inclusionSymbol, ty, paramName)
 	}
 }
 
-func (this *BallerinaParser) parseComma() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseComma() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.COMMA_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_COMMA)
-		return this.parseComma()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_COMMA)
+		return b.parseComma()
 	}
 }
 
-func (this *BallerinaParser) parseFuncReturnTypeDescriptor(isFuncTypeDesc bool) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseFuncReturnTypeDescriptor(isFuncTypeDesc bool) tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.OPEN_BRACE_TOKEN,
 		common.EQUAL_TOKEN:
@@ -2253,33 +2253,33 @@ func (this *BallerinaParser) parseFuncReturnTypeDescriptor(isFuncTypeDesc bool) 
 	case common.RETURNS_KEYWORD:
 		break
 	case common.IDENTIFIER_TOKEN:
-		if (!isFuncTypeDesc) || this.isSafeMissingReturnsParse() {
+		if (!isFuncTypeDesc) || b.isSafeMissingReturnsParse() {
 			break
 		}
 		fallthrough
 	default:
-		nextNextToken := this.getNextNextToken()
+		nextNextToken := b.getNextNextToken()
 		if nextNextToken.Kind() == common.RETURNS_KEYWORD {
 			break
 		}
 		return tree.CreateEmptyNode()
 	}
-	returnsKeyword := this.parseReturnsKeyword()
-	annot := this.parseOptionalAnnotations()
-	ty := this.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_RETURN_TYPE_DESC)
+	returnsKeyword := b.parseReturnsKeyword()
+	annot := b.parseOptionalAnnotations()
+	ty := b.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_RETURN_TYPE_DESC)
 	return tree.CreateReturnTypeDescriptorNode(returnsKeyword, annot, ty)
 }
 
-func (this *BallerinaParser) isSafeMissingReturnsParse() bool {
-	for _, context := range this.errorHandler.GetContextStack() {
-		if !this.isSafeMissingReturnsParseCtx(context) {
+func (b *BallerinaParser) isSafeMissingReturnsParse() bool {
+	for _, context := range b.errorHandler.GetContextStack() {
+		if !b.isSafeMissingReturnsParseCtx(context) {
 			return false
 		}
 	}
 	return true
 }
 
-func (this *BallerinaParser) isSafeMissingReturnsParseCtx(ctx common.ParserRuleContext) bool {
+func (b *BallerinaParser) isSafeMissingReturnsParseCtx(ctx common.ParserRuleContext) bool {
 	switch ctx {
 	case common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_ANNOTATION_DECL,
 		common.PARSER_RULE_CONTEXT_TYPE_DESC_BEFORE_IDENTIFIER,
@@ -2296,47 +2296,47 @@ func (this *BallerinaParser) isSafeMissingReturnsParseCtx(ctx common.ParserRuleC
 	}
 }
 
-func (this *BallerinaParser) parseReturnsKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseReturnsKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.RETURNS_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_RETURNS_KEYWORD)
-		return this.parseReturnsKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_RETURNS_KEYWORD)
+		return b.parseReturnsKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseTypeDescriptor(context common.ParserRuleContext) tree.STNode {
-	return this.parseTypeDescriptorWithinContext(nil, context, false, false, TYPE_PRECEDENCE_DEFAULT)
+func (b *BallerinaParser) parseTypeDescriptor(context common.ParserRuleContext) tree.STNode {
+	return b.parseTypeDescriptorWithinContext(nil, context, false, false, TYPE_PRECEDENCE_DEFAULT)
 }
 
-func (this *BallerinaParser) parseTypeDescriptorWithPrecedence(context common.ParserRuleContext, precedence TypePrecedence) tree.STNode {
-	return this.parseTypeDescriptorWithinContext(nil, context, false, false, precedence)
+func (b *BallerinaParser) parseTypeDescriptorWithPrecedence(context common.ParserRuleContext, precedence TypePrecedence) tree.STNode {
+	return b.parseTypeDescriptorWithinContext(nil, context, false, false, precedence)
 }
 
-func (this *BallerinaParser) parseTypeDescriptorWithQualifier(qualifiers []tree.STNode, context common.ParserRuleContext) tree.STNode {
-	return this.parseTypeDescriptorWithinContext(qualifiers, context, false, false, TYPE_PRECEDENCE_DEFAULT)
+func (b *BallerinaParser) parseTypeDescriptorWithQualifier(qualifiers []tree.STNode, context common.ParserRuleContext) tree.STNode {
+	return b.parseTypeDescriptorWithinContext(qualifiers, context, false, false, TYPE_PRECEDENCE_DEFAULT)
 }
 
-func (this *BallerinaParser) parseTypeDescriptorInExpression(isInConditionalExpr bool) tree.STNode {
-	return this.parseTypeDescriptorWithinContext(nil, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_EXPRESSION, false, isInConditionalExpr,
+func (b *BallerinaParser) parseTypeDescriptorInExpression(isInConditionalExpr bool) tree.STNode {
+	return b.parseTypeDescriptorWithinContext(nil, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_EXPRESSION, false, isInConditionalExpr,
 		TYPE_PRECEDENCE_DEFAULT)
 }
 
-func (this *BallerinaParser) parseTypeDescriptorWithoutQualifiers(context common.ParserRuleContext, isTypedBindingPattern bool, isInConditionalExpr bool, precedence TypePrecedence) tree.STNode {
-	return this.parseTypeDescriptorWithinContext(nil, context, isTypedBindingPattern, isInConditionalExpr, precedence)
+func (b *BallerinaParser) parseTypeDescriptorWithoutQualifiers(context common.ParserRuleContext, isTypedBindingPattern bool, isInConditionalExpr bool, precedence TypePrecedence) tree.STNode {
+	return b.parseTypeDescriptorWithinContext(nil, context, isTypedBindingPattern, isInConditionalExpr, precedence)
 }
 
-func (this *BallerinaParser) parseTypeDescriptorWithinContext(qualifiers []tree.STNode, context common.ParserRuleContext, isTypedBindingPattern bool, isInConditionalExpr bool, precedence TypePrecedence) tree.STNode {
-	this.startContext(context)
-	typeDesc := this.parseTypeDescriptorInner(qualifiers, context, isTypedBindingPattern, isInConditionalExpr,
+func (b *BallerinaParser) parseTypeDescriptorWithinContext(qualifiers []tree.STNode, context common.ParserRuleContext, isTypedBindingPattern bool, isInConditionalExpr bool, precedence TypePrecedence) tree.STNode {
+	b.startContext(context)
+	typeDesc := b.parseTypeDescriptorInner(qualifiers, context, isTypedBindingPattern, isInConditionalExpr,
 		precedence)
-	this.endContext()
+	b.endContext()
 	return typeDesc
 }
 
-func (this *BallerinaParser) parseTypeDescriptorInner(qualifiers []tree.STNode, context common.ParserRuleContext, isTypedBindingPattern bool, isInConditionalExpr bool, precedence TypePrecedence) tree.STNode {
-	typeDesc := this.parseTypeDescriptorInternal(qualifiers, context, isInConditionalExpr)
+func (b *BallerinaParser) parseTypeDescriptorInner(qualifiers []tree.STNode, context common.ParserRuleContext, isTypedBindingPattern bool, isInConditionalExpr bool, precedence TypePrecedence) tree.STNode {
+	typeDesc := b.parseTypeDescriptorInternal(qualifiers, context, isInConditionalExpr)
 	if ((typeDesc.Kind() == common.VAR_TYPE_DESC) && (context != common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN)) && (context != common.PARSER_RULE_CONTEXT_TYPE_DESC_BEFORE_IDENTIFIER_IN_GROUPING_KEY) {
 		var missingToken tree.STNode
 		missingToken = tree.CreateMissingToken(common.IDENTIFIER_TOKEN, nil)
@@ -2344,29 +2344,29 @@ func (this *BallerinaParser) parseTypeDescriptorInner(qualifiers []tree.STNode, 
 			&common.ERROR_INVALID_USAGE_OF_VAR)
 		typeDesc = tree.CreateSimpleNameReferenceNode(missingToken.(tree.STToken))
 	}
-	return this.parseComplexTypeDescriptorInternal(typeDesc, context, isTypedBindingPattern, precedence)
+	return b.parseComplexTypeDescriptorInternal(typeDesc, context, isTypedBindingPattern, precedence)
 }
 
-func (this *BallerinaParser) parseComplexTypeDescriptor(typeDesc tree.STNode, context common.ParserRuleContext, isTypedBindingPattern bool) tree.STNode {
-	this.startContext(context)
-	complexTypeDesc := this.parseComplexTypeDescriptorInternal(typeDesc, context, isTypedBindingPattern,
+func (b *BallerinaParser) parseComplexTypeDescriptor(typeDesc tree.STNode, context common.ParserRuleContext, isTypedBindingPattern bool) tree.STNode {
+	b.startContext(context)
+	complexTypeDesc := b.parseComplexTypeDescriptorInternal(typeDesc, context, isTypedBindingPattern,
 		TYPE_PRECEDENCE_DEFAULT)
-	this.endContext()
+	b.endContext()
 	return complexTypeDesc
 }
 
-func (this *BallerinaParser) parseComplexTypeDescriptorInternal(typeDesc tree.STNode, context common.ParserRuleContext, isTypedBindingPattern bool, precedence TypePrecedence) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseComplexTypeDescriptorInternal(typeDesc tree.STNode, context common.ParserRuleContext, isTypedBindingPattern bool, precedence TypePrecedence) tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.QUESTION_MARK_TOKEN:
 		if precedence.isHigherThanOrEqual(TYPE_PRECEDENCE_ARRAY_OR_OPTIONAL) {
 			return typeDesc
 		}
 		isPossibleOptionalType := true
-		nextNextToken := this.getNextNextToken()
-		if ((context == common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_EXPRESSION) && (!this.isValidTypeContinuationToken(nextNextToken))) && this.isValidExprStart(nextNextToken.Kind()) {
+		nextNextToken := b.getNextNextToken()
+		if ((context == common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_EXPRESSION) && (!b.isValidTypeContinuationToken(nextNextToken))) && b.isValidExprStart(nextNextToken.Kind()) {
 			if nextNextToken.Kind() == common.OPEN_BRACE_TOKEN {
-				grandParentCtx := this.errorHandler.GetGrandParentContext()
+				grandParentCtx := b.errorHandler.GetGrandParentContext()
 				isPossibleOptionalType = ((grandParentCtx == common.PARSER_RULE_CONTEXT_IF_BLOCK) || (grandParentCtx == common.PARSER_RULE_CONTEXT_WHILE_BLOCK))
 			} else {
 				isPossibleOptionalType = false
@@ -2375,8 +2375,8 @@ func (this *BallerinaParser) parseComplexTypeDescriptorInternal(typeDesc tree.ST
 		if !isPossibleOptionalType {
 			return typeDesc
 		}
-		optionalTypeDes := this.parseOptionalTypeDescriptor(typeDesc)
-		return this.parseComplexTypeDescriptorInternal(optionalTypeDes, context, isTypedBindingPattern, precedence)
+		optionalTypeDes := b.parseOptionalTypeDescriptor(typeDesc)
+		return b.parseComplexTypeDescriptorInternal(optionalTypeDes, context, isTypedBindingPattern, precedence)
 	case common.OPEN_BRACKET_TOKEN:
 		if isTypedBindingPattern {
 			return typeDesc
@@ -2384,26 +2384,26 @@ func (this *BallerinaParser) parseComplexTypeDescriptorInternal(typeDesc tree.ST
 		if precedence.isHigherThanOrEqual(TYPE_PRECEDENCE_ARRAY_OR_OPTIONAL) {
 			return typeDesc
 		}
-		arrayTypeDesc := this.parseArrayTypeDescriptor(typeDesc)
-		return this.parseComplexTypeDescriptorInternal(arrayTypeDesc, context, false, precedence)
+		arrayTypeDesc := b.parseArrayTypeDescriptor(typeDesc)
+		return b.parseComplexTypeDescriptorInternal(arrayTypeDesc, context, false, precedence)
 	case common.PIPE_TOKEN:
 		if precedence.isHigherThanOrEqual(TYPE_PRECEDENCE_UNION) {
 			return typeDesc
 		}
-		newTypeDesc := this.parseUnionTypeDescriptor(typeDesc, context, isTypedBindingPattern)
-		return this.parseComplexTypeDescriptorInternal(newTypeDesc, context, isTypedBindingPattern, precedence)
+		newTypeDesc := b.parseUnionTypeDescriptor(typeDesc, context, isTypedBindingPattern)
+		return b.parseComplexTypeDescriptorInternal(newTypeDesc, context, isTypedBindingPattern, precedence)
 	case common.BITWISE_AND_TOKEN:
 		if precedence.isHigherThanOrEqual(TYPE_PRECEDENCE_INTERSECTION) {
 			return typeDesc
 		}
-		newTypeDesc := this.parseIntersectionTypeDescriptor(typeDesc, context, isTypedBindingPattern)
-		return this.parseComplexTypeDescriptorInternal(newTypeDesc, context, isTypedBindingPattern, precedence)
+		newTypeDesc := b.parseIntersectionTypeDescriptor(typeDesc, context, isTypedBindingPattern)
+		return b.parseComplexTypeDescriptorInternal(newTypeDesc, context, isTypedBindingPattern, precedence)
 	default:
 		return typeDesc
 	}
 }
 
-func (this *BallerinaParser) isValidTypeContinuationToken(token tree.STToken) bool {
+func (b *BallerinaParser) isValidTypeContinuationToken(token tree.STToken) bool {
 	switch token.Kind() {
 	case common.QUESTION_MARK_TOKEN, common.OPEN_BRACKET_TOKEN, common.PIPE_TOKEN, common.BITWISE_AND_TOKEN:
 		return true
@@ -2412,7 +2412,7 @@ func (this *BallerinaParser) isValidTypeContinuationToken(token tree.STToken) bo
 	}
 }
 
-func (this *BallerinaParser) validateForUsageOfVar(typeDesc tree.STNode) tree.STNode {
+func (b *BallerinaParser) validateForUsageOfVar(typeDesc tree.STNode) tree.STNode {
 	if typeDesc.Kind() != common.VAR_TYPE_DESC {
 		return typeDesc
 	}
@@ -2423,71 +2423,71 @@ func (this *BallerinaParser) validateForUsageOfVar(typeDesc tree.STNode) tree.ST
 	return tree.CreateSimpleNameReferenceNode(missingToken)
 }
 
-func (this *BallerinaParser) parseTypeDescriptorInternal(qualifiers []tree.STNode, context common.ParserRuleContext, isInConditionalExpr bool) tree.STNode {
-	qualifiers = this.parseTypeDescQualifiers(qualifiers)
-	nextToken := this.peek()
-	if this.isQualifiedIdentifierPredeclaredPrefix(nextToken.Kind()) {
-		return this.parseQualifiedTypeRefOrTypeDesc(qualifiers, isInConditionalExpr)
+func (b *BallerinaParser) parseTypeDescriptorInternal(qualifiers []tree.STNode, context common.ParserRuleContext, isInConditionalExpr bool) tree.STNode {
+	qualifiers = b.parseTypeDescQualifiers(qualifiers)
+	nextToken := b.peek()
+	if b.isQualifiedIdentifierPredeclaredPrefix(nextToken.Kind()) {
+		return b.parseQualifiedTypeRefOrTypeDesc(qualifiers, isInConditionalExpr)
 	}
 	switch nextToken.Kind() {
 	case common.IDENTIFIER_TOKEN:
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseTypeReferenceInner(isInConditionalExpr)
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseTypeReferenceInner(isInConditionalExpr)
 	case common.RECORD_KEYWORD:
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseRecordTypeDescriptor()
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseRecordTypeDescriptor()
 	case common.OBJECT_KEYWORD:
-		objectTypeQualifiers := this.createObjectTypeQualNodeList(qualifiers)
-		return this.parseObjectTypeDescriptor(this.consume(), objectTypeQualifiers)
+		objectTypeQualifiers := b.createObjectTypeQualNodeList(qualifiers)
+		return b.parseObjectTypeDescriptor(b.consume(), objectTypeQualifiers)
 	case common.OPEN_PAREN_TOKEN:
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseNilOrParenthesisedTypeDesc()
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseNilOrParenthesisedTypeDesc()
 	case common.MAP_KEYWORD:
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseMapTypeDescriptor(this.consume())
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseMapTypeDescriptor(b.consume())
 	case common.STREAM_KEYWORD:
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseStreamTypeDescriptor(this.consume())
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseStreamTypeDescriptor(b.consume())
 	case common.TABLE_KEYWORD:
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseTableTypeDescriptor(this.consume())
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseTableTypeDescriptor(b.consume())
 	case common.FUNCTION_KEYWORD:
-		return this.parseFunctionTypeDesc(qualifiers)
+		return b.parseFunctionTypeDesc(qualifiers)
 	case common.OPEN_BRACKET_TOKEN:
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseTupleTypeDesc()
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseTupleTypeDesc()
 	case common.DISTINCT_KEYWORD:
-		this.reportInvalidQualifierList(qualifiers)
-		distinctKeyword := this.consume()
-		return this.parseDistinctTypeDesc(distinctKeyword, context)
+		b.reportInvalidQualifierList(qualifiers)
+		distinctKeyword := b.consume()
+		return b.parseDistinctTypeDesc(distinctKeyword, context)
 	case common.TRANSACTION_KEYWORD:
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseQualifiedIdentWithTransactionPrefix(context)
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseQualifiedIdentWithTransactionPrefix(context)
 	default:
 		if isParameterizedTypeToken(nextToken.Kind()) {
-			this.reportInvalidQualifierList(qualifiers)
-			return this.parseParameterizedTypeDescriptor(this.consume())
+			b.reportInvalidQualifierList(qualifiers)
+			return b.parseParameterizedTypeDescriptor(b.consume())
 		}
-		if isSingletonTypeDescStart(nextToken.Kind(), this.getNextNextToken()) {
-			this.reportInvalidQualifierList(qualifiers)
-			return this.parseSingletonTypeDesc()
+		if isSingletonTypeDescStart(nextToken.Kind(), b.getNextNextToken()) {
+			b.reportInvalidQualifierList(qualifiers)
+			return b.parseSingletonTypeDesc()
 		}
 		if isSimpleType(nextToken.Kind()) {
-			this.reportInvalidQualifierList(qualifiers)
-			return this.parseSimpleTypeDescriptor()
+			b.reportInvalidQualifierList(qualifiers)
+			return b.parseSimpleTypeDescriptor()
 		}
 	}
-	recoveryCtx := this.getTypeDescRecoveryCtx(qualifiers)
-	solution := this.recoverWithBlockContext(this.peek(), recoveryCtx)
+	recoveryCtx := b.getTypeDescRecoveryCtx(qualifiers)
+	solution := b.recoverWithBlockContext(b.peek(), recoveryCtx)
 	if solution.Action == ACTION_KEEP {
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseSingletonTypeDesc()
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseSingletonTypeDesc()
 	}
-	return this.parseTypeDescriptorInternal(qualifiers, context, isInConditionalExpr)
+	return b.parseTypeDescriptorInternal(qualifiers, context, isInConditionalExpr)
 }
 
-func (this *BallerinaParser) parseTypeDescriptorInternalWithPrecedence(qualifiers []tree.STNode, context common.ParserRuleContext, isTypedBindingPattern bool, isInConditionalExpr bool, precedence TypePrecedence) tree.STNode {
-	typeDesc := this.parseTypeDescriptorInternal(qualifiers, context, isInConditionalExpr)
+func (b *BallerinaParser) parseTypeDescriptorInternalWithPrecedence(qualifiers []tree.STNode, context common.ParserRuleContext, isTypedBindingPattern bool, isInConditionalExpr bool, precedence TypePrecedence) tree.STNode {
+	typeDesc := b.parseTypeDescriptorInternal(qualifiers, context, isInConditionalExpr)
 
 	// var is parsed as a built-in simple type. However, since var is not allowed everywhere,
 	// validate it here. This is done to give better error messages.
@@ -2499,14 +2499,14 @@ func (this *BallerinaParser) parseTypeDescriptorInternalWithPrecedence(qualifier
 		typeDesc = tree.CreateSimpleNameReferenceNode(missingToken.(tree.STToken))
 	}
 
-	return this.parseComplexTypeDescriptorInternal(typeDesc, context, isTypedBindingPattern, precedence)
+	return b.parseComplexTypeDescriptorInternal(typeDesc, context, isTypedBindingPattern, precedence)
 }
 
-func (this *BallerinaParser) getTypeDescRecoveryCtx(qualifiers []tree.STNode) common.ParserRuleContext {
+func (b *BallerinaParser) getTypeDescRecoveryCtx(qualifiers []tree.STNode) common.ParserRuleContext {
 	if len(qualifiers) == 0 {
 		return common.PARSER_RULE_CONTEXT_TYPE_DESCRIPTOR
 	}
-	lastQualifier := this.getLastNodeInList(qualifiers)
+	lastQualifier := b.getLastNodeInList(qualifiers)
 	switch lastQualifier.Kind() {
 	case common.ISOLATED_KEYWORD:
 		return common.PARSER_RULE_CONTEXT_TYPE_DESC_WITHOUT_ISOLATED
@@ -2517,22 +2517,22 @@ func (this *BallerinaParser) getTypeDescRecoveryCtx(qualifiers []tree.STNode) co
 	}
 }
 
-func (this *BallerinaParser) parseQualifiedIdentWithTransactionPrefix(context common.ParserRuleContext) tree.STNode {
-	transactionKeyword := this.consume()
+func (b *BallerinaParser) parseQualifiedIdentWithTransactionPrefix(context common.ParserRuleContext) tree.STNode {
+	transactionKeyword := b.consume()
 	identifier := tree.CreateIdentifierToken(transactionKeyword.Text(),
 		transactionKeyword.LeadingMinutiae(), transactionKeyword.TrailingMinutiae())
 	colon := tree.CreateMissingTokenWithDiagnostics(common.COLON_TOKEN,
 		&common.ERROR_MISSING_COLON_TOKEN)
-	varOrFuncName := this.parseIdentifier(context)
-	return this.createQualifiedNameReferenceNode(identifier, colon, varOrFuncName)
+	varOrFuncName := b.parseIdentifier(context)
+	return b.createQualifiedNameReferenceNode(identifier, colon, varOrFuncName)
 }
 
-func (this *BallerinaParser) parseQualifiedTypeRefOrTypeDesc(qualifiers []tree.STNode, isInConditionalExpr bool) tree.STNode {
-	preDeclaredPrefix := this.consume()
-	nextNextToken := this.getNextNextToken()
+func (b *BallerinaParser) parseQualifiedTypeRefOrTypeDesc(qualifiers []tree.STNode, isInConditionalExpr bool) tree.STNode {
+	preDeclaredPrefix := b.consume()
+	nextNextToken := b.getNextNextToken()
 	if (preDeclaredPrefix.Kind() == common.TRANSACTION_KEYWORD) || (nextNextToken.Kind() == common.IDENTIFIER_TOKEN) {
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseQualifiedIdentifierWithPredeclPrefix(preDeclaredPrefix, isInConditionalExpr)
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseQualifiedIdentifierWithPredeclPrefix(preDeclaredPrefix, isInConditionalExpr)
 	}
 	var context common.ParserRuleContext
 	switch preDeclaredPrefix.Kind() {
@@ -2551,119 +2551,119 @@ func (this *BallerinaParser) parseQualifiedTypeRefOrTypeDesc(qualifiers []tree.S
 			context = common.PARSER_RULE_CONTEXT_TYPE_DESC_RHS_OR_TYPE_REF
 		}
 	}
-	solution := this.recoverWithBlockContext(this.peek(), context)
+	solution := b.recoverWithBlockContext(b.peek(), context)
 	if solution.Action == ACTION_KEEP {
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseQualifiedIdentifierWithPredeclPrefix(preDeclaredPrefix, isInConditionalExpr)
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseQualifiedIdentifierWithPredeclPrefix(preDeclaredPrefix, isInConditionalExpr)
 	}
-	return this.parseTypeDescStartWithPredeclPrefix(preDeclaredPrefix, qualifiers)
+	return b.parseTypeDescStartWithPredeclPrefix(preDeclaredPrefix, qualifiers)
 }
 
-func (this *BallerinaParser) parseTypeDescStartWithPredeclPrefix(preDeclaredPrefix tree.STToken, qualifiers []tree.STNode) tree.STNode {
+func (b *BallerinaParser) parseTypeDescStartWithPredeclPrefix(preDeclaredPrefix tree.STToken, qualifiers []tree.STNode) tree.STNode {
 	switch preDeclaredPrefix.Kind() {
 	case common.MAP_KEYWORD:
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseMapTypeDescriptor(preDeclaredPrefix)
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseMapTypeDescriptor(preDeclaredPrefix)
 	case common.OBJECT_KEYWORD:
-		objectTypeQualifiers := this.createObjectTypeQualNodeList(qualifiers)
-		return this.parseObjectTypeDescriptor(preDeclaredPrefix, objectTypeQualifiers)
+		objectTypeQualifiers := b.createObjectTypeQualNodeList(qualifiers)
+		return b.parseObjectTypeDescriptor(preDeclaredPrefix, objectTypeQualifiers)
 	case common.STREAM_KEYWORD:
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseStreamTypeDescriptor(preDeclaredPrefix)
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseStreamTypeDescriptor(preDeclaredPrefix)
 	case common.TABLE_KEYWORD:
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseTableTypeDescriptor(preDeclaredPrefix)
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseTableTypeDescriptor(preDeclaredPrefix)
 	default:
 		if isParameterizedTypeToken(preDeclaredPrefix.Kind()) {
-			this.reportInvalidQualifierList(qualifiers)
-			return this.parseParameterizedTypeDescriptor(preDeclaredPrefix)
+			b.reportInvalidQualifierList(qualifiers)
+			return b.parseParameterizedTypeDescriptor(preDeclaredPrefix)
 		}
 		return CreateBuiltinSimpleNameReference(preDeclaredPrefix)
 	}
 }
 
-func (this *BallerinaParser) parseQualifiedIdentifierWithPredeclPrefix(preDeclaredPrefix tree.STToken, isInConditionalExpr bool) tree.STNode {
+func (b *BallerinaParser) parseQualifiedIdentifierWithPredeclPrefix(preDeclaredPrefix tree.STToken, isInConditionalExpr bool) tree.STNode {
 	identifier := tree.CreateIdentifierToken(preDeclaredPrefix.Text(),
 		preDeclaredPrefix.LeadingMinutiae(), preDeclaredPrefix.TrailingMinutiae())
-	return this.parseQualifiedIdentifierNode(identifier, isInConditionalExpr)
+	return b.parseQualifiedIdentifierNode(identifier, isInConditionalExpr)
 }
 
-func (this *BallerinaParser) parseDistinctTypeDesc(distinctKeyword tree.STNode, context common.ParserRuleContext) tree.STNode {
-	typeDesc := this.parseTypeDescriptorWithPrecedence(context, TYPE_PRECEDENCE_DISTINCT)
+func (b *BallerinaParser) parseDistinctTypeDesc(distinctKeyword tree.STNode, context common.ParserRuleContext) tree.STNode {
+	typeDesc := b.parseTypeDescriptorWithPrecedence(context, TYPE_PRECEDENCE_DISTINCT)
 	return tree.CreateDistinctTypeDescriptorNode(distinctKeyword, typeDesc)
 }
 
-func (this *BallerinaParser) parseNilOrParenthesisedTypeDesc() tree.STNode {
-	openParen := this.parseOpenParenthesis()
-	return this.parseNilOrParenthesisedTypeDescRhs(openParen)
+func (b *BallerinaParser) parseNilOrParenthesisedTypeDesc() tree.STNode {
+	openParen := b.parseOpenParenthesis()
+	return b.parseNilOrParenthesisedTypeDescRhs(openParen)
 }
 
-func (this *BallerinaParser) parseNilOrParenthesisedTypeDescRhs(openParen tree.STNode) tree.STNode {
+func (b *BallerinaParser) parseNilOrParenthesisedTypeDescRhs(openParen tree.STNode) tree.STNode {
 	var closeParen tree.STNode
-	nextToken := this.peek()
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.CLOSE_PAREN_TOKEN:
-		closeParen = this.parseCloseParenthesis()
+		closeParen = b.parseCloseParenthesis()
 		return tree.CreateNilTypeDescriptorNode(openParen, closeParen)
 	default:
-		if this.isTypeStartingToken(nextToken.Kind()) {
-			typedesc := this.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_PARENTHESIS)
-			closeParen = this.parseCloseParenthesis()
+		if b.isTypeStartingToken(nextToken.Kind()) {
+			typedesc := b.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_PARENTHESIS)
+			closeParen = b.parseCloseParenthesis()
 			return tree.CreateParenthesisedTypeDescriptorNode(openParen, typedesc, closeParen)
 		}
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_NIL_OR_PARENTHESISED_TYPE_DESC_RHS)
-		return this.parseNilOrParenthesisedTypeDescRhs(openParen)
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_NIL_OR_PARENTHESISED_TYPE_DESC_RHS)
+		return b.parseNilOrParenthesisedTypeDescRhs(openParen)
 	}
 }
 
-func (this *BallerinaParser) parseSimpleTypeInTerminalExpr() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_EXPRESSION)
-	simpleTypeDescriptor := this.parseSimpleTypeDescriptor()
-	this.endContext()
+func (b *BallerinaParser) parseSimpleTypeInTerminalExpr() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_EXPRESSION)
+	simpleTypeDescriptor := b.parseSimpleTypeDescriptor()
+	b.endContext()
 	return simpleTypeDescriptor
 }
 
-func (this *BallerinaParser) parseSimpleTypeDescriptor() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseSimpleTypeDescriptor() tree.STNode {
+	nextToken := b.peek()
 	if isSimpleType(nextToken.Kind()) {
-		token := this.consume()
+		token := b.consume()
 		return CreateBuiltinSimpleNameReference(token)
 	} else {
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_SIMPLE_TYPE_DESCRIPTOR)
-		return this.parseSimpleTypeDescriptor()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_SIMPLE_TYPE_DESCRIPTOR)
+		return b.parseSimpleTypeDescriptor()
 	}
 }
 
-func (this *BallerinaParser) parseFunctionBody() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseFunctionBody() tree.STNode {
+	token := b.peek()
 	switch token.Kind() {
 	case common.EQUAL_TOKEN:
-		return this.parseExternalFunctionBody()
+		return b.parseExternalFunctionBody()
 	case common.OPEN_BRACE_TOKEN:
-		return this.parseFunctionBodyBlock(false)
+		return b.parseFunctionBodyBlock(false)
 	case common.RIGHT_DOUBLE_ARROW_TOKEN:
-		return this.parseExpressionFuncBody(false, false)
+		return b.parseExpressionFuncBody(false, false)
 	default:
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_FUNC_BODY)
-		return this.parseFunctionBody()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_FUNC_BODY)
+		return b.parseFunctionBody()
 	}
 }
 
-func (this *BallerinaParser) parseFunctionBodyBlock(isAnonFunc bool) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_FUNC_BODY_BLOCK)
-	openBrace := this.parseOpenBrace()
-	token := this.peek()
+func (b *BallerinaParser) parseFunctionBodyBlock(isAnonFunc bool) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_FUNC_BODY_BLOCK)
+	openBrace := b.parseOpenBrace()
+	token := b.peek()
 	firstStmtList := make([]tree.STNode, 0)
 	workers := make([]tree.STNode, 0)
 	secondStmtList := make([]tree.STNode, 0)
 	currentCtx := common.PARSER_RULE_CONTEXT_DEFAULT_WORKER_INIT
 	hasNamedWorkers := false
-	for !this.isEndOfFuncBodyBlock(token.Kind(), isAnonFunc) {
-		stmt := this.parseStatement()
+	for !b.isEndOfFuncBodyBlock(token.Kind(), isAnonFunc) {
+		stmt := b.parseStatement()
 		if stmt == nil {
 			break
 		}
-		if this.validateStatement(stmt) {
+		if b.validateStatement(stmt) {
 			continue
 		}
 		switch currentCtx {
@@ -2686,13 +2686,13 @@ func (this *BallerinaParser) parseFunctionBodyBlock(isAnonFunc bool) tree.STNode
 			fallthrough
 		default:
 			if stmt.Kind() == common.NAMED_WORKER_DECLARATION {
-				this.updateLastNodeInListWithInvalidNode(secondStmtList, stmt,
+				b.updateLastNodeInListWithInvalidNode(secondStmtList, stmt,
 					&common.ERROR_NAMED_WORKER_NOT_ALLOWED_HERE)
 				break
 			}
 			secondStmtList = append(secondStmtList, stmt)
 		}
-		token = this.peek()
+		token = b.peek()
 	}
 	var namedWorkersList tree.STNode
 	var statements tree.STNode
@@ -2705,19 +2705,19 @@ func (this *BallerinaParser) parseFunctionBodyBlock(isAnonFunc bool) tree.STNode
 		namedWorkersList = tree.CreateEmptyNode()
 		statements = tree.CreateNodeList(firstStmtList...)
 	}
-	closeBrace := this.parseCloseBrace()
+	closeBrace := b.parseCloseBrace()
 	var semicolon tree.STNode
 	if isAnonFunc {
 		semicolon = tree.CreateEmptyNode()
 	} else {
-		semicolon = this.parseOptionalSemicolon()
+		semicolon = b.parseOptionalSemicolon()
 	}
-	this.endContext()
+	b.endContext()
 	return tree.CreateFunctionBodyBlockNode(openBrace, namedWorkersList, statements, closeBrace,
 		semicolon)
 }
 
-func (this *BallerinaParser) isEndOfFuncBodyBlock(nextTokenKind common.SyntaxKind, isAnonFunc bool) bool {
+func (b *BallerinaParser) isEndOfFuncBodyBlock(nextTokenKind common.SyntaxKind, isAnonFunc bool) bool {
 	if isAnonFunc {
 		switch nextTokenKind {
 		case common.CLOSE_BRACE_TOKEN, common.CLOSE_PAREN_TOKEN, common.CLOSE_BRACKET_TOKEN,
@@ -2728,32 +2728,32 @@ func (this *BallerinaParser) isEndOfFuncBodyBlock(nextTokenKind common.SyntaxKin
 			break
 		}
 	}
-	return this.isEndOfStatements()
+	return b.isEndOfStatements()
 }
 
-func (this *BallerinaParser) isEndOfRecordTypeNode(_ common.SyntaxKind) bool {
-	return this.isEndOfModuleLevelNode(1)
+func (b *BallerinaParser) isEndOfRecordTypeNode(_ common.SyntaxKind) bool {
+	return b.isEndOfModuleLevelNode(1)
 }
 
-func (this *BallerinaParser) isEndOfObjectTypeNode() bool {
-	return this.isEndOfModuleLevelNodeInner(1, true)
+func (b *BallerinaParser) isEndOfObjectTypeNode() bool {
+	return b.isEndOfModuleLevelNodeInner(1, true)
 }
 
-func (this *BallerinaParser) isEndOfStatements() bool {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) isEndOfStatements() bool {
+	switch b.peek().Kind() {
 	case common.RESOURCE_KEYWORD:
 		return true
 	default:
-		return this.isEndOfModuleLevelNode(1)
+		return b.isEndOfModuleLevelNode(1)
 	}
 }
 
-func (this *BallerinaParser) isEndOfModuleLevelNode(peekIndex int) bool {
-	return this.isEndOfModuleLevelNodeInner(peekIndex, false)
+func (b *BallerinaParser) isEndOfModuleLevelNode(peekIndex int) bool {
+	return b.isEndOfModuleLevelNodeInner(peekIndex, false)
 }
 
-func (this *BallerinaParser) isEndOfModuleLevelNodeInner(peekIndex int, isObject bool) bool {
-	switch this.peekN(peekIndex).Kind() {
+func (b *BallerinaParser) isEndOfModuleLevelNodeInner(peekIndex int, isObject bool) bool {
+	switch b.peekN(peekIndex).Kind() {
 	case common.EOF_TOKEN,
 		common.CLOSE_BRACE_TOKEN,
 		common.CLOSE_BRACE_PIPE_TOKEN,
@@ -2763,20 +2763,20 @@ func (this *BallerinaParser) isEndOfModuleLevelNodeInner(peekIndex int, isObject
 		common.CLASS_KEYWORD:
 		return true
 	case common.SERVICE_KEYWORD:
-		return this.isServiceDeclStart(common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR_MEMBER, 1)
+		return b.isServiceDeclStart(common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR_MEMBER, 1)
 	case common.PUBLIC_KEYWORD:
-		return ((!isObject) && this.isEndOfModuleLevelNodeInner(peekIndex+1, false))
+		return ((!isObject) && b.isEndOfModuleLevelNodeInner(peekIndex+1, false))
 	case common.FUNCTION_KEYWORD:
 		if isObject {
 			return false
 		}
-		return ((this.peekN(peekIndex+1).Kind() == common.IDENTIFIER_TOKEN) && (this.peekN(peekIndex+2).Kind() == common.OPEN_PAREN_TOKEN))
+		return ((b.peekN(peekIndex+1).Kind() == common.IDENTIFIER_TOKEN) && (b.peekN(peekIndex+2).Kind() == common.OPEN_PAREN_TOKEN))
 	default:
 		return false
 	}
 }
 
-func (this *BallerinaParser) isEndOfParameter(tokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isEndOfParameter(tokenKind common.SyntaxKind) bool {
 	switch tokenKind {
 	case common.CLOSE_PAREN_TOKEN,
 		common.CLOSE_BRACKET_TOKEN,
@@ -2790,11 +2790,11 @@ func (this *BallerinaParser) isEndOfParameter(tokenKind common.SyntaxKind) bool 
 		common.AT_TOKEN:
 		return true
 	default:
-		return this.isEndOfModuleLevelNode(1)
+		return b.isEndOfModuleLevelNode(1)
 	}
 }
 
-func (this *BallerinaParser) isEndOfParametersList(tokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isEndOfParametersList(tokenKind common.SyntaxKind) bool {
 	switch tokenKind {
 	case common.CLOSE_PAREN_TOKEN,
 		common.SEMICOLON_TOKEN,
@@ -2806,117 +2806,117 @@ func (this *BallerinaParser) isEndOfParametersList(tokenKind common.SyntaxKind) 
 		common.RIGHT_DOUBLE_ARROW_TOKEN:
 		return true
 	default:
-		return this.isEndOfModuleLevelNode(1)
+		return b.isEndOfModuleLevelNode(1)
 	}
 }
 
-func (this *BallerinaParser) parseStatementStartIdentifier() tree.STNode {
-	return this.parseQualifiedIdentifier(common.PARSER_RULE_CONTEXT_TYPE_NAME_OR_VAR_NAME)
+func (b *BallerinaParser) parseStatementStartIdentifier() tree.STNode {
+	return b.parseQualifiedIdentifier(common.PARSER_RULE_CONTEXT_TYPE_NAME_OR_VAR_NAME)
 }
 
-func (this *BallerinaParser) parseVariableName() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseVariableName() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.IDENTIFIER_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_VARIABLE_NAME)
-		return this.parseVariableName()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_VARIABLE_NAME)
+		return b.parseVariableName()
 	}
 }
 
-func (this *BallerinaParser) parseOpenBrace() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseOpenBrace() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.OPEN_BRACE_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_OPEN_BRACE)
-		return this.parseOpenBrace()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_OPEN_BRACE)
+		return b.parseOpenBrace()
 	}
 }
 
-func (this *BallerinaParser) parseCloseBrace() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseCloseBrace() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.CLOSE_BRACE_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_CLOSE_BRACE)
-		return this.parseCloseBrace()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_CLOSE_BRACE)
+		return b.parseCloseBrace()
 	}
 }
 
-func (this *BallerinaParser) parseExternalFunctionBody() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_EXTERNAL_FUNC_BODY)
-	assign := this.parseAssignOp()
-	return this.parseExternalFuncBodyRhs(assign)
+func (b *BallerinaParser) parseExternalFunctionBody() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_EXTERNAL_FUNC_BODY)
+	assign := b.parseAssignOp()
+	return b.parseExternalFuncBodyRhs(assign)
 }
 
-func (this *BallerinaParser) parseExternalFuncBodyRhs(assign tree.STNode) tree.STNode {
+func (b *BallerinaParser) parseExternalFuncBodyRhs(assign tree.STNode) tree.STNode {
 	var annotation tree.STNode
-	nextToken := this.peek()
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.AT_TOKEN:
-		annotation = this.parseAnnotations()
+		annotation = b.parseAnnotations()
 	case common.EXTERNAL_KEYWORD:
 		annotation = tree.CreateEmptyNodeList()
 	default:
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_EXTERNAL_FUNC_BODY_OPTIONAL_ANNOTS)
-		return this.parseExternalFuncBodyRhs(assign)
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_EXTERNAL_FUNC_BODY_OPTIONAL_ANNOTS)
+		return b.parseExternalFuncBodyRhs(assign)
 	}
-	externalKeyword := this.parseExternalKeyword()
-	semicolon := this.parseSemicolon()
-	this.endContext()
+	externalKeyword := b.parseExternalKeyword()
+	semicolon := b.parseSemicolon()
+	b.endContext()
 	return tree.CreateExternalFunctionBodyNode(assign, annotation, externalKeyword, semicolon)
 }
 
-func (this *BallerinaParser) parseSemicolon() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseSemicolon() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.SEMICOLON_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_SEMICOLON)
-		return this.parseSemicolon()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_SEMICOLON)
+		return b.parseSemicolon()
 	}
 }
 
-func (this *BallerinaParser) parseOptionalSemicolon() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseOptionalSemicolon() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.SEMICOLON_TOKEN {
-		return this.consume()
+		return b.consume()
 	}
 	return tree.CreateEmptyNode()
 }
 
-func (this *BallerinaParser) parseExternalKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseExternalKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.EXTERNAL_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_EXTERNAL_KEYWORD)
-		return this.parseExternalKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_EXTERNAL_KEYWORD)
+		return b.parseExternalKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseAssignOp() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseAssignOp() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.EQUAL_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_ASSIGN_OP)
-		return this.parseAssignOp()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_ASSIGN_OP)
+		return b.parseAssignOp()
 	}
 }
 
-func (this *BallerinaParser) parseBinaryOperator() tree.STNode {
-	token := this.peek()
-	if this.isBinaryOperator(token.Kind()) {
-		return this.consume()
+func (b *BallerinaParser) parseBinaryOperator() tree.STNode {
+	token := b.peek()
+	if b.isBinaryOperator(token.Kind()) {
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_BINARY_OPERATOR)
-		return this.parseBinaryOperator()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_BINARY_OPERATOR)
+		return b.parseBinaryOperator()
 	}
 }
 
-func (this *BallerinaParser) isBinaryOperator(kind common.SyntaxKind) bool {
+func (b *BallerinaParser) isBinaryOperator(kind common.SyntaxKind) bool {
 	switch kind {
 	case common.PLUS_TOKEN,
 		common.MINUS_TOKEN,
@@ -2948,7 +2948,7 @@ func (this *BallerinaParser) isBinaryOperator(kind common.SyntaxKind) bool {
 	}
 }
 
-func (this *BallerinaParser) getOpPrecedence(binaryOpKind common.SyntaxKind) OperatorPrecedence {
+func (b *BallerinaParser) getOpPrecedence(binaryOpKind common.SyntaxKind) OperatorPrecedence {
 	switch binaryOpKind {
 	case common.ASTERISK_TOKEN, // multiplication
 		common.SLASH_TOKEN, // division
@@ -3010,7 +3010,7 @@ func (this *BallerinaParser) getOpPrecedence(binaryOpKind common.SyntaxKind) Ope
 	}
 }
 
-func (this *BallerinaParser) getBinaryOperatorKindToInsert(opPrecedenceLevel OperatorPrecedence) common.SyntaxKind {
+func (b *BallerinaParser) getBinaryOperatorKindToInsert(opPrecedenceLevel OperatorPrecedence) common.SyntaxKind {
 	switch opPrecedenceLevel {
 	case OPERATOR_PRECEDENCE_MULTIPLICATIVE:
 		return common.ASTERISK_TOKEN
@@ -3050,7 +3050,7 @@ func (this *BallerinaParser) getBinaryOperatorKindToInsert(opPrecedenceLevel Ope
 	}
 }
 
-func (this *BallerinaParser) getMissingBinaryOperatorContext(opPrecedenceLevel OperatorPrecedence) common.ParserRuleContext {
+func (b *BallerinaParser) getMissingBinaryOperatorContext(opPrecedenceLevel OperatorPrecedence) common.ParserRuleContext {
 	switch opPrecedenceLevel {
 	case OPERATOR_PRECEDENCE_MULTIPLICATIVE:
 		return common.PARSER_RULE_CONTEXT_ASTERISK
@@ -3090,50 +3090,50 @@ func (this *BallerinaParser) getMissingBinaryOperatorContext(opPrecedenceLevel O
 	}
 }
 
-func (this *BallerinaParser) parseModuleTypeDefinition(metadata tree.STNode, qualifier tree.STNode) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_MODULE_TYPE_DEFINITION)
-	typeKeyword := this.parseTypeKeyword()
-	typeName := this.parseTypeName()
-	typeDescriptor := this.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_DEF)
-	semicolon := this.parseSemicolon()
-	this.endContext()
+func (b *BallerinaParser) parseModuleTypeDefinition(metadata tree.STNode, qualifier tree.STNode) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_MODULE_TYPE_DEFINITION)
+	typeKeyword := b.parseTypeKeyword()
+	typeName := b.parseTypeName()
+	typeDescriptor := b.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_DEF)
+	semicolon := b.parseSemicolon()
+	b.endContext()
 	return tree.CreateTypeDefinitionNode(metadata, qualifier, typeKeyword, typeName, typeDescriptor,
 		semicolon)
 }
 
-func (this *BallerinaParser) parseClassDefinition(metadata tree.STNode, qualifier tree.STNode, qualifiers []tree.STNode) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_MODULE_CLASS_DEFINITION)
-	classTypeQualifiers := this.createClassTypeQualNodeList(qualifiers)
-	classKeyword := this.parseClassKeyword()
-	className := this.parseClassName()
-	openBrace := this.parseOpenBrace()
-	classMembers := this.parseObjectMembers(common.PARSER_RULE_CONTEXT_CLASS_MEMBER)
-	closeBrace := this.parseCloseBrace()
-	semicolon := this.parseOptionalSemicolon()
-	this.endContext()
+func (b *BallerinaParser) parseClassDefinition(metadata tree.STNode, qualifier tree.STNode, qualifiers []tree.STNode) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_MODULE_CLASS_DEFINITION)
+	classTypeQualifiers := b.createClassTypeQualNodeList(qualifiers)
+	classKeyword := b.parseClassKeyword()
+	className := b.parseClassName()
+	openBrace := b.parseOpenBrace()
+	classMembers := b.parseObjectMembers(common.PARSER_RULE_CONTEXT_CLASS_MEMBER)
+	closeBrace := b.parseCloseBrace()
+	semicolon := b.parseOptionalSemicolon()
+	b.endContext()
 	return tree.CreateClassDefinitionNode(metadata, qualifier, classTypeQualifiers, classKeyword,
 		className, openBrace, classMembers, closeBrace, semicolon)
 }
 
-func (this *BallerinaParser) isClassTypeQual(tokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isClassTypeQual(tokenKind common.SyntaxKind) bool {
 	switch tokenKind {
 	case common.READONLY_KEYWORD, common.DISTINCT_KEYWORD, common.ISOLATED_KEYWORD:
 		return true
 	default:
-		return this.isObjectNetworkQual(tokenKind)
+		return b.isObjectNetworkQual(tokenKind)
 	}
 }
 
-func (this *BallerinaParser) isObjectTypeQual(tokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isObjectTypeQual(tokenKind common.SyntaxKind) bool {
 	switch tokenKind {
 	case common.ISOLATED_KEYWORD:
 		return true
 	default:
-		return this.isObjectNetworkQual(tokenKind)
+		return b.isObjectNetworkQual(tokenKind)
 	}
 }
 
-func (this *BallerinaParser) isObjectNetworkQual(tokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isObjectNetworkQual(tokenKind common.SyntaxKind) bool {
 	switch tokenKind {
 	case common.SERVICE_KEYWORD, common.CLIENT_KEYWORD:
 		return true
@@ -3142,21 +3142,21 @@ func (this *BallerinaParser) isObjectNetworkQual(tokenKind common.SyntaxKind) bo
 	}
 }
 
-func (this *BallerinaParser) createClassTypeQualNodeList(qualifierList []tree.STNode) tree.STNode {
+func (b *BallerinaParser) createClassTypeQualNodeList(qualifierList []tree.STNode) tree.STNode {
 	var validatedList []tree.STNode
 	hasNetworkQual := false
 	i := 0
 	for ; i < len(qualifierList); i++ {
 		qualifier := qualifierList[i]
 		nextIndex := (i + 1)
-		if this.isSyntaxKindInList(validatedList, qualifier.Kind()) {
-			this.updateLastNodeInListWithInvalidNode(validatedList, qualifier,
+		if b.isSyntaxKindInList(validatedList, qualifier.Kind()) {
+			b.updateLastNodeInListWithInvalidNode(validatedList, qualifier,
 				&common.ERROR_DUPLICATE_QUALIFIER, tree.ToToken(qualifier).Text())
 			continue
 		}
-		if this.isObjectNetworkQual(qualifier.Kind()) {
+		if b.isObjectNetworkQual(qualifier.Kind()) {
 			if hasNetworkQual {
-				this.updateLastNodeInListWithInvalidNode(validatedList, qualifier,
+				b.updateLastNodeInListWithInvalidNode(validatedList, qualifier,
 					&common.ERROR_MORE_THAN_ONE_OBJECT_NETWORK_QUALIFIERS)
 			} else {
 				validatedList = append(validatedList, qualifier)
@@ -3164,36 +3164,36 @@ func (this *BallerinaParser) createClassTypeQualNodeList(qualifierList []tree.ST
 			}
 			continue
 		}
-		if this.isClassTypeQual(qualifier.Kind()) {
+		if b.isClassTypeQual(qualifier.Kind()) {
 			validatedList = append(validatedList, qualifier)
 			continue
 		}
 		if len(qualifierList) == nextIndex {
-			this.addInvalidNodeToNextToken(qualifier, &common.ERROR_QUALIFIER_NOT_ALLOWED,
+			b.addInvalidNodeToNextToken(qualifier, &common.ERROR_QUALIFIER_NOT_ALLOWED,
 				tree.ToToken(qualifier).Text())
 		} else {
-			this.updateANodeInListWithLeadingInvalidNode(qualifierList, nextIndex, qualifier,
+			b.updateANodeInListWithLeadingInvalidNode(qualifierList, nextIndex, qualifier,
 				&common.ERROR_QUALIFIER_NOT_ALLOWED, tree.ToToken(qualifier).Text())
 		}
 	}
 	return tree.CreateNodeList(validatedList...)
 }
 
-func (this *BallerinaParser) createObjectTypeQualNodeList(qualifierList []tree.STNode) tree.STNode {
+func (b *BallerinaParser) createObjectTypeQualNodeList(qualifierList []tree.STNode) tree.STNode {
 	var validatedList []tree.STNode
 	hasNetworkQual := false
 	i := 0
 	for ; i < len(qualifierList); i++ {
 		qualifier := qualifierList[i]
 		nextIndex := (i + 1)
-		if this.isSyntaxKindInList(validatedList, qualifier.Kind()) {
-			this.updateLastNodeInListWithInvalidNode(validatedList, qualifier,
+		if b.isSyntaxKindInList(validatedList, qualifier.Kind()) {
+			b.updateLastNodeInListWithInvalidNode(validatedList, qualifier,
 				&common.ERROR_DUPLICATE_QUALIFIER, tree.ToToken(qualifier).Text())
 			continue
 		}
-		if this.isObjectNetworkQual(qualifier.Kind()) {
+		if b.isObjectNetworkQual(qualifier.Kind()) {
 			if hasNetworkQual {
-				this.updateLastNodeInListWithInvalidNode(validatedList, qualifier,
+				b.updateLastNodeInListWithInvalidNode(validatedList, qualifier,
 					&common.ERROR_MORE_THAN_ONE_OBJECT_NETWORK_QUALIFIERS)
 			} else {
 				validatedList = append(validatedList, qualifier)
@@ -3201,203 +3201,203 @@ func (this *BallerinaParser) createObjectTypeQualNodeList(qualifierList []tree.S
 			}
 			continue
 		}
-		if this.isObjectTypeQual(qualifier.Kind()) {
+		if b.isObjectTypeQual(qualifier.Kind()) {
 			validatedList = append(validatedList, qualifier)
 			continue
 		}
 		if len(qualifierList) == nextIndex {
-			this.addInvalidNodeToNextToken(qualifier, &common.ERROR_QUALIFIER_NOT_ALLOWED,
+			b.addInvalidNodeToNextToken(qualifier, &common.ERROR_QUALIFIER_NOT_ALLOWED,
 				tree.ToToken(qualifier).Text())
 		} else {
-			this.updateANodeInListWithLeadingInvalidNode(qualifierList, nextIndex, qualifier,
+			b.updateANodeInListWithLeadingInvalidNode(qualifierList, nextIndex, qualifier,
 				&common.ERROR_QUALIFIER_NOT_ALLOWED, tree.ToToken(qualifier).Text())
 		}
 	}
 	return tree.CreateNodeList(validatedList...)
 }
 
-func (this *BallerinaParser) parseClassKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseClassKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.CLASS_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_CLASS_KEYWORD)
-		return this.parseClassKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_CLASS_KEYWORD)
+		return b.parseClassKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseTypeKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseTypeKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.TYPE_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_TYPE_KEYWORD)
-		return this.parseTypeKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_TYPE_KEYWORD)
+		return b.parseTypeKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseTypeName() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseTypeName() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.IDENTIFIER_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_TYPE_NAME)
-		return this.parseTypeName()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_TYPE_NAME)
+		return b.parseTypeName()
 	}
 }
 
-func (this *BallerinaParser) parseClassName() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseClassName() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.IDENTIFIER_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_CLASS_NAME)
-		return this.parseClassName()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_CLASS_NAME)
+		return b.parseClassName()
 	}
 }
 
-func (this *BallerinaParser) parseRecordTypeDescriptor() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_RECORD_TYPE_DESCRIPTOR)
-	recordKeyword := this.parseRecordKeyword()
-	bodyStartDelimiter := this.parseRecordBodyStartDelimiter()
+func (b *BallerinaParser) parseRecordTypeDescriptor() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_RECORD_TYPE_DESCRIPTOR)
+	recordKeyword := b.parseRecordKeyword()
+	bodyStartDelimiter := b.parseRecordBodyStartDelimiter()
 	var recordFields []tree.STNode
-	token := this.peek()
+	token := b.peek()
 	recordRestDescriptor := tree.CreateEmptyNode()
-	for !this.isEndOfRecordTypeNode(token.Kind()) {
-		field := this.parseFieldOrRestDescriptor()
+	for !b.isEndOfRecordTypeNode(token.Kind()) {
+		field := b.parseFieldOrRestDescriptor()
 		if field == nil {
 			break
 		}
-		token = this.peek()
+		token = b.peek()
 		if (field.Kind() == common.RECORD_REST_TYPE) && (bodyStartDelimiter.Kind() == common.OPEN_BRACE_TOKEN) {
 			if len(recordFields) == 0 {
 				bodyStartDelimiter = tree.CloneWithTrailingInvalidNodeMinutiae(bodyStartDelimiter, field,
 					&common.ERROR_INCLUSIVE_RECORD_TYPE_CANNOT_CONTAIN_REST_FIELD)
 			} else {
-				this.updateLastNodeInListWithInvalidNode(recordFields, field,
+				b.updateLastNodeInListWithInvalidNode(recordFields, field,
 					&common.ERROR_INCLUSIVE_RECORD_TYPE_CANNOT_CONTAIN_REST_FIELD)
 			}
 			continue
 		} else if field.Kind() == common.RECORD_REST_TYPE {
 			recordRestDescriptor = field
-			for !this.isEndOfRecordTypeNode(token.Kind()) {
-				invalidField := this.parseFieldOrRestDescriptor()
+			for !b.isEndOfRecordTypeNode(token.Kind()) {
+				invalidField := b.parseFieldOrRestDescriptor()
 				if invalidField == nil {
 					break
 				}
 				recordRestDescriptor = tree.CloneWithTrailingInvalidNodeMinutiae(recordRestDescriptor,
 					invalidField, &common.ERROR_MORE_RECORD_FIELDS_AFTER_REST_FIELD)
-				token = this.peek()
+				token = b.peek()
 			}
 			break
 		}
 		recordFields = append(recordFields, field)
 	}
 	fields := tree.CreateNodeList(recordFields...)
-	bodyEndDelimiter := this.parseRecordBodyCloseDelimiter(bodyStartDelimiter.Kind())
-	this.endContext()
+	bodyEndDelimiter := b.parseRecordBodyCloseDelimiter(bodyStartDelimiter.Kind())
+	b.endContext()
 	return tree.CreateRecordTypeDescriptorNode(recordKeyword, bodyStartDelimiter, fields,
 		recordRestDescriptor, bodyEndDelimiter)
 }
 
-func (this *BallerinaParser) parseRecordBodyStartDelimiter() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseRecordBodyStartDelimiter() tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.OPEN_BRACE_PIPE_TOKEN:
-		return this.parseClosedRecordBodyStart()
+		return b.parseClosedRecordBodyStart()
 	case common.OPEN_BRACE_TOKEN:
-		return this.parseOpenBrace()
+		return b.parseOpenBrace()
 	default:
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_RECORD_BODY_START)
-		return this.parseRecordBodyStartDelimiter()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_RECORD_BODY_START)
+		return b.parseRecordBodyStartDelimiter()
 	}
 }
 
-func (this *BallerinaParser) parseClosedRecordBodyStart() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseClosedRecordBodyStart() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.OPEN_BRACE_PIPE_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_CLOSED_RECORD_BODY_START)
-		return this.parseClosedRecordBodyStart()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_CLOSED_RECORD_BODY_START)
+		return b.parseClosedRecordBodyStart()
 	}
 }
 
-func (this *BallerinaParser) parseRecordBodyCloseDelimiter(startingDelimeter common.SyntaxKind) tree.STNode {
+func (b *BallerinaParser) parseRecordBodyCloseDelimiter(startingDelimeter common.SyntaxKind) tree.STNode {
 	if startingDelimeter == common.OPEN_BRACE_PIPE_TOKEN {
-		return this.parseClosedRecordBodyEnd()
+		return b.parseClosedRecordBodyEnd()
 	}
-	return this.parseCloseBrace()
+	return b.parseCloseBrace()
 }
 
-func (this *BallerinaParser) parseClosedRecordBodyEnd() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseClosedRecordBodyEnd() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.CLOSE_BRACE_PIPE_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_CLOSED_RECORD_BODY_END)
-		return this.parseClosedRecordBodyEnd()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_CLOSED_RECORD_BODY_END)
+		return b.parseClosedRecordBodyEnd()
 	}
 }
 
-func (this *BallerinaParser) parseRecordKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseRecordKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.RECORD_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_RECORD_KEYWORD)
-		return this.parseRecordKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_RECORD_KEYWORD)
+		return b.parseRecordKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseFieldOrRestDescriptor() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseFieldOrRestDescriptor() tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.CLOSE_BRACE_TOKEN,
 		common.CLOSE_BRACE_PIPE_TOKEN:
 		return nil
 	case common.ASTERISK_TOKEN:
-		this.startContext(common.PARSER_RULE_CONTEXT_RECORD_FIELD)
-		asterisk := this.consume()
-		ty := this.parseTypeReferenceInTypeInclusion()
-		semicolonToken := this.parseSemicolon()
-		this.endContext()
+		b.startContext(common.PARSER_RULE_CONTEXT_RECORD_FIELD)
+		asterisk := b.consume()
+		ty := b.parseTypeReferenceInTypeInclusion()
+		semicolonToken := b.parseSemicolon()
+		b.endContext()
 		return tree.CreateTypeReferenceNode(asterisk, ty, semicolonToken)
 	case common.DOCUMENTATION_STRING,
 		common.AT_TOKEN:
-		return this.parseRecordField()
+		return b.parseRecordField()
 	default:
-		if this.isTypeStartingToken(nextToken.Kind()) {
-			return this.parseRecordField()
+		if b.isTypeStartingToken(nextToken.Kind()) {
+			return b.parseRecordField()
 		}
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_RECORD_FIELD_OR_RECORD_END)
-		return this.parseFieldOrRestDescriptor()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_RECORD_FIELD_OR_RECORD_END)
+		return b.parseFieldOrRestDescriptor()
 	}
 }
 
-func (this *BallerinaParser) parseRecordField() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_RECORD_FIELD)
-	metadata := this.parseMetaData()
-	fieldOrRestDesc := this.parseRecordFieldInner(this.peek(), metadata)
-	this.endContext()
+func (b *BallerinaParser) parseRecordField() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_RECORD_FIELD)
+	metadata := b.parseMetaData()
+	fieldOrRestDesc := b.parseRecordFieldInner(b.peek(), metadata)
+	b.endContext()
 	return fieldOrRestDesc
 }
 
-func (this *BallerinaParser) parseRecordFieldInner(nextToken tree.STToken, metadata tree.STNode) tree.STNode {
+func (b *BallerinaParser) parseRecordFieldInner(nextToken tree.STToken, metadata tree.STNode) tree.STNode {
 	if nextToken.Kind() != common.READONLY_KEYWORD {
-		ty := this.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_RECORD_FIELD)
-		return this.parseFieldOrRestDescriptorRhs(metadata, ty)
+		ty := b.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_RECORD_FIELD)
+		return b.parseFieldOrRestDescriptorRhs(metadata, ty)
 	}
 	var ty tree.STNode
 	var readOnlyQualifier tree.STNode
-	readOnlyQualifier = this.parseReadonlyKeyword()
-	nextToken = this.peek()
+	readOnlyQualifier = b.parseReadonlyKeyword()
+	nextToken = b.peek()
 	if nextToken.Kind() == common.IDENTIFIER_TOKEN {
-		fieldNameOrTypeDesc := this.parseQualifiedIdentifier(common.PARSER_RULE_CONTEXT_RECORD_FIELD_NAME_OR_TYPE_NAME)
+		fieldNameOrTypeDesc := b.parseQualifiedIdentifier(common.PARSER_RULE_CONTEXT_RECORD_FIELD_NAME_OR_TYPE_NAME)
 		if fieldNameOrTypeDesc.Kind() == common.QUALIFIED_NAME_REFERENCE {
 			ty = fieldNameOrTypeDesc
 		} else {
-			nextToken = this.peek()
+			nextToken = b.peek()
 			switch nextToken.Kind() {
 			case common.SEMICOLON_TOKEN, common.EQUAL_TOKEN:
 				ty = CreateBuiltinSimpleNameReference(readOnlyQualifier)
@@ -3407,32 +3407,32 @@ func (this *BallerinaParser) parseRecordFieldInner(nextToken tree.STToken, metad
 					panic("expected STSimpleNameReferenceNode")
 				}
 				fieldName := nameNode.Name
-				return this.parseFieldDescriptorRhs(metadata, readOnlyQualifier, ty, fieldName)
+				return b.parseFieldDescriptorRhs(metadata, readOnlyQualifier, ty, fieldName)
 			default:
-				ty = this.parseComplexTypeDescriptor(fieldNameOrTypeDesc,
+				ty = b.parseComplexTypeDescriptor(fieldNameOrTypeDesc,
 					common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_RECORD_FIELD, false)
 			}
 		}
 	} else if nextToken.Kind() == common.ELLIPSIS_TOKEN {
 		ty = CreateBuiltinSimpleNameReference(readOnlyQualifier)
-		return this.parseFieldOrRestDescriptorRhs(metadata, ty)
-	} else if this.isTypeStartingToken(nextToken.Kind()) {
-		ty = this.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_RECORD_FIELD)
+		return b.parseFieldOrRestDescriptorRhs(metadata, ty)
+	} else if b.isTypeStartingToken(nextToken.Kind()) {
+		ty = b.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_RECORD_FIELD)
 	} else {
 		readOnlyQualifier = CreateBuiltinSimpleNameReference(readOnlyQualifier)
-		ty = this.parseComplexTypeDescriptor(readOnlyQualifier, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_RECORD_FIELD, false)
+		ty = b.parseComplexTypeDescriptor(readOnlyQualifier, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_RECORD_FIELD, false)
 		readOnlyQualifier = tree.CreateEmptyNode()
 	}
-	return this.parseIndividualRecordField(metadata, readOnlyQualifier, ty)
+	return b.parseIndividualRecordField(metadata, readOnlyQualifier, ty)
 }
 
-func (this *BallerinaParser) parseIndividualRecordField(metadata tree.STNode, readOnlyQualifier tree.STNode, ty tree.STNode) tree.STNode {
-	fieldName := this.parseVariableName()
-	return this.parseFieldDescriptorRhs(metadata, readOnlyQualifier, ty, fieldName)
+func (b *BallerinaParser) parseIndividualRecordField(metadata tree.STNode, readOnlyQualifier tree.STNode, ty tree.STNode) tree.STNode {
+	fieldName := b.parseVariableName()
+	return b.parseFieldDescriptorRhs(metadata, readOnlyQualifier, ty, fieldName)
 }
 
-func (this *BallerinaParser) parseTypeReferenceInTypeInclusion() tree.STNode {
-	typeReference := this.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_REFERENCE_IN_TYPE_INCLUSION)
+func (b *BallerinaParser) parseTypeReferenceInTypeInclusion() tree.STNode {
+	typeReference := b.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_REFERENCE_IN_TYPE_INCLUSION)
 	if typeReference.Kind() == common.SIMPLE_NAME_REFERENCE {
 		if typeReference.HasDiagnostics() {
 			emptyNameReference := tree.CreateSimpleNameReferenceNode(tree.CreateMissingTokenWithDiagnostics(common.IDENTIFIER_TOKEN, &common.ERROR_MISSING_IDENTIFIER))
@@ -3449,149 +3449,149 @@ func (this *BallerinaParser) parseTypeReferenceInTypeInclusion() tree.STNode {
 	return emptyNameReference
 }
 
-func (this *BallerinaParser) parseTypeReference() tree.STNode {
-	return this.parseTypeReferenceInner(false)
+func (b *BallerinaParser) parseTypeReference() tree.STNode {
+	return b.parseTypeReferenceInner(false)
 }
 
-func (this *BallerinaParser) parseTypeReferenceInner(isInConditionalExpr bool) tree.STNode {
-	return this.parseQualifiedIdentifierInner(common.PARSER_RULE_CONTEXT_TYPE_REFERENCE, isInConditionalExpr)
+func (b *BallerinaParser) parseTypeReferenceInner(isInConditionalExpr bool) tree.STNode {
+	return b.parseQualifiedIdentifierInner(common.PARSER_RULE_CONTEXT_TYPE_REFERENCE, isInConditionalExpr)
 }
 
-func (this *BallerinaParser) parseQualifiedIdentifier(currentCtx common.ParserRuleContext) tree.STNode {
-	return this.parseQualifiedIdentifierInner(currentCtx, false)
+func (b *BallerinaParser) parseQualifiedIdentifier(currentCtx common.ParserRuleContext) tree.STNode {
+	return b.parseQualifiedIdentifierInner(currentCtx, false)
 }
 
-func (this *BallerinaParser) parseQualifiedIdentifierInner(currentCtx common.ParserRuleContext, isInConditionalExpr bool) tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseQualifiedIdentifierInner(currentCtx common.ParserRuleContext, isInConditionalExpr bool) tree.STNode {
+	token := b.peek()
 	var typeRefOrPkgRef tree.STNode
 	if token.Kind() == common.IDENTIFIER_TOKEN {
-		typeRefOrPkgRef = this.consume()
-	} else if this.isQualifiedIdentifierPredeclaredPrefix(token.Kind()) {
-		preDeclaredPrefix := this.consume()
+		typeRefOrPkgRef = b.consume()
+	} else if b.isQualifiedIdentifierPredeclaredPrefix(token.Kind()) {
+		preDeclaredPrefix := b.consume()
 		typeRefOrPkgRef = tree.CreateIdentifierToken(preDeclaredPrefix.Text(),
 			preDeclaredPrefix.LeadingMinutiae(), preDeclaredPrefix.TrailingMinutiae())
 	} else {
-		this.recover(token, currentCtx, false)
-		if this.peek().Kind() != common.IDENTIFIER_TOKEN {
-			this.addInvalidTokenToNextToken(this.errorHandler.ConsumeInvalidToken())
-			return this.parseQualifiedIdentifierInner(currentCtx, isInConditionalExpr)
+		b.recover(token, currentCtx, false)
+		if b.peek().Kind() != common.IDENTIFIER_TOKEN {
+			b.addInvalidTokenToNextToken(b.errorHandler.ConsumeInvalidToken())
+			return b.parseQualifiedIdentifierInner(currentCtx, isInConditionalExpr)
 		}
-		typeRefOrPkgRef = this.consume()
+		typeRefOrPkgRef = b.consume()
 	}
-	return this.parseQualifiedIdentifierNode(typeRefOrPkgRef, isInConditionalExpr)
+	return b.parseQualifiedIdentifierNode(typeRefOrPkgRef, isInConditionalExpr)
 }
 
-func (this *BallerinaParser) parseQualifiedIdentifierNode(identifier tree.STNode, isInConditionalExpr bool) tree.STNode {
-	nextToken := this.peekN(1)
+func (b *BallerinaParser) parseQualifiedIdentifierNode(identifier tree.STNode, isInConditionalExpr bool) tree.STNode {
+	nextToken := b.peekN(1)
 	if nextToken.Kind() != common.COLON_TOKEN {
 		return tree.CreateSimpleNameReferenceNode(identifier)
 	}
-	if isInConditionalExpr && (this.hasTrailingMinutiae(identifier) || this.hasTrailingMinutiae(nextToken)) {
+	if isInConditionalExpr && (b.hasTrailingMinutiae(identifier) || b.hasTrailingMinutiae(nextToken)) {
 		return tree.GetSimpleNameRefNode(identifier)
 	}
-	nextNextToken := this.peekN(2)
+	nextNextToken := b.peekN(2)
 	switch nextNextToken.Kind() {
 	case common.IDENTIFIER_TOKEN:
-		colon := this.consume()
-		varOrFuncName := this.consume()
-		return this.createQualifiedNameReferenceNode(identifier, colon, varOrFuncName)
+		colon := b.consume()
+		varOrFuncName := b.consume()
+		return b.createQualifiedNameReferenceNode(identifier, colon, varOrFuncName)
 	case common.COLON_TOKEN:
-		this.addInvalidTokenToNextToken(this.errorHandler.ConsumeInvalidToken())
-		return this.parseQualifiedIdentifierNode(identifier, isInConditionalExpr)
+		b.addInvalidTokenToNextToken(b.errorHandler.ConsumeInvalidToken())
+		return b.parseQualifiedIdentifierNode(identifier, isInConditionalExpr)
 	default:
-		if (nextNextToken.Kind() == common.MAP_KEYWORD) && (this.peekN(3).Kind() != common.LT_TOKEN) {
-			colon := this.consume()
-			mapKeyword := this.consume()
+		if (nextNextToken.Kind() == common.MAP_KEYWORD) && (b.peekN(3).Kind() != common.LT_TOKEN) {
+			colon := b.consume()
+			mapKeyword := b.consume()
 			refName := tree.CreateIdentifierTokenWithDiagnostics(mapKeyword.Text(),
 				mapKeyword.LeadingMinutiae(), mapKeyword.TrailingMinutiae(), mapKeyword.Diagnostics())
-			return this.createQualifiedNameReferenceNode(identifier, colon, refName)
+			return b.createQualifiedNameReferenceNode(identifier, colon, refName)
 		}
 		if isInConditionalExpr {
 			return tree.GetSimpleNameRefNode(identifier)
 		}
-		colon := this.consume()
+		colon := b.consume()
 		varOrFuncName := tree.CreateMissingTokenWithDiagnostics(common.IDENTIFIER_TOKEN,
 			&common.ERROR_MISSING_IDENTIFIER)
-		return this.createQualifiedNameReferenceNode(identifier, colon, varOrFuncName)
+		return b.createQualifiedNameReferenceNode(identifier, colon, varOrFuncName)
 	}
 }
 
-func (this *BallerinaParser) createQualifiedNameReferenceNode(identifier tree.STNode, colon tree.STNode, varOrFuncName tree.STNode) tree.STNode {
-	if this.hasTrailingMinutiae(identifier) || this.hasTrailingMinutiae(colon) {
+func (b *BallerinaParser) createQualifiedNameReferenceNode(identifier tree.STNode, colon tree.STNode, varOrFuncName tree.STNode) tree.STNode {
+	if b.hasTrailingMinutiae(identifier) || b.hasTrailingMinutiae(colon) {
 		colon = tree.AddDiagnostic(colon,
 			&common.ERROR_INTERVENING_WHITESPACES_ARE_NOT_ALLOWED)
 	}
 	return tree.CreateQualifiedNameReferenceNode(identifier, colon, varOrFuncName)
 }
 
-func (this *BallerinaParser) parseFieldOrRestDescriptorRhs(metadata tree.STNode, ty tree.STNode) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseFieldOrRestDescriptorRhs(metadata tree.STNode, ty tree.STNode) tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.ELLIPSIS_TOKEN:
-		this.reportInvalidMetaData(metadata, "record rest descriptor")
-		ellipsis := this.parseEllipsis()
-		semicolonToken := this.parseSemicolon()
+		b.reportInvalidMetaData(metadata, "record rest descriptor")
+		ellipsis := b.parseEllipsis()
+		semicolonToken := b.parseSemicolon()
 		return tree.CreateRecordRestDescriptorNode(ty, ellipsis, semicolonToken)
 	case common.IDENTIFIER_TOKEN:
 		readonlyQualifier := tree.CreateEmptyNode()
-		return this.parseIndividualRecordField(metadata, readonlyQualifier, ty)
+		return b.parseIndividualRecordField(metadata, readonlyQualifier, ty)
 	default:
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_FIELD_OR_REST_DESCIPTOR_RHS)
-		return this.parseFieldOrRestDescriptorRhs(metadata, ty)
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_FIELD_OR_REST_DESCIPTOR_RHS)
+		return b.parseFieldOrRestDescriptorRhs(metadata, ty)
 	}
 }
 
-func (this *BallerinaParser) parseFieldDescriptorRhs(metadata tree.STNode, readonlyQualifier tree.STNode, ty tree.STNode, fieldName tree.STNode) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseFieldDescriptorRhs(metadata tree.STNode, readonlyQualifier tree.STNode, ty tree.STNode, fieldName tree.STNode) tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.SEMICOLON_TOKEN:
 		questionMarkToken := tree.CreateEmptyNode()
-		semicolonToken := this.parseSemicolon()
+		semicolonToken := b.parseSemicolon()
 		return tree.CreateRecordFieldNode(metadata, readonlyQualifier, ty, fieldName,
 			questionMarkToken, semicolonToken)
 	case common.QUESTION_MARK_TOKEN:
-		questionMarkToken := this.parseQuestionMark()
-		semicolonToken := this.parseSemicolon()
+		questionMarkToken := b.parseQuestionMark()
+		semicolonToken := b.parseSemicolon()
 		return tree.CreateRecordFieldNode(metadata, readonlyQualifier, ty, fieldName,
 			questionMarkToken, semicolonToken)
 	case common.EQUAL_TOKEN:
-		equalsToken := this.parseAssignOp()
-		expression := this.parseExpression()
-		semicolonToken := this.parseSemicolon()
+		equalsToken := b.parseAssignOp()
+		expression := b.parseExpression()
+		semicolonToken := b.parseSemicolon()
 		return tree.CreateRecordFieldWithDefaultValueNode(metadata, readonlyQualifier, ty, fieldName,
 			equalsToken, expression, semicolonToken)
 	default:
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_FIELD_DESCRIPTOR_RHS)
-		return this.parseFieldDescriptorRhs(metadata, readonlyQualifier, ty, fieldName)
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_FIELD_DESCRIPTOR_RHS)
+		return b.parseFieldDescriptorRhs(metadata, readonlyQualifier, ty, fieldName)
 	}
 }
 
-func (this *BallerinaParser) parseQuestionMark() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseQuestionMark() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.QUESTION_MARK_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_QUESTION_MARK)
-		return this.parseQuestionMark()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_QUESTION_MARK)
+		return b.parseQuestionMark()
 	}
 }
 
-func (this *BallerinaParser) parseStatements() tree.STNode {
-	res, _ := this.parseStatementsInner(nil)
+func (b *BallerinaParser) parseStatements() tree.STNode {
+	res, _ := b.parseStatementsInner(nil)
 	return res
 }
 
-func (this *BallerinaParser) parseStatementsInner(stmts []tree.STNode) (tree.STNode, []tree.STNode) {
-	for !this.isEndOfStatements() {
-		stmt := this.parseStatement()
+func (b *BallerinaParser) parseStatementsInner(stmts []tree.STNode) (tree.STNode, []tree.STNode) {
+	for !b.isEndOfStatements() {
+		stmt := b.parseStatement()
 		if stmt == nil {
 			break
 		}
 		if stmt.Kind() == common.NAMED_WORKER_DECLARATION {
-			this.addInvalidNodeToNextToken(stmt, &common.ERROR_NAMED_WORKER_NOT_ALLOWED_HERE)
+			b.addInvalidNodeToNextToken(stmt, &common.ERROR_NAMED_WORKER_NOT_ALLOWED_HERE)
 			continue
 		}
-		if this.validateStatement(stmt) {
+		if b.validateStatement(stmt) {
 			continue
 		}
 		stmts = append(stmts, stmt)
@@ -3599,130 +3599,130 @@ func (this *BallerinaParser) parseStatementsInner(stmts []tree.STNode) (tree.STN
 	return tree.CreateNodeList(stmts...), stmts
 }
 
-func (this *BallerinaParser) parseStatement() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseStatement() tree.STNode {
+	nextToken := b.peek()
 	annots := tree.CreateEmptyNodeList()
 	switch nextToken.Kind() {
 	case common.CLOSE_BRACE_TOKEN, common.EOF_TOKEN:
 		return nil
 	case common.SEMICOLON_TOKEN:
-		this.addInvalidTokenToNextToken(this.errorHandler.ConsumeInvalidToken())
-		return this.parseStatement()
+		b.addInvalidTokenToNextToken(b.errorHandler.ConsumeInvalidToken())
+		return b.parseStatement()
 	case common.AT_TOKEN:
-		annots = this.parseOptionalAnnotations()
+		annots = b.parseOptionalAnnotations()
 	default:
-		if this.isStatementStartingToken(nextToken.Kind()) {
+		if b.isStatementStartingToken(nextToken.Kind()) {
 			break
 		}
-		token := this.peek()
-		solution := this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_STATEMENT)
+		token := b.peek()
+		solution := b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_STATEMENT)
 		if solution.Action == ACTION_KEEP {
 			break
 		}
-		return this.parseStatement()
+		return b.parseStatement()
 	}
-	return this.parseStatementWithAnnotataions(annots)
+	return b.parseStatementWithAnnotataions(annots)
 }
 
-func (this *BallerinaParser) validateStatement(statement tree.STNode) bool {
+func (b *BallerinaParser) validateStatement(statement tree.STNode) bool {
 	switch statement.Kind() {
 	case common.LOCAL_TYPE_DEFINITION_STATEMENT:
-		this.addInvalidNodeToNextToken(statement, &common.ERROR_LOCAL_TYPE_DEFINITION_NOT_ALLOWED)
+		b.addInvalidNodeToNextToken(statement, &common.ERROR_LOCAL_TYPE_DEFINITION_NOT_ALLOWED)
 		return true
 	case common.CONST_DECLARATION:
-		this.addInvalidNodeToNextToken(statement, &common.ERROR_LOCAL_CONST_DECL_NOT_ALLOWED)
+		b.addInvalidNodeToNextToken(statement, &common.ERROR_LOCAL_CONST_DECL_NOT_ALLOWED)
 		return true
 	default:
 		return false
 	}
 }
 
-func (this *BallerinaParser) getAnnotations(nullbaleAnnot tree.STNode) tree.STNode {
+func (b *BallerinaParser) getAnnotations(nullbaleAnnot tree.STNode) tree.STNode {
 	if nullbaleAnnot != nil {
 		return nullbaleAnnot
 	}
 	return tree.CreateEmptyNodeList()
 }
 
-func (this *BallerinaParser) parseStatementWithAnnotataions(annots tree.STNode) tree.STNode {
-	result, _ := this.parseStatementInner(annots, nil)
+func (b *BallerinaParser) parseStatementWithAnnotataions(annots tree.STNode) tree.STNode {
+	result, _ := b.parseStatementInner(annots, nil)
 	return result
 }
 
-func (this *BallerinaParser) parseStatementInner(annots tree.STNode, qualifiers []tree.STNode) (tree.STNode, []tree.STNode) {
-	qualifiers = this.parseTypeDescQualifiers(qualifiers)
-	nextToken := this.peek()
-	if this.isPredeclaredIdentifier(nextToken.Kind()) {
-		return this.parseStmtStartsWithTypeOrExpr(this.getAnnotations(annots), qualifiers), qualifiers
+func (b *BallerinaParser) parseStatementInner(annots tree.STNode, qualifiers []tree.STNode) (tree.STNode, []tree.STNode) {
+	qualifiers = b.parseTypeDescQualifiers(qualifiers)
+	nextToken := b.peek()
+	if b.isPredeclaredIdentifier(nextToken.Kind()) {
+		return b.parseStmtStartsWithTypeOrExpr(b.getAnnotations(annots), qualifiers), qualifiers
 	}
 	switch nextToken.Kind() {
 	case common.CLOSE_BRACE_TOKEN,
 		common.EOF_TOKEN:
 		publicQualifier := tree.CreateEmptyNode()
-		return this.createMissingSimpleVarDeclInnerWithQualifiers(this.getAnnotations(annots), publicQualifier, qualifiers, false), qualifiers
+		return b.createMissingSimpleVarDeclInnerWithQualifiers(b.getAnnotations(annots), publicQualifier, qualifiers, false), qualifiers
 	case common.SEMICOLON_TOKEN:
-		this.addInvalidTokenToNextToken(this.errorHandler.ConsumeInvalidToken())
-		return this.parseStatementInner(annots, qualifiers)
+		b.addInvalidTokenToNextToken(b.errorHandler.ConsumeInvalidToken())
+		return b.parseStatementInner(annots, qualifiers)
 	case common.FINAL_KEYWORD:
-		this.reportInvalidQualifierList(qualifiers)
-		finalKeyword := this.consume()
-		return this.parseVariableDecl(this.getAnnotations(annots), finalKeyword), qualifiers
+		b.reportInvalidQualifierList(qualifiers)
+		finalKeyword := b.consume()
+		return b.parseVariableDecl(b.getAnnotations(annots), finalKeyword), qualifiers
 	case common.IF_KEYWORD:
-		this.reportInvalidStatementAnnots(annots, qualifiers)
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseIfElseBlock(), qualifiers
+		b.reportInvalidStatementAnnots(annots, qualifiers)
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseIfElseBlock(), qualifiers
 	case common.WHILE_KEYWORD:
-		this.reportInvalidStatementAnnots(annots, qualifiers)
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseWhileStatement(), qualifiers
+		b.reportInvalidStatementAnnots(annots, qualifiers)
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseWhileStatement(), qualifiers
 	case common.DO_KEYWORD:
-		this.reportInvalidStatementAnnots(annots, qualifiers)
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseDoStatement(), qualifiers
+		b.reportInvalidStatementAnnots(annots, qualifiers)
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseDoStatement(), qualifiers
 	case common.PANIC_KEYWORD:
-		this.reportInvalidStatementAnnots(annots, qualifiers)
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parsePanicStatement(), qualifiers
+		b.reportInvalidStatementAnnots(annots, qualifiers)
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parsePanicStatement(), qualifiers
 	case common.CONTINUE_KEYWORD:
-		this.reportInvalidStatementAnnots(annots, qualifiers)
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseContinueStatement(), qualifiers
+		b.reportInvalidStatementAnnots(annots, qualifiers)
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseContinueStatement(), qualifiers
 	case common.BREAK_KEYWORD:
-		this.reportInvalidStatementAnnots(annots, qualifiers)
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseBreakStatement(), qualifiers
+		b.reportInvalidStatementAnnots(annots, qualifiers)
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseBreakStatement(), qualifiers
 	case common.RETURN_KEYWORD:
-		this.reportInvalidStatementAnnots(annots, qualifiers)
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseReturnStatement(), qualifiers
+		b.reportInvalidStatementAnnots(annots, qualifiers)
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseReturnStatement(), qualifiers
 	case common.FAIL_KEYWORD:
-		this.reportInvalidStatementAnnots(annots, qualifiers)
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseFailStatement(), qualifiers
+		b.reportInvalidStatementAnnots(annots, qualifiers)
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseFailStatement(), qualifiers
 	case common.TYPE_KEYWORD:
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseLocalTypeDefinitionStatement(this.getAnnotations(annots)), qualifiers
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseLocalTypeDefinitionStatement(b.getAnnotations(annots)), qualifiers
 	case common.CONST_KEYWORD:
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseConstantDeclaration(annots, tree.CreateEmptyNode()), qualifiers
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseConstantDeclaration(annots, tree.CreateEmptyNode()), qualifiers
 	case common.LOCK_KEYWORD:
-		this.reportInvalidStatementAnnots(annots, qualifiers)
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseLockStatement(), qualifiers
+		b.reportInvalidStatementAnnots(annots, qualifiers)
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseLockStatement(), qualifiers
 	case common.OPEN_BRACE_TOKEN:
-		this.reportInvalidStatementAnnots(annots, qualifiers)
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseStatementStartsWithOpenBrace(), qualifiers
+		b.reportInvalidStatementAnnots(annots, qualifiers)
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseStatementStartsWithOpenBrace(), qualifiers
 	case common.WORKER_KEYWORD:
-		return this.parseNamedWorkerDeclaration(this.getAnnotations(annots), qualifiers), qualifiers
+		return b.parseNamedWorkerDeclaration(b.getAnnotations(annots), qualifiers), qualifiers
 	case common.FORK_KEYWORD:
-		this.reportInvalidStatementAnnots(annots, qualifiers)
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseForkStatement(), qualifiers
+		b.reportInvalidStatementAnnots(annots, qualifiers)
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseForkStatement(), qualifiers
 	case common.FOREACH_KEYWORD:
-		this.reportInvalidStatementAnnots(annots, qualifiers)
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseForEachStatement(), qualifiers
+		b.reportInvalidStatementAnnots(annots, qualifiers)
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseForEachStatement(), qualifiers
 	case common.START_KEYWORD,
 		common.CHECK_KEYWORD,
 		common.CHECKPANIC_KEYWORD,
@@ -3732,25 +3732,25 @@ func (this *BallerinaParser) parseStatementInner(annots tree.STNode, qualifiers 
 		common.WAIT_KEYWORD,
 		common.FROM_KEYWORD,
 		common.COMMIT_KEYWORD:
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseExpressionStatement(this.getAnnotations(annots)), qualifiers
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseExpressionStatement(b.getAnnotations(annots)), qualifiers
 	case common.XMLNS_KEYWORD:
-		this.reportInvalidStatementAnnots(annots, qualifiers)
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseXMLNamespaceDeclaration(false), qualifiers
+		b.reportInvalidStatementAnnots(annots, qualifiers)
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseXMLNamespaceDeclaration(false), qualifiers
 	case common.TRANSACTION_KEYWORD:
-		return this.parseTransactionStmtOrVarDecl(annots, qualifiers, this.consume())
+		return b.parseTransactionStmtOrVarDecl(annots, qualifiers, b.consume())
 	case common.RETRY_KEYWORD:
-		this.reportInvalidStatementAnnots(annots, qualifiers)
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseRetryStatement(), qualifiers
+		b.reportInvalidStatementAnnots(annots, qualifiers)
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseRetryStatement(), qualifiers
 	case common.ROLLBACK_KEYWORD:
-		this.reportInvalidStatementAnnots(annots, qualifiers)
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseRollbackStatement(), qualifiers
+		b.reportInvalidStatementAnnots(annots, qualifiers)
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseRollbackStatement(), qualifiers
 	case common.OPEN_BRACKET_TOKEN:
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseStatementStartsWithOpenBracket(this.getAnnotations(annots), false), qualifiers
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseStatementStartsWithOpenBracket(b.getAnnotations(annots), false), qualifiers
 	case common.FUNCTION_KEYWORD,
 		common.OPEN_PAREN_TOKEN,
 		common.DECIMAL_INTEGER_LITERAL_TOKEN,
@@ -3763,110 +3763,110 @@ func (this *BallerinaParser) parseStatementInner(annots tree.STNode, qualifiers 
 		common.HEX_FLOATING_POINT_LITERAL_TOKEN,
 		common.STRING_KEYWORD,
 		common.XML_KEYWORD:
-		return this.parseStmtStartsWithTypeOrExpr(this.getAnnotations(annots), qualifiers), qualifiers
+		return b.parseStmtStartsWithTypeOrExpr(b.getAnnotations(annots), qualifiers), qualifiers
 	case common.MATCH_KEYWORD:
-		this.reportInvalidStatementAnnots(annots, qualifiers)
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseMatchStatement(), qualifiers
+		b.reportInvalidStatementAnnots(annots, qualifiers)
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseMatchStatement(), qualifiers
 	case common.ERROR_KEYWORD:
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseErrorTypeDescOrErrorBP(this.getAnnotations(annots)), qualifiers
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseErrorTypeDescOrErrorBP(b.getAnnotations(annots)), qualifiers
 	default:
-		if this.isValidExpressionStart(nextToken.Kind(), 1) {
-			this.reportInvalidQualifierList(qualifiers)
-			return this.parseStatementStartWithExpr(this.getAnnotations(annots)), qualifiers
+		if b.isValidExpressionStart(nextToken.Kind(), 1) {
+			b.reportInvalidQualifierList(qualifiers)
+			return b.parseStatementStartWithExpr(b.getAnnotations(annots)), qualifiers
 		}
-		if this.isTypeStartingToken(nextToken.Kind()) {
+		if b.isTypeStartingToken(nextToken.Kind()) {
 			publicQualifier := tree.CreateEmptyNode()
-			res, _ := this.parseVariableDeclInner(this.getAnnotations(annots), publicQualifier, nil, qualifiers,
+			res, _ := b.parseVariableDeclInner(b.getAnnotations(annots), publicQualifier, nil, qualifiers,
 				false)
 			return res, qualifiers
 		}
-		token := this.peek()
-		solution := this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_STATEMENT_WITHOUT_ANNOTS)
+		token := b.peek()
+		solution := b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_STATEMENT_WITHOUT_ANNOTS)
 		if solution.Action == ACTION_KEEP {
-			this.reportInvalidQualifierList(qualifiers)
+			b.reportInvalidQualifierList(qualifiers)
 			finalKeyword := tree.CreateEmptyNode()
-			return this.parseVariableDecl(this.getAnnotations(annots), finalKeyword), qualifiers
+			return b.parseVariableDecl(b.getAnnotations(annots), finalKeyword), qualifiers
 		}
-		return this.parseStatementInner(annots, qualifiers)
+		return b.parseStatementInner(annots, qualifiers)
 	}
 }
 
-func (this *BallerinaParser) parseVariableDecl(annots tree.STNode, finalKeyword tree.STNode) tree.STNode {
+func (b *BallerinaParser) parseVariableDecl(annots tree.STNode, finalKeyword tree.STNode) tree.STNode {
 	var typeDescQualifiers []tree.STNode
 	var varDecQualifiers []tree.STNode
 	if finalKeyword != nil {
 		varDecQualifiers = append(varDecQualifiers, finalKeyword)
 	}
 	publicQualifier := tree.CreateEmptyNode()
-	res, _ := this.parseVariableDeclInner(annots, publicQualifier, varDecQualifiers, typeDescQualifiers, false)
+	res, _ := b.parseVariableDeclInner(annots, publicQualifier, varDecQualifiers, typeDescQualifiers, false)
 	return res
 }
 
 // Return result, and modified varDeclQuals
-func (this *BallerinaParser) parseVariableDeclInner(annots tree.STNode, publicQualifier tree.STNode, varDeclQuals []tree.STNode, typeDescQualifiers []tree.STNode, isModuleVar bool) (tree.STNode, []tree.STNode) {
-	this.startContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
-	typeBindingPattern := this.parseTypedBindingPatternInner(typeDescQualifiers,
+func (b *BallerinaParser) parseVariableDeclInner(annots tree.STNode, publicQualifier tree.STNode, varDeclQuals []tree.STNode, typeDescQualifiers []tree.STNode, isModuleVar bool) (tree.STNode, []tree.STNode) {
+	b.startContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+	typeBindingPattern := b.parseTypedBindingPatternInner(typeDescQualifiers,
 		common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
-	return this.parseVarDeclRhsInner(annots, publicQualifier, varDeclQuals, typeBindingPattern, isModuleVar)
+	return b.parseVarDeclRhsInner(annots, publicQualifier, varDeclQuals, typeBindingPattern, isModuleVar)
 }
 
 // Return result, and modified qualifiers
-func (this *BallerinaParser) parseVarDeclTypeDescRhs(typeDesc tree.STNode, metadata tree.STNode, qualifiers []tree.STNode, isTypedBindingPattern bool, isModuleVar bool) (tree.STNode, []tree.STNode) {
+func (b *BallerinaParser) parseVarDeclTypeDescRhs(typeDesc tree.STNode, metadata tree.STNode, qualifiers []tree.STNode, isTypedBindingPattern bool, isModuleVar bool) (tree.STNode, []tree.STNode) {
 	publicQualifier := tree.CreateEmptyNode()
-	return this.parseVarDeclTypeDescRhsInner(typeDesc, metadata, publicQualifier, qualifiers, isTypedBindingPattern,
+	return b.parseVarDeclTypeDescRhsInner(typeDesc, metadata, publicQualifier, qualifiers, isTypedBindingPattern,
 		isModuleVar)
 }
 
 // Return result, and modified qualifiers
-func (this *BallerinaParser) parseVarDeclTypeDescRhsInner(typeDesc tree.STNode, metadata tree.STNode, publicQual tree.STNode, qualifiers []tree.STNode, isTypedBindingPattern bool, isModuleVar bool) (tree.STNode, []tree.STNode) {
-	this.startContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
-	typeDesc = this.parseComplexTypeDescriptor(typeDesc,
+func (b *BallerinaParser) parseVarDeclTypeDescRhsInner(typeDesc tree.STNode, metadata tree.STNode, publicQual tree.STNode, qualifiers []tree.STNode, isTypedBindingPattern bool, isModuleVar bool) (tree.STNode, []tree.STNode) {
+	b.startContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+	typeDesc = b.parseComplexTypeDescriptor(typeDesc,
 		common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN, isTypedBindingPattern)
-	typedBindingPattern := this.parseTypedBindingPatternTypeRhs(typeDesc,
+	typedBindingPattern := b.parseTypedBindingPatternTypeRhs(typeDesc,
 		common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
-	return this.parseVarDeclRhsInner(metadata, publicQual, qualifiers, typedBindingPattern, isModuleVar)
+	return b.parseVarDeclRhsInner(metadata, publicQual, qualifiers, typedBindingPattern, isModuleVar)
 }
 
 // Return result, and modified varDeclQuals
-func (this *BallerinaParser) parseVarDeclRhs(metadata tree.STNode, varDeclQuals []tree.STNode, typedBindingPattern tree.STNode, isModuleVar bool) (tree.STNode, []tree.STNode) {
+func (b *BallerinaParser) parseVarDeclRhs(metadata tree.STNode, varDeclQuals []tree.STNode, typedBindingPattern tree.STNode, isModuleVar bool) (tree.STNode, []tree.STNode) {
 	publicQualifier := tree.CreateEmptyNode()
-	return this.parseVarDeclRhsInner(metadata, publicQualifier, varDeclQuals, typedBindingPattern, isModuleVar)
+	return b.parseVarDeclRhsInner(metadata, publicQualifier, varDeclQuals, typedBindingPattern, isModuleVar)
 }
 
 // Return result, and modified varDeclQuals
-func (this *BallerinaParser) parseVarDeclRhsInner(metadata tree.STNode, publicQualifier tree.STNode, varDeclQuals []tree.STNode, typedBindingPattern tree.STNode, isModuleVar bool) (tree.STNode, []tree.STNode) {
+func (b *BallerinaParser) parseVarDeclRhsInner(metadata tree.STNode, publicQualifier tree.STNode, varDeclQuals []tree.STNode, typedBindingPattern tree.STNode, isModuleVar bool) (tree.STNode, []tree.STNode) {
 	var assign tree.STNode
 	var expr tree.STNode
 	var semicolon tree.STNode
 	hasVarInit := false
-	isConfigurable := isModuleVar && this.isSyntaxKindInList(varDeclQuals, common.CONFIGURABLE_KEYWORD)
+	isConfigurable := isModuleVar && b.isSyntaxKindInList(varDeclQuals, common.CONFIGURABLE_KEYWORD)
 
-	nextToken := this.peek()
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.EQUAL_TOKEN:
-		assign = this.parseAssignOp()
+		assign = b.parseAssignOp()
 		if isModuleVar {
 			if isConfigurable {
-				expr = this.parseConfigurableVarDeclRhs()
+				expr = b.parseConfigurableVarDeclRhs()
 			} else {
-				expr = this.parseExpression()
+				expr = b.parseExpression()
 			}
 		} else {
-			expr = this.parseActionOrExpression()
+			expr = b.parseActionOrExpression()
 		}
-		semicolon = this.parseSemicolon()
+		semicolon = b.parseSemicolon()
 		hasVarInit = true
 	case common.SEMICOLON_TOKEN:
 		assign = tree.CreateEmptyNode()
 		expr = tree.CreateEmptyNode()
-		semicolon = this.parseSemicolon()
+		semicolon = b.parseSemicolon()
 	default:
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_VAR_DECL_STMT_RHS)
-		return this.parseVarDeclRhsInner(metadata, publicQualifier, varDeclQuals, typedBindingPattern, isModuleVar)
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_VAR_DECL_STMT_RHS)
+		return b.parseVarDeclRhsInner(metadata, publicQualifier, varDeclQuals, typedBindingPattern, isModuleVar)
 	}
-	this.endContext()
+	b.endContext()
 	if !hasVarInit {
 		typedBindingPatternNode, ok := typedBindingPattern.(*tree.STTypedBindingPatternNode)
 		if !ok {
@@ -3881,7 +3881,7 @@ func (this *BallerinaParser) parseVarDeclRhsInner(metadata tree.STNode, publicQu
 		}
 	}
 	if isModuleVar {
-		return this.createModuleVarDeclaration(metadata, publicQualifier, varDeclQuals, typedBindingPattern, assign,
+		return b.createModuleVarDeclaration(metadata, publicQualifier, varDeclQuals, typedBindingPattern, assign,
 			expr, semicolon, isConfigurable, hasVarInit)
 	}
 	var finalKeyword tree.STNode
@@ -3897,54 +3897,54 @@ func (this *BallerinaParser) parseVarDeclRhsInner(metadata tree.STNode, publicQu
 		expr, semicolon), varDeclQuals
 }
 
-func (this *BallerinaParser) parseConfigurableVarDeclRhs() tree.STNode {
+func (b *BallerinaParser) parseConfigurableVarDeclRhs() tree.STNode {
 	var expr tree.STNode
-	nextToken := this.peek()
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.QUESTION_MARK_TOKEN:
-		expr = tree.CreateRequiredExpressionNode(this.consume())
+		expr = tree.CreateRequiredExpressionNode(b.consume())
 	default:
-		if this.isValidExprStart(nextToken.Kind()) {
-			expr = this.parseExpression()
+		if b.isValidExprStart(nextToken.Kind()) {
+			expr = b.parseExpression()
 			break
 		}
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_CONFIG_VAR_DECL_RHS)
-		return this.parseConfigurableVarDeclRhs()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_CONFIG_VAR_DECL_RHS)
+		return b.parseConfigurableVarDeclRhs()
 	}
 	return expr
 }
 
-func (this *BallerinaParser) createModuleVarDeclaration(metadata tree.STNode, publicQualifier tree.STNode, varDeclQuals []tree.STNode, typedBindingPattern tree.STNode, assign tree.STNode, expr tree.STNode, semicolon tree.STNode, isConfigurable bool, hasVarInit bool) (tree.STNode, []tree.STNode) {
+func (b *BallerinaParser) createModuleVarDeclaration(metadata tree.STNode, publicQualifier tree.STNode, varDeclQuals []tree.STNode, typedBindingPattern tree.STNode, assign tree.STNode, expr tree.STNode, semicolon tree.STNode, isConfigurable bool, hasVarInit bool) (tree.STNode, []tree.STNode) {
 	if hasVarInit || len(varDeclQuals) == 0 {
-		return this.createModuleVarDeclarationInner(metadata, publicQualifier, varDeclQuals, typedBindingPattern, assign,
+		return b.createModuleVarDeclarationInner(metadata, publicQualifier, varDeclQuals, typedBindingPattern, assign,
 			expr, semicolon), varDeclQuals
 	}
 	if isConfigurable {
-		return this.createConfigurableModuleVarDeclWithMissingInitializer(metadata, publicQualifier, varDeclQuals,
+		return b.createConfigurableModuleVarDeclWithMissingInitializer(metadata, publicQualifier, varDeclQuals,
 			typedBindingPattern, semicolon), varDeclQuals
 	}
-	lastQualifier := this.getLastNodeInList(varDeclQuals)
+	lastQualifier := b.getLastNodeInList(varDeclQuals)
 	if lastQualifier.Kind() == common.ISOLATED_KEYWORD {
 		lastQualifier = varDeclQuals[len(varDeclQuals)-1]
 		varDeclQuals = varDeclQuals[:len(varDeclQuals)-1]
-		typedBindingPattern = this.modifyTypedBindingPatternWithIsolatedQualifier(typedBindingPattern, lastQualifier)
+		typedBindingPattern = b.modifyTypedBindingPatternWithIsolatedQualifier(typedBindingPattern, lastQualifier)
 	}
-	return this.createModuleVarDeclarationInner(metadata, publicQualifier, varDeclQuals, typedBindingPattern, assign, expr,
+	return b.createModuleVarDeclarationInner(metadata, publicQualifier, varDeclQuals, typedBindingPattern, assign, expr,
 		semicolon), varDeclQuals
 }
 
-func (this *BallerinaParser) createConfigurableModuleVarDeclWithMissingInitializer(metadata tree.STNode, publicQualifier tree.STNode, varDeclQuals []tree.STNode, typedBindingPattern tree.STNode, semicolon tree.STNode) tree.STNode {
+func (b *BallerinaParser) createConfigurableModuleVarDeclWithMissingInitializer(metadata tree.STNode, publicQualifier tree.STNode, varDeclQuals []tree.STNode, typedBindingPattern tree.STNode, semicolon tree.STNode) tree.STNode {
 	var assign tree.STNode
 	assign = tree.CreateMissingToken(common.EQUAL_TOKEN, nil)
 	assign = tree.AddDiagnostic(assign,
 		&common.ERROR_CONFIGURABLE_VARIABLE_MUST_BE_INITIALIZED_OR_REQUIRED)
 	questionMarkToken := tree.CreateMissingToken(common.QUESTION_MARK_TOKEN, nil)
 	expr := tree.CreateRequiredExpressionNode(questionMarkToken)
-	return this.createModuleVarDeclarationInner(metadata, publicQualifier, varDeclQuals, typedBindingPattern, assign, expr,
+	return b.createModuleVarDeclarationInner(metadata, publicQualifier, varDeclQuals, typedBindingPattern, assign, expr,
 		semicolon)
 }
 
-func (this *BallerinaParser) createModuleVarDeclarationInner(metadata tree.STNode, publicQualifier tree.STNode, varDeclQuals []tree.STNode, typedBindingPattern tree.STNode, assign tree.STNode, expr tree.STNode, semicolon tree.STNode) tree.STNode {
+func (b *BallerinaParser) createModuleVarDeclarationInner(metadata tree.STNode, publicQualifier tree.STNode, varDeclQuals []tree.STNode, typedBindingPattern tree.STNode, assign tree.STNode, expr tree.STNode, semicolon tree.STNode) tree.STNode {
 	if publicQualifier != nil {
 		typedBindingPatternNode, ok := typedBindingPattern.(*tree.STTypedBindingPatternNode)
 		if !ok {
@@ -3952,15 +3952,15 @@ func (this *BallerinaParser) createModuleVarDeclarationInner(metadata tree.STNod
 		}
 		if typedBindingPatternNode.TypeDescriptor.Kind() == common.VAR_TYPE_DESC {
 			if len(varDeclQuals) != 0 {
-				this.updateFirstNodeInListWithLeadingInvalidNode(varDeclQuals, publicQualifier,
+				b.updateFirstNodeInListWithLeadingInvalidNode(varDeclQuals, publicQualifier,
 					&common.ERROR_VARIABLE_DECLARED_WITH_VAR_CANNOT_BE_PUBLIC)
 			} else {
 				typedBindingPattern = tree.CloneWithLeadingInvalidNodeMinutiae(typedBindingPattern,
 					publicQualifier, &common.ERROR_VARIABLE_DECLARED_WITH_VAR_CANNOT_BE_PUBLIC)
 			}
 			publicQualifier = tree.CreateEmptyNode()
-		} else if this.isSyntaxKindInList(varDeclQuals, common.ISOLATED_KEYWORD) {
-			this.updateFirstNodeInListWithLeadingInvalidNode(varDeclQuals, publicQualifier,
+		} else if b.isSyntaxKindInList(varDeclQuals, common.ISOLATED_KEYWORD) {
+			b.updateFirstNodeInListWithLeadingInvalidNode(varDeclQuals, publicQualifier,
 				&common.ERROR_ISOLATED_VAR_CANNOT_BE_DECLARED_AS_PUBLIC)
 			publicQualifier = tree.CreateEmptyNode()
 		}
@@ -3970,22 +3970,22 @@ func (this *BallerinaParser) createModuleVarDeclarationInner(metadata tree.STNod
 		typedBindingPattern, assign, expr, semicolon)
 }
 
-func (this *BallerinaParser) createMissingSimpleVarDecl(isModuleVar bool) tree.STNode {
+func (b *BallerinaParser) createMissingSimpleVarDecl(isModuleVar bool) tree.STNode {
 	var metadata tree.STNode
 	if isModuleVar {
 		metadata = tree.CreateEmptyNode()
 	} else {
 		metadata = tree.CreateEmptyNodeList()
 	}
-	return this.createMissingSimpleVarDeclInner(metadata, isModuleVar)
+	return b.createMissingSimpleVarDeclInner(metadata, isModuleVar)
 }
 
-func (this *BallerinaParser) createMissingSimpleVarDeclInner(metadata tree.STNode, isModuleVar bool) tree.STNode {
+func (b *BallerinaParser) createMissingSimpleVarDeclInner(metadata tree.STNode, isModuleVar bool) tree.STNode {
 	publicQualifier := tree.CreateEmptyNode()
-	return this.createMissingSimpleVarDeclInnerWithQualifiers(metadata, publicQualifier, nil, isModuleVar)
+	return b.createMissingSimpleVarDeclInnerWithQualifiers(metadata, publicQualifier, nil, isModuleVar)
 }
 
-func (this *BallerinaParser) createMissingSimpleVarDeclInnerWithQualifiers(metadata tree.STNode, publicQualifier tree.STNode, qualifiers []tree.STNode, isModuleVar bool) tree.STNode {
+func (b *BallerinaParser) createMissingSimpleVarDeclInnerWithQualifiers(metadata tree.STNode, publicQualifier tree.STNode, qualifiers []tree.STNode, isModuleVar bool) tree.STNode {
 	emptyNode := tree.CreateEmptyNode()
 	simpleTypeDescIdentifier := tree.CreateMissingTokenWithDiagnostics(common.IDENTIFIER_TOKEN,
 		&common.ERROR_MISSING_TYPE_DESC)
@@ -3997,22 +3997,22 @@ func (this *BallerinaParser) createMissingSimpleVarDeclInnerWithQualifiers(metad
 	captureBP := tree.CreateCaptureBindingPatternNode(identifier)
 	typedBindingPattern := tree.CreateTypedBindingPatternNode(simpleNameRef, captureBP)
 	if isModuleVar {
-		varDeclQuals, qualifiers := this.extractVarDeclQualifiers(qualifiers, true)
-		typedBindingPattern = this.modifyNodeWithInvalidTokenList(qualifiers, typedBindingPattern)
-		if this.isSyntaxKindInList(varDeclQuals, common.CONFIGURABLE_KEYWORD) {
-			return this.createConfigurableModuleVarDeclWithMissingInitializer(metadata, publicQualifier, varDeclQuals,
+		varDeclQuals, qualifiers := b.extractVarDeclQualifiers(qualifiers, true)
+		typedBindingPattern = b.modifyNodeWithInvalidTokenList(qualifiers, typedBindingPattern)
+		if b.isSyntaxKindInList(varDeclQuals, common.CONFIGURABLE_KEYWORD) {
+			return b.createConfigurableModuleVarDeclWithMissingInitializer(metadata, publicQualifier, varDeclQuals,
 				typedBindingPattern, semicolon)
 		}
 		varDeclQualNodeList := tree.CreateNodeList(varDeclQuals...)
 		return tree.CreateModuleVariableDeclarationNode(metadata, publicQualifier, varDeclQualNodeList,
 			typedBindingPattern, emptyNode, emptyNode, semicolon)
 	}
-	typedBindingPattern = this.modifyNodeWithInvalidTokenList(qualifiers, typedBindingPattern)
+	typedBindingPattern = b.modifyNodeWithInvalidTokenList(qualifiers, typedBindingPattern)
 	return tree.CreateVariableDeclarationNode(metadata, emptyNode, typedBindingPattern, emptyNode,
 		emptyNode, semicolon)
 }
 
-func (this *BallerinaParser) createMissingWhereClause() tree.STNode {
+func (b *BallerinaParser) createMissingWhereClause() tree.STNode {
 	whereKeyword := tree.CreateMissingTokenWithDiagnostics(common.WHERE_KEYWORD,
 		&common.ERROR_MISSING_WHERE_KEYWORD)
 	missingIdentifier := tree.CreateMissingTokenWithDiagnostics(
@@ -4021,7 +4021,7 @@ func (this *BallerinaParser) createMissingWhereClause() tree.STNode {
 	return tree.CreateWhereClauseNode(whereKeyword, missingExpr)
 }
 
-func (this *BallerinaParser) createMissingSimpleObjectFieldInner(metadata tree.STNode, qualifiers []tree.STNode, isObjectTypeDesc bool) (tree.STNode, []tree.STNode) {
+func (b *BallerinaParser) createMissingSimpleObjectFieldInner(metadata tree.STNode, qualifiers []tree.STNode, isObjectTypeDesc bool) (tree.STNode, []tree.STNode) {
 	emptyNode := tree.CreateEmptyNode()
 	simpleTypeDescIdentifier := tree.CreateMissingTokenWithDiagnostics(common.IDENTIFIER_TOKEN,
 		&common.ERROR_MISSING_TYPE_DESC)
@@ -4030,27 +4030,27 @@ func (this *BallerinaParser) createMissingSimpleObjectFieldInner(metadata tree.S
 		&common.ERROR_MISSING_FIELD_NAME)
 	semicolon := tree.CreateMissingTokenWithDiagnostics(common.SEMICOLON_TOKEN,
 		&common.ERROR_MISSING_SEMICOLON_TOKEN)
-	objectFieldQualifiers, qualifiers := this.extractObjectFieldQualifiers(qualifiers, isObjectTypeDesc)
+	objectFieldQualifiers, qualifiers := b.extractObjectFieldQualifiers(qualifiers, isObjectTypeDesc)
 	objectFieldQualNodeList := tree.CreateNodeList(objectFieldQualifiers...)
-	simpleNameRef = this.modifyNodeWithInvalidTokenList(qualifiers, simpleNameRef)
+	simpleNameRef = b.modifyNodeWithInvalidTokenList(qualifiers, simpleNameRef)
 	metadataNode, ok := metadata.(*tree.STMetadataNode)
 	if !ok {
 		panic("expected STMetadataNode")
 	}
 	if metadata != nil {
-		metadata = this.addMetadataNotAttachedDiagnostic(*metadataNode)
+		metadata = b.addMetadataNotAttachedDiagnostic(*metadataNode)
 	}
 	return tree.CreateObjectFieldNode(metadata, emptyNode, objectFieldQualNodeList,
 		simpleNameRef, identifier, emptyNode, emptyNode, semicolon), qualifiers
 }
 
-func (this *BallerinaParser) createMissingSimpleObjectField() tree.STNode {
+func (b *BallerinaParser) createMissingSimpleObjectField() tree.STNode {
 	metadata := tree.CreateEmptyNode()
-	res, _ := this.createMissingSimpleObjectFieldInner(metadata, nil, false)
+	res, _ := b.createMissingSimpleObjectFieldInner(metadata, nil, false)
 	return res
 }
 
-func (this *BallerinaParser) modifyNodeWithInvalidTokenList(qualifiers []tree.STNode, node tree.STNode) tree.STNode {
+func (b *BallerinaParser) modifyNodeWithInvalidTokenList(qualifiers []tree.STNode, node tree.STNode) tree.STNode {
 	i := (len(qualifiers) - 1)
 	for ; i >= 0; i-- {
 		qualifier := qualifiers[i]
@@ -4059,7 +4059,7 @@ func (this *BallerinaParser) modifyNodeWithInvalidTokenList(qualifiers []tree.ST
 	return node
 }
 
-func (this *BallerinaParser) modifyTypedBindingPatternWithIsolatedQualifier(typedBindingPattern tree.STNode, isolatedQualifier tree.STNode) tree.STNode {
+func (b *BallerinaParser) modifyTypedBindingPatternWithIsolatedQualifier(typedBindingPattern tree.STNode, isolatedQualifier tree.STNode) tree.STNode {
 	typedBindingPatternNode, ok := typedBindingPattern.(*tree.STTypedBindingPatternNode)
 	if !ok {
 		panic("expected STTypedBindingPatternNode")
@@ -4068,9 +4068,9 @@ func (this *BallerinaParser) modifyTypedBindingPatternWithIsolatedQualifier(type
 	bindingPattern := typedBindingPatternNode.BindingPattern
 	switch typeDescriptor.Kind() {
 	case common.OBJECT_TYPE_DESC:
-		typeDescriptor = this.modifyObjectTypeDescWithALeadingQualifier(typeDescriptor, isolatedQualifier)
+		typeDescriptor = b.modifyObjectTypeDescWithALeadingQualifier(typeDescriptor, isolatedQualifier)
 	case common.FUNCTION_TYPE_DESC:
-		typeDescriptor = this.modifyFuncTypeDescWithALeadingQualifier(typeDescriptor, isolatedQualifier)
+		typeDescriptor = b.modifyFuncTypeDescWithALeadingQualifier(typeDescriptor, isolatedQualifier)
 	default:
 		typeDescriptor = tree.CloneWithLeadingInvalidNodeMinutiae(typeDescriptor, isolatedQualifier,
 			&common.ERROR_QUALIFIER_NOT_ALLOWED, tree.ToToken(isolatedQualifier).Text())
@@ -4078,7 +4078,7 @@ func (this *BallerinaParser) modifyTypedBindingPatternWithIsolatedQualifier(type
 	return tree.CreateTypedBindingPatternNode(typeDescriptor, bindingPattern)
 }
 
-func (this *BallerinaParser) modifyObjectTypeDescWithALeadingQualifier(objectTypeDesc tree.STNode, newQualifier tree.STNode) tree.STNode {
+func (b *BallerinaParser) modifyObjectTypeDescWithALeadingQualifier(objectTypeDesc tree.STNode, newQualifier tree.STNode) tree.STNode {
 	objectTypeDescriptorNode, ok := objectTypeDesc.(*tree.STObjectTypeDescriptorNode)
 	if !ok {
 		panic("expected STObjectTypeDescriptorNode")
@@ -4088,24 +4088,24 @@ func (this *BallerinaParser) modifyObjectTypeDescWithALeadingQualifier(objectTyp
 	if !ok {
 		panic("expected STNodeList")
 	}
-	newObjectTypeQualifiers := this.modifyNodeListWithALeadingQualifier(qualifierList, newQualifier)
+	newObjectTypeQualifiers := b.modifyNodeListWithALeadingQualifier(qualifierList, newQualifier)
 	return tree.CreateObjectTypeDescriptorNode(newObjectTypeQualifiers, objectTypeDescriptorNode.ObjectKeyword,
 		objectTypeDescriptorNode.OpenBrace, objectTypeDescriptorNode.Members,
 		objectTypeDescriptorNode.CloseBrace)
 }
 
-func (this *BallerinaParser) modifyFuncTypeDescWithALeadingQualifier(funcTypeDesc tree.STNode, newQualifier tree.STNode) tree.STNode {
+func (b *BallerinaParser) modifyFuncTypeDescWithALeadingQualifier(funcTypeDesc tree.STNode, newQualifier tree.STNode) tree.STNode {
 	funcTypeDescriptorNode, ok := funcTypeDesc.(*tree.STFunctionTypeDescriptorNode)
 	if !ok {
 		panic("expected STFunctionTypeDescriptorNode")
 	}
 	qualifierList := funcTypeDescriptorNode.QualifierList
-	newfuncTypeQualifiers := this.modifyNodeListWithALeadingQualifier(qualifierList, newQualifier)
+	newfuncTypeQualifiers := b.modifyNodeListWithALeadingQualifier(qualifierList, newQualifier)
 	return tree.CreateFunctionTypeDescriptorNode(newfuncTypeQualifiers, funcTypeDescriptorNode.FunctionKeyword,
 		funcTypeDescriptorNode.FunctionSignature)
 }
 
-func (this *BallerinaParser) modifyNodeListWithALeadingQualifier(qualifiers tree.STNode, newQualifier tree.STNode) tree.STNode {
+func (b *BallerinaParser) modifyNodeListWithALeadingQualifier(qualifiers tree.STNode, newQualifier tree.STNode) tree.STNode {
 	var newQualifierList []tree.STNode
 	newQualifierList = append(newQualifierList, newQualifier)
 	qualifierNodeList, ok := qualifiers.(*tree.STNodeList)
@@ -4116,7 +4116,7 @@ func (this *BallerinaParser) modifyNodeListWithALeadingQualifier(qualifiers tree
 	for ; i < qualifierNodeList.Size(); i++ {
 		qualifier := qualifierNodeList.Get(i)
 		if qualifier.Kind() == newQualifier.Kind() {
-			this.updateLastNodeInListWithInvalidNode(newQualifierList, qualifier,
+			b.updateLastNodeInListWithInvalidNode(newQualifierList, qualifier,
 				&common.ERROR_DUPLICATE_QUALIFIER, tree.ToToken(qualifier).Text())
 		} else {
 			newQualifierList = append(newQualifierList, qualifier)
@@ -4125,24 +4125,24 @@ func (this *BallerinaParser) modifyNodeListWithALeadingQualifier(qualifiers tree
 	return tree.CreateNodeList(newQualifierList...)
 }
 
-func (this *BallerinaParser) parseAssignmentStmtRhs(lvExpr tree.STNode) tree.STNode {
-	assign := this.parseAssignOp()
-	expr := this.parseActionOrExpression()
-	semicolon := this.parseSemicolon()
-	this.endContext()
+func (b *BallerinaParser) parseAssignmentStmtRhs(lvExpr tree.STNode) tree.STNode {
+	assign := b.parseAssignOp()
+	expr := b.parseActionOrExpression()
+	semicolon := b.parseSemicolon()
+	b.endContext()
 	if lvExpr.Kind() == common.ERROR_CONSTRUCTOR {
 		errConstructor, ok := lvExpr.(*tree.STErrorConstructorExpressionNode)
 		if !ok {
 			panic("expected STErrorConstructorExpressionNode")
 		}
-		if this.isPossibleErrorBindingPattern(*errConstructor) {
-			lvExpr = this.getBindingPattern(lvExpr, false)
+		if b.isPossibleErrorBindingPattern(*errConstructor) {
+			lvExpr = b.getBindingPattern(lvExpr, false)
 		}
 	}
-	if this.isWildcardBP(lvExpr) {
-		lvExpr = this.getWildcardBindingPattern(lvExpr)
+	if b.isWildcardBP(lvExpr) {
+		lvExpr = b.getWildcardBindingPattern(lvExpr)
 	}
-	lvExprValid := this.isValidLVExpr(lvExpr)
+	lvExprValid := b.isValidLVExpr(lvExpr)
 	if !lvExprValid {
 		identifier := tree.CreateMissingToken(common.IDENTIFIER_TOKEN, nil)
 		simpleNameRef := tree.CreateSimpleNameReferenceNode(identifier)
@@ -4152,23 +4152,23 @@ func (this *BallerinaParser) parseAssignmentStmtRhs(lvExpr tree.STNode) tree.STN
 	return tree.CreateAssignmentStatementNode(lvExpr, assign, expr, semicolon)
 }
 
-func (this *BallerinaParser) parseExpression() tree.STNode {
-	return this.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_DEFAULT, true, false)
+func (b *BallerinaParser) parseExpression() tree.STNode {
+	return b.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_DEFAULT, true, false)
 }
 
-func (this *BallerinaParser) parseActionOrExpression() tree.STNode {
-	return this.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_DEFAULT, true, true)
+func (b *BallerinaParser) parseActionOrExpression() tree.STNode {
+	return b.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_DEFAULT, true, true)
 }
 
-func (this *BallerinaParser) parseActionOrExpressionInLhs(annots tree.STNode) tree.STNode {
-	return this.parseExpressionInner(OPERATOR_PRECEDENCE_DEFAULT, annots, false, true, false)
+func (b *BallerinaParser) parseActionOrExpressionInLhs(annots tree.STNode) tree.STNode {
+	return b.parseExpressionInner(OPERATOR_PRECEDENCE_DEFAULT, annots, false, true, false)
 }
 
-func (this *BallerinaParser) parseExpressionPossibleRhsExpr(isRhsExpr bool) tree.STNode {
-	return this.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_DEFAULT, isRhsExpr, false)
+func (b *BallerinaParser) parseExpressionPossibleRhsExpr(isRhsExpr bool) tree.STNode {
+	return b.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_DEFAULT, isRhsExpr, false)
 }
 
-func (this *BallerinaParser) isValidLVExpr(expression tree.STNode) bool {
+func (b *BallerinaParser) isValidLVExpr(expression tree.STNode) bool {
 	switch expression.Kind() {
 	case common.SIMPLE_NAME_REFERENCE,
 		common.QUALIFIED_NAME_REFERENCE,
@@ -4182,20 +4182,20 @@ func (this *BallerinaParser) isValidLVExpr(expression tree.STNode) bool {
 		if !ok {
 			panic("expected STFieldAccessExpressionNode")
 		}
-		return this.isValidLVMemberExpr(fieldAccessExpressionNode.Expression)
+		return b.isValidLVMemberExpr(fieldAccessExpressionNode.Expression)
 	case common.INDEXED_EXPRESSION:
 		indexedExpressionNode, ok := expression.(*tree.STIndexedExpressionNode)
 		if !ok {
 			panic("expected STIndexedExpressionNode")
 		}
-		return this.isValidLVMemberExpr(indexedExpressionNode.ContainerExpression)
+		return b.isValidLVMemberExpr(indexedExpressionNode.ContainerExpression)
 	default:
 		_, ok := expression.(*tree.STMissingToken)
 		return ok
 	}
 }
 
-func (this *BallerinaParser) isValidLVMemberExpr(expression tree.STNode) bool {
+func (b *BallerinaParser) isValidLVMemberExpr(expression tree.STNode) bool {
 	switch expression.Kind() {
 	case common.SIMPLE_NAME_REFERENCE,
 		common.QUALIFIED_NAME_REFERENCE:
@@ -4205,74 +4205,74 @@ func (this *BallerinaParser) isValidLVMemberExpr(expression tree.STNode) bool {
 		if !ok {
 			panic("expected STFieldAccessExpressionNode")
 		}
-		return this.isValidLVMemberExpr(fieldAccessExpressionNode.Expression)
+		return b.isValidLVMemberExpr(fieldAccessExpressionNode.Expression)
 	case common.INDEXED_EXPRESSION:
 		indexedExpressionNode, ok := expression.(*tree.STIndexedExpressionNode)
 		if !ok {
 			panic("expected STIndexedExpressionNode")
 		}
-		return this.isValidLVMemberExpr(indexedExpressionNode.ContainerExpression)
+		return b.isValidLVMemberExpr(indexedExpressionNode.ContainerExpression)
 	case common.BRACED_EXPRESSION:
 		bracedExpressionNode, ok := expression.(*tree.STBracedExpressionNode)
 		if !ok {
 			panic("expected STBracedExpressionNode")
 		}
-		return this.isValidLVMemberExpr(bracedExpressionNode.Expression)
+		return b.isValidLVMemberExpr(bracedExpressionNode.Expression)
 	default:
 		_, ok := expression.(*tree.STMissingToken)
 		return ok
 	}
 }
 
-func (this *BallerinaParser) parseExpressionWithPrecedence(precedenceLevel OperatorPrecedence, isRhsExpr bool, allowActions bool) tree.STNode {
-	return this.parseExpressionWithConditional(precedenceLevel, isRhsExpr, allowActions, false)
+func (b *BallerinaParser) parseExpressionWithPrecedence(precedenceLevel OperatorPrecedence, isRhsExpr bool, allowActions bool) tree.STNode {
+	return b.parseExpressionWithConditional(precedenceLevel, isRhsExpr, allowActions, false)
 }
 
-func (this *BallerinaParser) parseExpressionWithConditional(precedenceLevel OperatorPrecedence, isRhsExpr bool, allowActions bool, isInConditionalExpr bool) tree.STNode {
-	return this.parseExpressionWithMatchGuard(precedenceLevel, isRhsExpr, allowActions, false, isInConditionalExpr)
+func (b *BallerinaParser) parseExpressionWithConditional(precedenceLevel OperatorPrecedence, isRhsExpr bool, allowActions bool, isInConditionalExpr bool) tree.STNode {
+	return b.parseExpressionWithMatchGuard(precedenceLevel, isRhsExpr, allowActions, false, isInConditionalExpr)
 }
 
-func (this *BallerinaParser) parseExpressionWithMatchGuard(precedenceLevel OperatorPrecedence, isRhsExpr bool, allowActions bool, isInMatchGuard bool, isInConditionalExpr bool) tree.STNode {
-	expr := this.parseTerminalExpression(isRhsExpr, allowActions, isInConditionalExpr)
-	return this.parseExpressionRhsInner(precedenceLevel, expr, isRhsExpr, allowActions, isInMatchGuard, isInConditionalExpr)
+func (b *BallerinaParser) parseExpressionWithMatchGuard(precedenceLevel OperatorPrecedence, isRhsExpr bool, allowActions bool, isInMatchGuard bool, isInConditionalExpr bool) tree.STNode {
+	expr := b.parseTerminalExpression(isRhsExpr, allowActions, isInConditionalExpr)
+	return b.parseExpressionRhsInner(precedenceLevel, expr, isRhsExpr, allowActions, isInMatchGuard, isInConditionalExpr)
 }
 
-func (this *BallerinaParser) invalidateActionAndGetMissingExpr(node tree.STNode) tree.STNode {
+func (b *BallerinaParser) invalidateActionAndGetMissingExpr(node tree.STNode) tree.STNode {
 	var identifier tree.STNode
 	identifier = tree.CreateMissingToken(common.IDENTIFIER_TOKEN, nil)
 	identifier = tree.CloneWithTrailingInvalidNodeMinutiae(identifier, node, &common.ERROR_EXPRESSION_EXPECTED_ACTION_FOUND)
 	return tree.CreateSimpleNameReferenceNode(identifier)
 }
 
-func (this *BallerinaParser) parseExpressionInner(precedenceLevel OperatorPrecedence, annots tree.STNode, isRhsExpr bool, allowActions bool, isInConditionalExpr bool) tree.STNode {
-	expr := this.parseTerminalExpressionWithAnnotations(annots, isRhsExpr, allowActions, isInConditionalExpr)
-	return this.parseExpressionRhsInner(precedenceLevel, expr, isRhsExpr, allowActions, false, isInConditionalExpr)
+func (b *BallerinaParser) parseExpressionInner(precedenceLevel OperatorPrecedence, annots tree.STNode, isRhsExpr bool, allowActions bool, isInConditionalExpr bool) tree.STNode {
+	expr := b.parseTerminalExpressionWithAnnotations(annots, isRhsExpr, allowActions, isInConditionalExpr)
+	return b.parseExpressionRhsInner(precedenceLevel, expr, isRhsExpr, allowActions, false, isInConditionalExpr)
 }
 
-func (this *BallerinaParser) parseTerminalExpression(isRhsExpr bool, allowActions bool, isInConditionalExpr bool) tree.STNode {
+func (b *BallerinaParser) parseTerminalExpression(isRhsExpr bool, allowActions bool, isInConditionalExpr bool) tree.STNode {
 	annots := tree.CreateEmptyNodeList()
-	if this.peek().Kind() == common.AT_TOKEN {
-		annots = this.parseOptionalAnnotations()
+	if b.peek().Kind() == common.AT_TOKEN {
+		annots = b.parseOptionalAnnotations()
 	}
-	return this.parseTerminalExpressionWithAnnotations(annots, isRhsExpr, allowActions, isInConditionalExpr)
+	return b.parseTerminalExpressionWithAnnotations(annots, isRhsExpr, allowActions, isInConditionalExpr)
 }
 
-func (this *BallerinaParser) parseTerminalExpressionWithAnnotations(annots tree.STNode, isRhsExpr bool, allowActions bool, isInConditionalExpr bool) tree.STNode {
-	return this.parseTerminalExpressionInner(annots, nil, isRhsExpr, allowActions, isInConditionalExpr)
+func (b *BallerinaParser) parseTerminalExpressionWithAnnotations(annots tree.STNode, isRhsExpr bool, allowActions bool, isInConditionalExpr bool) tree.STNode {
+	return b.parseTerminalExpressionInner(annots, nil, isRhsExpr, allowActions, isInConditionalExpr)
 }
 
-func (this *BallerinaParser) parseTerminalExpressionInner(annots tree.STNode, qualifiers []tree.STNode, isRhsExpr bool, allowActions bool, isInConditionalExpr bool) tree.STNode {
-	qualifiers = this.parseExprQualifiers(qualifiers)
-	nextToken := this.peek()
+func (b *BallerinaParser) parseTerminalExpressionInner(annots tree.STNode, qualifiers []tree.STNode, isRhsExpr bool, allowActions bool, isInConditionalExpr bool) tree.STNode {
+	qualifiers = b.parseExprQualifiers(qualifiers)
+	nextToken := b.peek()
 	annotNodeList := annots.(*tree.STNodeList)
-	if (!annotNodeList.IsEmpty()) && (!this.isAnnotAllowedExprStart(nextToken)) {
-		annots = this.addAnnotNotAttachedDiagnostic(annotNodeList)
-		qualifierNodeList := this.createObjectTypeQualNodeList(qualifiers)
-		return this.createMissingObjectConstructor(annots, qualifierNodeList)
+	if (!annotNodeList.IsEmpty()) && (!b.isAnnotAllowedExprStart(nextToken)) {
+		annots = b.addAnnotNotAttachedDiagnostic(annotNodeList)
+		qualifierNodeList := b.createObjectTypeQualNodeList(qualifiers)
+		return b.createMissingObjectConstructor(annots, qualifierNodeList)
 	}
-	this.validateExprAnnotsAndQualifiers(nextToken, annots, qualifiers)
-	if this.isQualifiedIdentifierPredeclaredPrefix(nextToken.Kind()) {
-		return this.parseQualifiedIdentifierOrExpression(isInConditionalExpr, isRhsExpr, allowActions)
+	b.validateExprAnnotsAndQualifiers(nextToken, annots, qualifiers)
+	if b.isQualifiedIdentifierPredeclaredPrefix(nextToken.Kind()) {
+		return b.parseQualifiedIdentifierOrExpression(isInConditionalExpr, isRhsExpr, allowActions)
 	}
 	switch nextToken.Kind() {
 	case common.DECIMAL_INTEGER_LITERAL_TOKEN,
@@ -4283,116 +4283,116 @@ func (this *BallerinaParser) parseTerminalExpressionInner(annots tree.STNode, qu
 		common.FALSE_KEYWORD,
 		common.DECIMAL_FLOATING_POINT_LITERAL_TOKEN,
 		common.HEX_FLOATING_POINT_LITERAL_TOKEN:
-		return this.parseBasicLiteral()
+		return b.parseBasicLiteral()
 	case common.OPEN_PAREN_TOKEN:
-		return this.parseBracedExpression(isRhsExpr, allowActions)
+		return b.parseBracedExpression(isRhsExpr, allowActions)
 	case common.CHECK_KEYWORD,
 		common.CHECKPANIC_KEYWORD:
-		return this.parseCheckExpression(isRhsExpr, allowActions, isInConditionalExpr)
+		return b.parseCheckExpression(isRhsExpr, allowActions, isInConditionalExpr)
 	case common.OPEN_BRACE_TOKEN:
-		return this.parseMappingConstructorExpr()
+		return b.parseMappingConstructorExpr()
 	case common.TYPEOF_KEYWORD:
-		return this.parseTypeofExpression(isRhsExpr, isInConditionalExpr)
+		return b.parseTypeofExpression(isRhsExpr, isInConditionalExpr)
 	case common.PLUS_TOKEN, common.MINUS_TOKEN, common.NEGATION_TOKEN, common.EXCLAMATION_MARK_TOKEN:
-		return this.parseUnaryExpression(isRhsExpr, isInConditionalExpr)
+		return b.parseUnaryExpression(isRhsExpr, isInConditionalExpr)
 	case common.TRAP_KEYWORD:
-		return this.parseTrapExpression(isRhsExpr, allowActions, isInConditionalExpr)
+		return b.parseTrapExpression(isRhsExpr, allowActions, isInConditionalExpr)
 	case common.OPEN_BRACKET_TOKEN:
-		return this.parseListConstructorExpr()
+		return b.parseListConstructorExpr()
 	case common.LT_TOKEN:
-		return this.parseTypeCastExpr(isRhsExpr, allowActions, isInConditionalExpr)
+		return b.parseTypeCastExpr(isRhsExpr, allowActions, isInConditionalExpr)
 	case common.TABLE_KEYWORD, common.STREAM_KEYWORD, common.FROM_KEYWORD, common.MAP_KEYWORD:
-		return this.parseTableConstructorOrQuery(isRhsExpr, allowActions)
+		return b.parseTableConstructorOrQuery(isRhsExpr, allowActions)
 	case common.ERROR_KEYWORD:
-		return this.parseErrorConstructorExpr(this.consume())
+		return b.parseErrorConstructorExpr(b.consume())
 	case common.LET_KEYWORD:
-		return this.parseLetExpression(isRhsExpr, isInConditionalExpr)
+		return b.parseLetExpression(isRhsExpr, isInConditionalExpr)
 	case common.BACKTICK_TOKEN:
-		return this.parseTemplateExpression()
+		return b.parseTemplateExpression()
 	case common.OBJECT_KEYWORD:
-		return this.parseObjectConstructorExpression(annots, qualifiers)
+		return b.parseObjectConstructorExpression(annots, qualifiers)
 	case common.XML_KEYWORD:
-		return this.parseXMLTemplateExpression()
+		return b.parseXMLTemplateExpression()
 	case common.RE_KEYWORD:
-		return this.parseRegExpTemplateExpression()
+		return b.parseRegExpTemplateExpression()
 	case common.STRING_KEYWORD:
-		nextNextToken := this.getNextNextToken()
+		nextNextToken := b.getNextNextToken()
 		if nextNextToken.Kind() == common.BACKTICK_TOKEN {
-			return this.parseStringTemplateExpression()
+			return b.parseStringTemplateExpression()
 		}
-		return this.parseSimpleTypeInTerminalExpr()
+		return b.parseSimpleTypeInTerminalExpr()
 	case common.FUNCTION_KEYWORD:
-		return this.parseExplicitFunctionExpression(annots, qualifiers, isRhsExpr)
+		return b.parseExplicitFunctionExpression(annots, qualifiers, isRhsExpr)
 	case common.NEW_KEYWORD:
-		return this.parseNewExpression()
+		return b.parseNewExpression()
 	case common.START_KEYWORD:
-		return this.parseStartAction(annots)
+		return b.parseStartAction(annots)
 	case common.FLUSH_KEYWORD:
-		return this.parseFlushAction()
+		return b.parseFlushAction()
 	case common.LEFT_ARROW_TOKEN:
-		return this.parseReceiveAction()
+		return b.parseReceiveAction()
 	case common.WAIT_KEYWORD:
-		return this.parseWaitAction()
+		return b.parseWaitAction()
 	case common.COMMIT_KEYWORD:
-		return this.parseCommitAction()
+		return b.parseCommitAction()
 	case common.TRANSACTIONAL_KEYWORD:
-		return this.parseTransactionalExpression()
+		return b.parseTransactionalExpression()
 	case common.BASE16_KEYWORD,
 		common.BASE64_KEYWORD:
-		return this.parseByteArrayLiteral()
+		return b.parseByteArrayLiteral()
 	case common.TRANSACTION_KEYWORD:
-		return this.parseQualifiedIdentWithTransactionPrefix(common.PARSER_RULE_CONTEXT_VARIABLE_REF)
+		return b.parseQualifiedIdentWithTransactionPrefix(common.PARSER_RULE_CONTEXT_VARIABLE_REF)
 	case common.IDENTIFIER_TOKEN:
-		if this.isNaturalKeyword(nextToken) && (this.getNextNextToken().Kind() == common.OPEN_BRACE_TOKEN) {
-			return this.parseNaturalExpression()
+		if b.isNaturalKeyword(nextToken) && (b.getNextNextToken().Kind() == common.OPEN_BRACE_TOKEN) {
+			return b.parseNaturalExpression()
 		}
-		return this.parseQualifiedIdentifierInner(common.PARSER_RULE_CONTEXT_VARIABLE_REF, isInConditionalExpr)
+		return b.parseQualifiedIdentifierInner(common.PARSER_RULE_CONTEXT_VARIABLE_REF, isInConditionalExpr)
 	case common.CONST_KEYWORD:
-		if this.isNaturalKeyword(this.getNextNextToken()) {
-			return this.parseNaturalExpression()
+		if b.isNaturalKeyword(b.getNextNextToken()) {
+			return b.parseNaturalExpression()
 		}
 		fallthrough
 	default:
-		if this.isSimpleTypeInExpression(nextToken.Kind()) {
-			return this.parseSimpleTypeInTerminalExpr()
+		if b.isSimpleTypeInExpression(nextToken.Kind()) {
+			return b.parseSimpleTypeInTerminalExpr()
 		}
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_TERMINAL_EXPRESSION)
-		return this.parseTerminalExpressionInner(annots, qualifiers, isRhsExpr, allowActions, isInConditionalExpr)
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_TERMINAL_EXPRESSION)
+		return b.parseTerminalExpressionInner(annots, qualifiers, isRhsExpr, allowActions, isInConditionalExpr)
 	}
 }
 
-func (this *BallerinaParser) parseNaturalExpression() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_NATURAL_EXPRESSION)
+func (b *BallerinaParser) parseNaturalExpression() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_NATURAL_EXPRESSION)
 	var optionalConstKeyword tree.STNode
-	if this.peek().Kind() == common.CONST_KEYWORD {
-		optionalConstKeyword = this.consume()
+	if b.peek().Kind() == common.CONST_KEYWORD {
+		optionalConstKeyword = b.consume()
 	} else {
 		optionalConstKeyword = tree.CreateEmptyNode()
 	}
-	naturalKeyword := this.parseNaturalKeyword()
-	optionalParenthesizedArgList := this.parseOptionalParenthesizedArgList()
-	return this.parseNaturalExprBody(optionalConstKeyword, naturalKeyword, optionalParenthesizedArgList)
+	naturalKeyword := b.parseNaturalKeyword()
+	optionalParenthesizedArgList := b.parseOptionalParenthesizedArgList()
+	return b.parseNaturalExprBody(optionalConstKeyword, naturalKeyword, optionalParenthesizedArgList)
 }
 
-func (this *BallerinaParser) parseNaturalExprBody(optionalConstKeyword tree.STNode, naturalKeyword tree.STNode, optionalParenthesizedArgList tree.STNode) tree.STNode {
-	openBrace := this.parseOpenBrace()
+func (b *BallerinaParser) parseNaturalExprBody(optionalConstKeyword tree.STNode, naturalKeyword tree.STNode, optionalParenthesizedArgList tree.STNode) tree.STNode {
+	openBrace := b.parseOpenBrace()
 	if openBrace.IsMissing() {
-		this.endContext()
-		return this.createMissingNaturalExpressionNode(optionalConstKeyword, naturalKeyword,
+		b.endContext()
+		return b.createMissingNaturalExpressionNode(optionalConstKeyword, naturalKeyword,
 			optionalParenthesizedArgList)
 	}
-	this.tokenReader.StartMode(PARSER_MODE_PROMPT)
-	prompt := this.parsePromptContent()
-	closeBrace := this.parseCloseBrace()
-	if this.tokenReader.GetCurrentMode() == PARSER_MODE_PROMPT {
-		this.tokenReader.EndMode()
+	b.tokenReader.StartMode(PARSER_MODE_PROMPT)
+	prompt := b.parsePromptContent()
+	closeBrace := b.parseCloseBrace()
+	if b.tokenReader.GetCurrentMode() == PARSER_MODE_PROMPT {
+		b.tokenReader.EndMode()
 	}
-	this.endContext()
+	b.endContext()
 	return tree.CreateNaturalExpressionNode(optionalConstKeyword, naturalKeyword,
 		optionalParenthesizedArgList, openBrace, prompt, closeBrace)
 }
 
-func (this *BallerinaParser) createMissingNaturalExpressionNode(optionalConstKeyword tree.STNode, naturalKeyword tree.STNode, optionalParenthesizedArgList tree.STNode) tree.STNode {
+func (b *BallerinaParser) createMissingNaturalExpressionNode(optionalConstKeyword tree.STNode, naturalKeyword tree.STNode, optionalParenthesizedArgList tree.STNode) tree.STNode {
 	openBrace := tree.CreateMissingToken(common.OPEN_BRACE_TOKEN, nil)
 	closeBrace := tree.CreateMissingToken(common.CLOSE_BRACE_TOKEN, nil)
 	prompt := tree.CreateEmptyNodeList()
@@ -4402,25 +4402,25 @@ func (this *BallerinaParser) createMissingNaturalExpressionNode(optionalConstKey
 	return naturalExpr
 }
 
-func (this *BallerinaParser) parseOptionalParenthesizedArgList() tree.STNode {
-	if this.peek().Kind() == common.OPEN_PAREN_TOKEN {
-		return this.parseParenthesizedArgList()
+func (b *BallerinaParser) parseOptionalParenthesizedArgList() tree.STNode {
+	if b.peek().Kind() == common.OPEN_PAREN_TOKEN {
+		return b.parseParenthesizedArgList()
 	}
 	return tree.CreateEmptyNode()
 }
 
-func (this *BallerinaParser) parsePromptContent() tree.STNode {
+func (b *BallerinaParser) parsePromptContent() tree.STNode {
 	var items []tree.STNode
-	nextToken := this.peek()
-	for !this.isEndOfPromptContent(nextToken.Kind()) {
-		contentItem := this.parsePromptItem()
+	nextToken := b.peek()
+	for !b.isEndOfPromptContent(nextToken.Kind()) {
+		contentItem := b.parsePromptItem()
 		items = append(items, contentItem)
-		nextToken = this.peek()
+		nextToken = b.peek()
 	}
 	return tree.CreateNodeList(items...)
 }
 
-func (this *BallerinaParser) isEndOfPromptContent(kind common.SyntaxKind) bool {
+func (b *BallerinaParser) isEndOfPromptContent(kind common.SyntaxKind) bool {
 	switch kind {
 	case common.EOF_TOKEN, common.CLOSE_BRACE_TOKEN:
 		return true
@@ -4429,21 +4429,21 @@ func (this *BallerinaParser) isEndOfPromptContent(kind common.SyntaxKind) bool {
 	}
 }
 
-func (this *BallerinaParser) parsePromptItem() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parsePromptItem() tree.STNode {
+	nextToken := b.peek()
 	if nextToken.Kind() == common.INTERPOLATION_START_TOKEN {
-		return this.parseInterpolation()
+		return b.parseInterpolation()
 	}
 	if nextToken.Kind() != common.PROMPT_CONTENT {
-		nextToken = this.consume()
+		nextToken = b.consume()
 		return tree.CreateLiteralValueTokenWithDiagnostics(common.PROMPT_CONTENT,
 			nextToken.Text(), nextToken.LeadingMinutiae(), nextToken.TrailingMinutiae(),
 			nextToken.Diagnostics())
 	}
-	return this.consume()
+	return b.consume()
 }
 
-func (this *BallerinaParser) createMissingObjectConstructor(annots tree.STNode, qualifierNodeList tree.STNode) tree.STNode {
+func (b *BallerinaParser) createMissingObjectConstructor(annots tree.STNode, qualifierNodeList tree.STNode) tree.STNode {
 	objectKeyword := tree.CreateMissingToken(common.OBJECT_KEYWORD, nil)
 	openBrace := tree.CreateMissingToken(common.OPEN_BRACE_TOKEN, nil)
 	closeBrace := tree.CreateMissingToken(common.CLOSE_BRACE_TOKEN, nil)
@@ -4455,11 +4455,11 @@ func (this *BallerinaParser) createMissingObjectConstructor(annots tree.STNode, 
 	return objConstructor
 }
 
-func (this *BallerinaParser) parseQualifiedIdentifierOrExpression(isInConditionalExpr bool, isRhsExpr bool, allowActions bool) tree.STNode {
-	preDeclaredPrefix := this.consume()
-	nextNextToken := this.getNextNextToken()
+func (b *BallerinaParser) parseQualifiedIdentifierOrExpression(isInConditionalExpr bool, isRhsExpr bool, allowActions bool) tree.STNode {
+	preDeclaredPrefix := b.consume()
+	nextNextToken := b.getNextNextToken()
 	if (nextNextToken.Kind() == common.IDENTIFIER_TOKEN) && (!isKeyKeyword(nextNextToken)) {
-		return this.parseQualifiedIdentifierWithPredeclPrefix(preDeclaredPrefix, isInConditionalExpr)
+		return b.parseQualifiedIdentifierWithPredeclPrefix(preDeclaredPrefix, isInConditionalExpr)
 	}
 	var context common.ParserRuleContext
 	switch preDeclaredPrefix.Kind() {
@@ -4470,42 +4470,42 @@ func (this *BallerinaParser) parseQualifiedIdentifierOrExpression(isInConditiona
 	case common.ERROR_KEYWORD:
 		context = common.PARSER_RULE_CONTEXT_ERROR_CONS_EXPR_OR_VAR_REF
 	default:
-		return this.parseQualifiedIdentifierWithPredeclPrefix(preDeclaredPrefix, isInConditionalExpr)
+		return b.parseQualifiedIdentifierWithPredeclPrefix(preDeclaredPrefix, isInConditionalExpr)
 	}
-	solution := this.recoverWithBlockContext(this.peek(), context)
+	solution := b.recoverWithBlockContext(b.peek(), context)
 	if solution.Action == ACTION_KEEP {
-		return this.parseQualifiedIdentifierWithPredeclPrefix(preDeclaredPrefix, isInConditionalExpr)
+		return b.parseQualifiedIdentifierWithPredeclPrefix(preDeclaredPrefix, isInConditionalExpr)
 	}
 	if preDeclaredPrefix.Kind() == common.ERROR_KEYWORD {
-		return this.parseErrorConstructorExpr(preDeclaredPrefix)
+		return b.parseErrorConstructorExpr(preDeclaredPrefix)
 	}
-	this.startContext(common.PARSER_RULE_CONTEXT_TABLE_CONSTRUCTOR_OR_QUERY_EXPRESSION)
+	b.startContext(common.PARSER_RULE_CONTEXT_TABLE_CONSTRUCTOR_OR_QUERY_EXPRESSION)
 	var tableOrQuery tree.STNode
 	if preDeclaredPrefix.Kind() == common.STREAM_KEYWORD {
-		queryConstructType := this.parseQueryConstructType(preDeclaredPrefix, nil)
-		tableOrQuery = this.parseQueryExprRhs(queryConstructType, isRhsExpr, allowActions)
+		queryConstructType := b.parseQueryConstructType(preDeclaredPrefix, nil)
+		tableOrQuery = b.parseQueryExprRhs(queryConstructType, isRhsExpr, allowActions)
 	} else {
-		tableOrQuery = this.parseTableConstructorOrQueryWithKeyword(preDeclaredPrefix, isRhsExpr, allowActions)
+		tableOrQuery = b.parseTableConstructorOrQueryWithKeyword(preDeclaredPrefix, isRhsExpr, allowActions)
 	}
-	this.endContext()
+	b.endContext()
 	return tableOrQuery
 }
 
-func (this *BallerinaParser) validateExprAnnotsAndQualifiers(nextToken tree.STToken, annots tree.STNode, qualifiers []tree.STNode) {
+func (b *BallerinaParser) validateExprAnnotsAndQualifiers(nextToken tree.STToken, annots tree.STNode, qualifiers []tree.STNode) {
 	switch nextToken.Kind() {
 	case common.START_KEYWORD:
-		this.reportInvalidQualifierList(qualifiers)
+		b.reportInvalidQualifierList(qualifiers)
 	case common.FUNCTION_KEYWORD, common.OBJECT_KEYWORD, common.AT_TOKEN:
 		break
 	default:
-		if this.isValidExprStart(nextToken.Kind()) {
-			this.reportInvalidExpressionAnnots(annots, qualifiers)
-			this.reportInvalidQualifierList(qualifiers)
+		if b.isValidExprStart(nextToken.Kind()) {
+			b.reportInvalidExpressionAnnots(annots, qualifiers)
+			b.reportInvalidQualifierList(qualifiers)
 		}
 	}
 }
 
-func (this *BallerinaParser) isAnnotAllowedExprStart(nextToken tree.STToken) bool {
+func (b *BallerinaParser) isAnnotAllowedExprStart(nextToken tree.STToken) bool {
 	switch nextToken.Kind() {
 	case common.START_KEYWORD, common.FUNCTION_KEYWORD, common.OBJECT_KEYWORD:
 		return true
@@ -4514,7 +4514,7 @@ func (this *BallerinaParser) isAnnotAllowedExprStart(nextToken tree.STToken) boo
 	}
 }
 
-func (this *BallerinaParser) isValidExprStart(tokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isValidExprStart(tokenKind common.SyntaxKind) bool {
 	switch tokenKind {
 	case common.DECIMAL_INTEGER_LITERAL_TOKEN,
 		common.HEX_INTEGER_LITERAL_TOKEN,
@@ -4567,112 +4567,112 @@ func (this *BallerinaParser) isValidExprStart(tokenKind common.SyntaxKind) bool 
 		if isPredeclaredPrefix(tokenKind) {
 			return true
 		}
-		return this.isSimpleTypeInExpression(tokenKind)
+		return b.isSimpleTypeInExpression(tokenKind)
 	}
 }
 
-func (this *BallerinaParser) parseNewExpression() tree.STNode {
-	newKeyword := this.parseNewKeyword()
-	return this.parseNewKeywordRhs(newKeyword)
+func (b *BallerinaParser) parseNewExpression() tree.STNode {
+	newKeyword := b.parseNewKeyword()
+	return b.parseNewKeywordRhs(newKeyword)
 }
 
-func (this *BallerinaParser) parseNewKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseNewKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.NEW_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_NEW_KEYWORD)
-		return this.parseNewKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_NEW_KEYWORD)
+		return b.parseNewKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseNewKeywordRhs(newKeyword tree.STNode) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseNewKeywordRhs(newKeyword tree.STNode) tree.STNode {
+	nextToken := b.peek()
 	if nextToken.Kind() == common.OPEN_PAREN_TOKEN {
-		return this.parseImplicitNewExpr(newKeyword)
+		return b.parseImplicitNewExpr(newKeyword)
 	}
-	if this.isClassDescriptorStartToken(nextToken.Kind()) {
-		return this.parseExplicitNewExpr(newKeyword)
+	if b.isClassDescriptorStartToken(nextToken.Kind()) {
+		return b.parseExplicitNewExpr(newKeyword)
 	}
-	return this.createImplicitNewExpr(newKeyword, tree.CreateEmptyNode())
+	return b.createImplicitNewExpr(newKeyword, tree.CreateEmptyNode())
 }
 
-func (this *BallerinaParser) isClassDescriptorStartToken(tokenKind common.SyntaxKind) bool {
-	return ((tokenKind == common.STREAM_KEYWORD) || this.isPredeclaredIdentifier(tokenKind))
+func (b *BallerinaParser) isClassDescriptorStartToken(tokenKind common.SyntaxKind) bool {
+	return ((tokenKind == common.STREAM_KEYWORD) || b.isPredeclaredIdentifier(tokenKind))
 }
 
-func (this *BallerinaParser) parseExplicitNewExpr(newKeyword tree.STNode) tree.STNode {
-	typeDescriptor := this.parseClassDescriptor()
-	parenthesizedArgsList := this.parseParenthesizedArgList()
+func (b *BallerinaParser) parseExplicitNewExpr(newKeyword tree.STNode) tree.STNode {
+	typeDescriptor := b.parseClassDescriptor()
+	parenthesizedArgsList := b.parseParenthesizedArgList()
 	return tree.CreateExplicitNewExpressionNode(newKeyword, typeDescriptor, parenthesizedArgsList)
 }
 
-func (this *BallerinaParser) parseClassDescriptor() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_CLASS_DESCRIPTOR_IN_NEW_EXPR)
+func (b *BallerinaParser) parseClassDescriptor() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_CLASS_DESCRIPTOR_IN_NEW_EXPR)
 	var classDescriptor tree.STNode
-	nextToken := this.peek()
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.STREAM_KEYWORD:
-		classDescriptor = this.parseStreamTypeDescriptor(this.consume())
+		classDescriptor = b.parseStreamTypeDescriptor(b.consume())
 	default:
-		if this.isPredeclaredIdentifier(nextToken.Kind()) {
-			classDescriptor = this.parseTypeReference()
+		if b.isPredeclaredIdentifier(nextToken.Kind()) {
+			classDescriptor = b.parseTypeReference()
 			break
 		}
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_CLASS_DESCRIPTOR)
-		return this.parseClassDescriptor()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_CLASS_DESCRIPTOR)
+		return b.parseClassDescriptor()
 	}
-	this.endContext()
+	b.endContext()
 	return classDescriptor
 }
 
-func (this *BallerinaParser) parseImplicitNewExpr(newKeyword tree.STNode) tree.STNode {
-	parenthesizedArgList := this.parseParenthesizedArgList()
-	return this.createImplicitNewExpr(newKeyword, parenthesizedArgList)
+func (b *BallerinaParser) parseImplicitNewExpr(newKeyword tree.STNode) tree.STNode {
+	parenthesizedArgList := b.parseParenthesizedArgList()
+	return b.createImplicitNewExpr(newKeyword, parenthesizedArgList)
 }
 
-func (this *BallerinaParser) createImplicitNewExpr(newKeyword tree.STNode, parenthesizedArgList tree.STNode) tree.STNode {
+func (b *BallerinaParser) createImplicitNewExpr(newKeyword tree.STNode, parenthesizedArgList tree.STNode) tree.STNode {
 	return tree.CreateImplicitNewExpressionNode(newKeyword, parenthesizedArgList)
 }
 
-func (this *BallerinaParser) parseParenthesizedArgList() tree.STNode {
-	openParan := this.parseArgListOpenParenthesis()
-	arguments := this.parseArgsList()
-	closeParan := this.parseArgListCloseParenthesis()
+func (b *BallerinaParser) parseParenthesizedArgList() tree.STNode {
+	openParan := b.parseArgListOpenParenthesis()
+	arguments := b.parseArgsList()
+	closeParan := b.parseArgListCloseParenthesis()
 	return tree.CreateParenthesizedArgList(openParan, arguments, closeParan)
 }
 
-func (this *BallerinaParser) parseExpressionRhs(precedenceLevel OperatorPrecedence, lhsExpr tree.STNode, isRhsExpr bool, allowActions bool) tree.STNode {
-	return this.parseExpressionRhsInner(precedenceLevel, lhsExpr, isRhsExpr, allowActions, false, false)
+func (b *BallerinaParser) parseExpressionRhs(precedenceLevel OperatorPrecedence, lhsExpr tree.STNode, isRhsExpr bool, allowActions bool) tree.STNode {
+	return b.parseExpressionRhsInner(precedenceLevel, lhsExpr, isRhsExpr, allowActions, false, false)
 }
 
-func (this *BallerinaParser) parseExpressionRhsInner(currentPrecedenceLevel OperatorPrecedence, lhsExpr tree.STNode, isRhsExpr bool, allowActions bool, isInMatchGuard bool, isInConditionalExpr bool) tree.STNode {
-	actionOrExpression := this.parseExpressionRhsInternal(currentPrecedenceLevel, lhsExpr, isRhsExpr, allowActions,
+func (b *BallerinaParser) parseExpressionRhsInner(currentPrecedenceLevel OperatorPrecedence, lhsExpr tree.STNode, isRhsExpr bool, allowActions bool, isInMatchGuard bool, isInConditionalExpr bool) tree.STNode {
+	actionOrExpression := b.parseExpressionRhsInternal(currentPrecedenceLevel, lhsExpr, isRhsExpr, allowActions,
 		isInMatchGuard, isInConditionalExpr)
-	if ((!allowActions) && this.isAction(actionOrExpression)) && (actionOrExpression.Kind() != common.BRACED_ACTION) {
-		actionOrExpression = this.invalidateActionAndGetMissingExpr(actionOrExpression)
+	if ((!allowActions) && b.isAction(actionOrExpression)) && (actionOrExpression.Kind() != common.BRACED_ACTION) {
+		actionOrExpression = b.invalidateActionAndGetMissingExpr(actionOrExpression)
 	}
 	return actionOrExpression
 }
 
-func (this *BallerinaParser) parseExpressionRhsInternal(currentPrecedenceLevel OperatorPrecedence, lhsExpr tree.STNode, isRhsExpr bool, allowActions bool, isInMatchGuard bool, isInConditionalExpr bool) tree.STNode {
-	nextToken := this.peek()
-	if this.isAction(lhsExpr) || this.isEndOfActionOrExpression(nextToken, isRhsExpr, isInMatchGuard) {
+func (b *BallerinaParser) parseExpressionRhsInternal(currentPrecedenceLevel OperatorPrecedence, lhsExpr tree.STNode, isRhsExpr bool, allowActions bool, isInMatchGuard bool, isInConditionalExpr bool) tree.STNode {
+	nextToken := b.peek()
+	if b.isAction(lhsExpr) || b.isEndOfActionOrExpression(nextToken, isRhsExpr, isInMatchGuard) {
 		return lhsExpr
 	}
 	nextTokenKind := nextToken.Kind()
-	if !this.isValidExprRhsStart(nextTokenKind, lhsExpr.Kind()) {
-		return this.recoverExpressionRhs(currentPrecedenceLevel, lhsExpr, isRhsExpr, allowActions, isInMatchGuard,
+	if !b.isValidExprRhsStart(nextTokenKind, lhsExpr.Kind()) {
+		return b.recoverExpressionRhs(currentPrecedenceLevel, lhsExpr, isRhsExpr, allowActions, isInMatchGuard,
 			isInConditionalExpr)
 	}
-	if (nextTokenKind == common.GT_TOKEN) && (this.peekN(2).Kind() == common.GT_TOKEN) {
-		if this.peekN(3).Kind() == common.GT_TOKEN {
+	if (nextTokenKind == common.GT_TOKEN) && (b.peekN(2).Kind() == common.GT_TOKEN) {
+		if b.peekN(3).Kind() == common.GT_TOKEN {
 			nextTokenKind = common.TRIPPLE_GT_TOKEN
 		} else {
 			nextTokenKind = common.DOUBLE_GT_TOKEN
 		}
 	}
-	nextOperatorPrecedence := this.getOpPrecedence(nextTokenKind)
+	nextOperatorPrecedence := b.getOpPrecedence(nextTokenKind)
 	if currentPrecedenceLevel.isHigherThanOrEqual(nextOperatorPrecedence, allowActions) {
 		return lhsExpr
 	}
@@ -4680,85 +4680,85 @@ func (this *BallerinaParser) parseExpressionRhsInternal(currentPrecedenceLevel O
 	var operator tree.STNode
 	switch nextTokenKind {
 	case common.OPEN_PAREN_TOKEN:
-		newLhsExpr = this.parseFuncCallOrNaturalExpr(lhsExpr)
+		newLhsExpr = b.parseFuncCallOrNaturalExpr(lhsExpr)
 	case common.OPEN_BRACKET_TOKEN:
-		newLhsExpr = this.parseMemberAccessExpr(lhsExpr, isRhsExpr)
+		newLhsExpr = b.parseMemberAccessExpr(lhsExpr, isRhsExpr)
 	case common.DOT_TOKEN:
-		newLhsExpr = this.parseFieldAccessOrMethodCall(lhsExpr, isInConditionalExpr)
+		newLhsExpr = b.parseFieldAccessOrMethodCall(lhsExpr, isInConditionalExpr)
 	case common.IS_KEYWORD,
 		common.NOT_IS_KEYWORD:
-		newLhsExpr = this.parseTypeTestExpression(lhsExpr, isInConditionalExpr)
+		newLhsExpr = b.parseTypeTestExpression(lhsExpr, isInConditionalExpr)
 	case common.RIGHT_ARROW_TOKEN:
-		newLhsExpr = this.parseRemoteMethodCallOrClientResourceAccessOrAsyncSendAction(lhsExpr, isRhsExpr,
+		newLhsExpr = b.parseRemoteMethodCallOrClientResourceAccessOrAsyncSendAction(lhsExpr, isRhsExpr,
 			isInMatchGuard)
 	case common.SYNC_SEND_TOKEN:
-		newLhsExpr = this.parseSyncSendAction(lhsExpr)
+		newLhsExpr = b.parseSyncSendAction(lhsExpr)
 	case common.RIGHT_DOUBLE_ARROW_TOKEN:
-		newLhsExpr = this.parseImplicitAnonFuncWithParams(lhsExpr, isRhsExpr)
+		newLhsExpr = b.parseImplicitAnonFuncWithParams(lhsExpr, isRhsExpr)
 	case common.ANNOT_CHAINING_TOKEN:
-		newLhsExpr = this.parseAnnotAccessExpression(lhsExpr, isInConditionalExpr)
+		newLhsExpr = b.parseAnnotAccessExpression(lhsExpr, isInConditionalExpr)
 	case common.OPTIONAL_CHAINING_TOKEN:
-		newLhsExpr = this.parseOptionalFieldAccessExpression(lhsExpr, isInConditionalExpr)
+		newLhsExpr = b.parseOptionalFieldAccessExpression(lhsExpr, isInConditionalExpr)
 	case common.QUESTION_MARK_TOKEN:
-		newLhsExpr = this.parseConditionalExpression(lhsExpr, isInConditionalExpr)
+		newLhsExpr = b.parseConditionalExpression(lhsExpr, isInConditionalExpr)
 	case common.DOT_LT_TOKEN:
-		newLhsExpr = this.parseXMLFilterExpression(lhsExpr)
+		newLhsExpr = b.parseXMLFilterExpression(lhsExpr)
 	case common.SLASH_LT_TOKEN,
 		common.DOUBLE_SLASH_DOUBLE_ASTERISK_LT_TOKEN,
 		common.SLASH_ASTERISK_TOKEN:
-		newLhsExpr = this.parseXMLStepExpression(lhsExpr)
+		newLhsExpr = b.parseXMLStepExpression(lhsExpr)
 	default:
-		if (nextTokenKind == common.SLASH_TOKEN) && (this.peekN(2).Kind() == common.LT_TOKEN) {
-			expectedNodeType := this.getExpectedNodeKind(3)
+		if (nextTokenKind == common.SLASH_TOKEN) && (b.peekN(2).Kind() == common.LT_TOKEN) {
+			expectedNodeType := b.getExpectedNodeKind(3)
 			if expectedNodeType == common.XML_STEP_EXPRESSION {
-				newLhsExpr = this.createXMLStepExpression(lhsExpr)
+				newLhsExpr = b.createXMLStepExpression(lhsExpr)
 				break
 			}
 		}
 		switch nextTokenKind {
 		case common.DOUBLE_GT_TOKEN:
-			operator = this.parseSignedRightShiftToken()
+			operator = b.parseSignedRightShiftToken()
 		case common.TRIPPLE_GT_TOKEN:
-			operator = this.parseUnsignedRightShiftToken()
+			operator = b.parseUnsignedRightShiftToken()
 		default:
-			operator = this.parseBinaryOperator()
+			operator = b.parseBinaryOperator()
 		}
-		rhsExpr := this.parseExpressionWithConditional(nextOperatorPrecedence, isRhsExpr, false, isInConditionalExpr)
+		rhsExpr := b.parseExpressionWithConditional(nextOperatorPrecedence, isRhsExpr, false, isInConditionalExpr)
 		newLhsExpr = tree.CreateBinaryExpressionNode(common.BINARY_EXPRESSION, lhsExpr, operator,
 			rhsExpr)
 	}
-	return this.parseExpressionRhsInternal(currentPrecedenceLevel, newLhsExpr, isRhsExpr, allowActions, isInMatchGuard,
+	return b.parseExpressionRhsInternal(currentPrecedenceLevel, newLhsExpr, isRhsExpr, allowActions, isInMatchGuard,
 		isInConditionalExpr)
 }
 
-func (this *BallerinaParser) recoverExpressionRhs(currentPrecedenceLevel OperatorPrecedence, lhsExpr tree.STNode, isRhsExpr bool, allowActions bool, isInMatchGuard bool, isInConditionalExpr bool) tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) recoverExpressionRhs(currentPrecedenceLevel OperatorPrecedence, lhsExpr tree.STNode, isRhsExpr bool, allowActions bool, isInMatchGuard bool, isInConditionalExpr bool) tree.STNode {
+	token := b.peek()
 	lhsExprKind := lhsExpr.Kind()
 	var solution *Solution
 	if (lhsExprKind == common.QUALIFIED_NAME_REFERENCE) || (lhsExprKind == common.SIMPLE_NAME_REFERENCE) {
-		solution = this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_VARIABLE_REF_RHS)
+		solution = b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_VARIABLE_REF_RHS)
 	} else {
-		solution = this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_EXPRESSION_RHS)
+		solution = b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_EXPRESSION_RHS)
 	}
 	if solution.Action == ACTION_REMOVE {
-		return this.parseExpressionRhsInner(currentPrecedenceLevel, lhsExpr, isRhsExpr, allowActions, isInMatchGuard,
+		return b.parseExpressionRhsInner(currentPrecedenceLevel, lhsExpr, isRhsExpr, allowActions, isInMatchGuard,
 			isInConditionalExpr)
 	}
 	if solution.Ctx == common.PARSER_RULE_CONTEXT_BINARY_OPERATOR {
-		binaryOpKind := this.getBinaryOperatorKindToInsert(currentPrecedenceLevel)
-		binaryOpContext := this.getMissingBinaryOperatorContext(currentPrecedenceLevel)
-		this.insertToken(binaryOpKind, binaryOpContext)
+		binaryOpKind := b.getBinaryOperatorKindToInsert(currentPrecedenceLevel)
+		binaryOpContext := b.getMissingBinaryOperatorContext(currentPrecedenceLevel)
+		b.insertToken(binaryOpKind, binaryOpContext)
 	}
-	return this.parseExpressionRhsInternal(currentPrecedenceLevel, lhsExpr, isRhsExpr, allowActions, isInMatchGuard,
+	return b.parseExpressionRhsInternal(currentPrecedenceLevel, lhsExpr, isRhsExpr, allowActions, isInMatchGuard,
 		isInConditionalExpr)
 }
 
-func (this *BallerinaParser) createXMLStepExpression(lhsExpr tree.STNode) tree.STNode {
+func (b *BallerinaParser) createXMLStepExpression(lhsExpr tree.STNode) tree.STNode {
 	var newLhsExpr tree.STNode
-	slashToken := this.parseSlashToken()
-	ltToken := this.parseLTToken()
+	slashToken := b.parseSlashToken()
+	ltToken := b.parseLTToken()
 	var slashLT tree.STNode
-	if this.hasTrailingMinutiae(slashToken) || this.hasLeadingMinutiae(ltToken) {
+	if b.hasTrailingMinutiae(slashToken) || b.hasLeadingMinutiae(ltToken) {
 		var diagnostics []tree.STNodeDiagnostic
 		diagnostics = append(diagnostics, tree.CreateDiagnostic(&common.ERROR_INVALID_WHITESPACE_IN_SLASH_LT_TOKEN))
 		slashLT = tree.CreateMissingToken(common.SLASH_LT_TOKEN, diagnostics)
@@ -4768,38 +4768,38 @@ func (this *BallerinaParser) createXMLStepExpression(lhsExpr tree.STNode) tree.S
 		slashLT = tree.CreateToken(common.SLASH_LT_TOKEN, slashToken.LeadingMinutiae(),
 			ltToken.TrailingMinutiae())
 	}
-	namePattern := this.parseXMLNamePatternChain(slashLT)
-	xmlStepExtends := this.parseXMLStepExtends()
+	namePattern := b.parseXMLNamePatternChain(slashLT)
+	xmlStepExtends := b.parseXMLStepExtends()
 	newLhsExpr = tree.CreateXMLStepExpressionNode(lhsExpr, namePattern, xmlStepExtends)
 	return newLhsExpr
 }
 
-func (this *BallerinaParser) getExpectedNodeKind(lookahead int) common.SyntaxKind {
-	nextToken := this.peekN(lookahead)
+func (b *BallerinaParser) getExpectedNodeKind(lookahead int) common.SyntaxKind {
+	nextToken := b.peekN(lookahead)
 	switch nextToken.Kind() {
 	case common.ASTERISK_TOKEN:
 		return common.XML_STEP_EXPRESSION
 	case common.GT_TOKEN:
 		break
 	case common.PIPE_TOKEN:
-		return this.getExpectedNodeKind(lookahead + 1)
+		return b.getExpectedNodeKind(lookahead + 1)
 	case common.IDENTIFIER_TOKEN:
-		nextToken = this.peekN(lookahead + 1)
+		nextToken = b.peekN(lookahead + 1)
 		switch nextToken.Kind() {
 		case common.GT_TOKEN:
 			break
 		case common.PIPE_TOKEN:
-			return this.getExpectedNodeKind(lookahead + 1)
+			return b.getExpectedNodeKind(lookahead + 1)
 		case common.COLON_TOKEN:
-			nextToken = this.peekN(lookahead + 1)
+			nextToken = b.peekN(lookahead + 1)
 			switch nextToken.Kind() {
 			case common.ASTERISK_TOKEN,
 				common.GT_TOKEN:
 				return common.XML_STEP_EXPRESSION
 			case common.IDENTIFIER_TOKEN:
-				nextToken = this.peekN(lookahead + 1)
+				nextToken = b.peekN(lookahead + 1)
 				if nextToken.Kind() == common.PIPE_TOKEN {
-					return this.getExpectedNodeKind(lookahead + 1)
+					return b.getExpectedNodeKind(lookahead + 1)
 				}
 			default:
 				return common.TYPE_CAST_EXPRESSION
@@ -4810,7 +4810,7 @@ func (this *BallerinaParser) getExpectedNodeKind(lookahead int) common.SyntaxKin
 	default:
 		return common.TYPE_CAST_EXPRESSION
 	}
-	nextToken = this.peekN(lookahead + 1)
+	nextToken = b.peekN(lookahead + 1)
 	switch nextToken.Kind() {
 	case common.OPEN_BRACKET_TOKEN,
 		common.OPEN_BRACE_TOKEN,
@@ -4820,7 +4820,7 @@ func (this *BallerinaParser) getExpectedNodeKind(lookahead int) common.SyntaxKin
 		common.LET_KEYWORD:
 		return common.XML_STEP_EXPRESSION
 	default:
-		if this.isValidExpressionStart(nextToken.Kind(), lookahead) {
+		if b.isValidExpressionStart(nextToken.Kind(), lookahead) {
 			break
 		}
 		return common.XML_STEP_EXPRESSION
@@ -4828,15 +4828,15 @@ func (this *BallerinaParser) getExpectedNodeKind(lookahead int) common.SyntaxKin
 	return common.TYPE_CAST_EXPRESSION
 }
 
-func (this *BallerinaParser) hasTrailingMinutiae(node tree.STNode) bool {
+func (b *BallerinaParser) hasTrailingMinutiae(node tree.STNode) bool {
 	return (node.WidthWithTrailingMinutiae() > node.Width())
 }
 
-func (this *BallerinaParser) hasLeadingMinutiae(node tree.STNode) bool {
+func (b *BallerinaParser) hasLeadingMinutiae(node tree.STNode) bool {
 	return (node.WidthWithLeadingMinutiae() > node.Width())
 }
 
-func (this *BallerinaParser) isValidExprRhsStart(tokenKind common.SyntaxKind, precedingNodeKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isValidExprRhsStart(tokenKind common.SyntaxKind, precedingNodeKind common.SyntaxKind) bool {
 	switch tokenKind {
 	case common.OPEN_PAREN_TOKEN:
 		return ((precedingNodeKind == common.QUALIFIED_NAME_REFERENCE) || (precedingNodeKind == common.SIMPLE_NAME_REFERENCE))
@@ -4856,18 +4856,18 @@ func (this *BallerinaParser) isValidExprRhsStart(tokenKind common.SyntaxKind, pr
 		common.NOT_IS_KEYWORD:
 		return true
 	case common.QUESTION_MARK_TOKEN:
-		return ((this.getNextNextToken().Kind() != common.EQUAL_TOKEN) && (this.peekN(3).Kind() != common.EQUAL_TOKEN))
+		return ((b.getNextNextToken().Kind() != common.EQUAL_TOKEN) && (b.peekN(3).Kind() != common.EQUAL_TOKEN))
 	default:
-		return this.isBinaryOperator(tokenKind)
+		return b.isBinaryOperator(tokenKind)
 	}
 }
 
-func (this *BallerinaParser) parseMemberAccessExpr(lhsExpr tree.STNode, isRhsExpr bool) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_MEMBER_ACCESS_KEY_EXPR)
-	openBracket := this.parseOpenBracket()
-	keyExpr := this.parseMemberAccessKeyExprs(isRhsExpr)
-	closeBracket := this.parseCloseBracket()
-	this.endContext()
+func (b *BallerinaParser) parseMemberAccessExpr(lhsExpr tree.STNode, isRhsExpr bool) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_MEMBER_ACCESS_KEY_EXPR)
+	openBracket := b.parseOpenBracket()
+	keyExpr := b.parseMemberAccessKeyExprs(isRhsExpr)
+	closeBracket := b.parseCloseBracket()
+	b.endContext()
 	if isRhsExpr {
 		listKeyExprNode, ok := keyExpr.(*tree.STNodeList)
 		if !ok {
@@ -4883,14 +4883,14 @@ func (this *BallerinaParser) parseMemberAccessExpr(lhsExpr tree.STNode, isRhsExp
 	return tree.CreateIndexedExpressionNode(lhsExpr, openBracket, keyExpr, closeBracket)
 }
 
-func (this *BallerinaParser) parseMemberAccessKeyExprs(isRhsExpr bool) tree.STNode {
+func (b *BallerinaParser) parseMemberAccessKeyExprs(isRhsExpr bool) tree.STNode {
 	var exprList []tree.STNode
 	var keyExpr tree.STNode
 	var keyExprEnd tree.STNode
-	for !this.isEndOfTypeList(this.peek().Kind()) {
-		keyExpr = this.parseKeyExpr(isRhsExpr)
+	for !b.isEndOfTypeList(b.peek().Kind()) {
+		keyExpr = b.parseKeyExpr(isRhsExpr)
 		exprList = append(exprList, keyExpr)
-		keyExprEnd = this.parseMemberAccessKeyExprEnd()
+		keyExprEnd = b.parseMemberAccessKeyExprEnd()
 		if keyExprEnd == nil {
 			break
 		}
@@ -4899,62 +4899,62 @@ func (this *BallerinaParser) parseMemberAccessKeyExprs(isRhsExpr bool) tree.STNo
 	return tree.CreateNodeList(exprList...)
 }
 
-func (this *BallerinaParser) parseKeyExpr(isRhsExpr bool) tree.STNode {
-	if (!isRhsExpr) && (this.peek().Kind() == common.ASTERISK_TOKEN) {
-		return tree.CreateBasicLiteralNode(common.ASTERISK_LITERAL, this.consume())
+func (b *BallerinaParser) parseKeyExpr(isRhsExpr bool) tree.STNode {
+	if (!isRhsExpr) && (b.peek().Kind() == common.ASTERISK_TOKEN) {
+		return tree.CreateBasicLiteralNode(common.ASTERISK_LITERAL, b.consume())
 	}
-	return this.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_DEFAULT, isRhsExpr, false)
+	return b.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_DEFAULT, isRhsExpr, false)
 }
 
-func (this *BallerinaParser) parseMemberAccessKeyExprEnd() tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseMemberAccessKeyExprEnd() tree.STNode {
+	switch b.peek().Kind() {
 	case common.COMMA_TOKEN:
-		return this.parseComma()
+		return b.parseComma()
 	case common.CLOSE_BRACKET_TOKEN:
 		return nil
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_MEMBER_ACCESS_KEY_EXPR_END)
-		return this.parseMemberAccessKeyExprEnd()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_MEMBER_ACCESS_KEY_EXPR_END)
+		return b.parseMemberAccessKeyExprEnd()
 	}
 }
 
-func (this *BallerinaParser) parseCloseBracket() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseCloseBracket() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.CLOSE_BRACKET_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_CLOSE_BRACKET)
-		return this.parseCloseBracket()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_CLOSE_BRACKET)
+		return b.parseCloseBracket()
 	}
 }
 
-func (this *BallerinaParser) parseFieldAccessOrMethodCall(lhsExpr tree.STNode, isInConditionalExpr bool) tree.STNode {
-	dotToken := this.parseDotToken()
-	if this.isSpecialMethodName(this.peek()) {
-		methodName := this.getKeywordAsSimpleNameRef()
-		openParen := this.parseArgListOpenParenthesis()
-		args := this.parseArgsList()
-		closeParen := this.parseArgListCloseParenthesis()
+func (b *BallerinaParser) parseFieldAccessOrMethodCall(lhsExpr tree.STNode, isInConditionalExpr bool) tree.STNode {
+	dotToken := b.parseDotToken()
+	if b.isSpecialMethodName(b.peek()) {
+		methodName := b.getKeywordAsSimpleNameRef()
+		openParen := b.parseArgListOpenParenthesis()
+		args := b.parseArgsList()
+		closeParen := b.parseArgListCloseParenthesis()
 		return tree.CreateMethodCallExpressionNode(lhsExpr, dotToken, methodName, openParen, args,
 			closeParen)
 	}
-	fieldOrMethodName := this.parseFieldAccessIdentifier(isInConditionalExpr)
+	fieldOrMethodName := b.parseFieldAccessIdentifier(isInConditionalExpr)
 	if fieldOrMethodName.Kind() == common.QUALIFIED_NAME_REFERENCE {
 		return tree.CreateFieldAccessExpressionNode(lhsExpr, dotToken, fieldOrMethodName)
 	}
-	nextToken := this.peek()
+	nextToken := b.peek()
 	if nextToken.Kind() == common.OPEN_PAREN_TOKEN {
-		openParen := this.parseArgListOpenParenthesis()
-		args := this.parseArgsList()
-		closeParen := this.parseArgListCloseParenthesis()
+		openParen := b.parseArgListOpenParenthesis()
+		args := b.parseArgsList()
+		closeParen := b.parseArgListCloseParenthesis()
 		return tree.CreateMethodCallExpressionNode(lhsExpr, dotToken, fieldOrMethodName, openParen, args,
 			closeParen)
 	}
 	return tree.CreateFieldAccessExpressionNode(lhsExpr, dotToken, fieldOrMethodName)
 }
 
-func (this *BallerinaParser) getKeywordAsSimpleNameRef() tree.STNode {
-	mapKeyword := this.consume()
+func (b *BallerinaParser) getKeywordAsSimpleNameRef() tree.STNode {
+	mapKeyword := b.consume()
 	var methodName tree.STNode
 	methodName = tree.CreateIdentifierTokenWithDiagnostics(mapKeyword.Text(), mapKeyword.LeadingMinutiae(),
 		mapKeyword.TrailingMinutiae(), mapKeyword.Diagnostics())
@@ -4962,43 +4962,43 @@ func (this *BallerinaParser) getKeywordAsSimpleNameRef() tree.STNode {
 	return methodName
 }
 
-func (this *BallerinaParser) parseBracedExpression(isRhsExpr bool, allowActions bool) tree.STNode {
-	openParen := this.parseOpenParenthesis()
-	if this.peek().Kind() == common.CLOSE_PAREN_TOKEN {
-		return tree.CreateNilLiteralNode(openParen, this.consume())
+func (b *BallerinaParser) parseBracedExpression(isRhsExpr bool, allowActions bool) tree.STNode {
+	openParen := b.parseOpenParenthesis()
+	if b.peek().Kind() == common.CLOSE_PAREN_TOKEN {
+		return tree.CreateNilLiteralNode(openParen, b.consume())
 	}
-	this.startContext(common.PARSER_RULE_CONTEXT_BRACED_EXPR_OR_ANON_FUNC_PARAMS)
+	b.startContext(common.PARSER_RULE_CONTEXT_BRACED_EXPR_OR_ANON_FUNC_PARAMS)
 	var expr tree.STNode
 	if allowActions {
-		expr = this.parseExpressionWithPrecedence(DEFAULT_OP_PRECEDENCE, isRhsExpr, true)
+		expr = b.parseExpressionWithPrecedence(DEFAULT_OP_PRECEDENCE, isRhsExpr, true)
 	} else {
-		expr = this.parseExpressionWithPrecedence(DEFAULT_OP_PRECEDENCE, isRhsExpr, false)
+		expr = b.parseExpressionWithPrecedence(DEFAULT_OP_PRECEDENCE, isRhsExpr, false)
 	}
-	return this.parseBracedExprOrAnonFuncParamRhs(openParen, expr, isRhsExpr)
+	return b.parseBracedExprOrAnonFuncParamRhs(openParen, expr, isRhsExpr)
 }
 
-func (this *BallerinaParser) parseBracedExprOrAnonFuncParamRhs(openParen tree.STNode, expr tree.STNode, isRhsExpr bool) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseBracedExprOrAnonFuncParamRhs(openParen tree.STNode, expr tree.STNode, isRhsExpr bool) tree.STNode {
+	nextToken := b.peek()
 	if expr.Kind() == common.SIMPLE_NAME_REFERENCE {
 		switch nextToken.Kind() {
 		case common.CLOSE_PAREN_TOKEN:
 			break
 		case common.COMMA_TOKEN:
-			return this.parseImplicitAnonFuncWithOpenParenAndFirstParam(openParen, expr, isRhsExpr)
+			return b.parseImplicitAnonFuncWithOpenParenAndFirstParam(openParen, expr, isRhsExpr)
 		default:
-			this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_BRACED_EXPR_OR_ANON_FUNC_PARAM_RHS)
-			return this.parseBracedExprOrAnonFuncParamRhs(openParen, expr, isRhsExpr)
+			b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_BRACED_EXPR_OR_ANON_FUNC_PARAM_RHS)
+			return b.parseBracedExprOrAnonFuncParamRhs(openParen, expr, isRhsExpr)
 		}
 	}
-	closeParen := this.parseCloseParenthesis()
-	this.endContext()
-	if this.isAction(expr) {
+	closeParen := b.parseCloseParenthesis()
+	b.endContext()
+	if b.isAction(expr) {
 		return tree.CreateBracedExpressionNode(common.BRACED_ACTION, openParen, expr, closeParen)
 	}
 	return tree.CreateBracedExpressionNode(common.BRACED_EXPRESSION, openParen, expr, closeParen)
 }
 
-func (this *BallerinaParser) isAction(node tree.STNode) bool {
+func (b *BallerinaParser) isAction(node tree.STNode) bool {
 	switch node.Kind() {
 	case common.REMOTE_METHOD_CALL_ACTION,
 		common.BRACED_ACTION,
@@ -5019,10 +5019,10 @@ func (this *BallerinaParser) isAction(node tree.STNode) bool {
 	}
 }
 
-func (this *BallerinaParser) isEndOfActionOrExpression(nextToken tree.STToken, isRhsExpr bool, isInMatchGuard bool) bool {
+func (b *BallerinaParser) isEndOfActionOrExpression(nextToken tree.STToken, isRhsExpr bool, isInMatchGuard bool) bool {
 	tokenKind := nextToken.Kind()
 	if !isRhsExpr {
-		if this.isCompoundAssignment(tokenKind) {
+		if b.isCompoundAssignment(tokenKind) {
 			return true
 		}
 		if isInMatchGuard && (tokenKind == common.RIGHT_DOUBLE_ARROW_TOKEN) {
@@ -5073,12 +5073,12 @@ func (this *BallerinaParser) isEndOfActionOrExpression(nextToken tree.STToken, i
 	}
 }
 
-func (this *BallerinaParser) parseBasicLiteral() tree.STNode {
-	literalToken := this.consume()
-	return this.parseBasicLiteralInner(literalToken)
+func (b *BallerinaParser) parseBasicLiteral() tree.STNode {
+	literalToken := b.consume()
+	return b.parseBasicLiteralInner(literalToken)
 }
 
-func (this *BallerinaParser) parseBasicLiteralInner(literalToken tree.STNode) tree.STNode {
+func (b *BallerinaParser) parseBasicLiteralInner(literalToken tree.STNode) tree.STNode {
 	var nodeKind common.SyntaxKind
 	switch literalToken.Kind() {
 	case common.NULL_KEYWORD:
@@ -5100,76 +5100,76 @@ func (this *BallerinaParser) parseBasicLiteralInner(literalToken tree.STNode) tr
 	return tree.CreateBasicLiteralNode(nodeKind, literalToken)
 }
 
-func (this *BallerinaParser) parseFuncCallOrNaturalExpr(identifier tree.STNode) tree.STNode {
-	openParen := this.parseArgListOpenParenthesis()
-	args := this.parseArgsList()
-	closeParen := this.parseArgListCloseParenthesis()
-	if (this.peek().Kind() == common.OPEN_BRACE_TOKEN) && this.isNaturalKeyword(identifier) {
+func (b *BallerinaParser) parseFuncCallOrNaturalExpr(identifier tree.STNode) tree.STNode {
+	openParen := b.parseArgListOpenParenthesis()
+	args := b.parseArgsList()
+	closeParen := b.parseArgListCloseParenthesis()
+	if (b.peek().Kind() == common.OPEN_BRACE_TOKEN) && b.isNaturalKeyword(identifier) {
 		nameRef, ok := identifier.(*tree.STSimpleNameReferenceNode)
 		if !ok {
 			panic("expected STSimpleNameReferenceNode")
 		}
-		return this.parseNaturalExpressionInner(*nameRef, openParen, args, closeParen)
+		return b.parseNaturalExpressionInner(*nameRef, openParen, args, closeParen)
 	}
 	return tree.CreateFunctionCallExpressionNode(identifier, openParen, args, closeParen)
 }
 
-func (this *BallerinaParser) parseNaturalExpressionInner(nameRef tree.STSimpleNameReferenceNode, openParen tree.STNode, args tree.STNode, closeParen tree.STNode) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_NATURAL_EXPRESSION)
+func (b *BallerinaParser) parseNaturalExpressionInner(nameRef tree.STSimpleNameReferenceNode, openParen tree.STNode, args tree.STNode, closeParen tree.STNode) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_NATURAL_EXPRESSION)
 	optionalConstKeyword := tree.CreateEmptyNode()
-	naturalKeyword := this.getNaturalKeyword(tree.ToToken(nameRef.Name))
+	naturalKeyword := b.getNaturalKeyword(tree.ToToken(nameRef.Name))
 	parenthesizedArgList := tree.CreateParenthesizedArgList(openParen, args, closeParen)
-	return this.parseNaturalExprBody(optionalConstKeyword, naturalKeyword, parenthesizedArgList)
+	return b.parseNaturalExprBody(optionalConstKeyword, naturalKeyword, parenthesizedArgList)
 }
 
-func (this *BallerinaParser) parseErrorBindingPatternOrErrorConstructor() tree.STNode {
-	return this.parseErrorConstructorExprAmbiguous(true)
+func (b *BallerinaParser) parseErrorBindingPatternOrErrorConstructor() tree.STNode {
+	return b.parseErrorConstructorExprAmbiguous(true)
 }
 
-func (this *BallerinaParser) parseErrorConstructorExpr(errorKeyword tree.STNode) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_ERROR_CONSTRUCTOR)
-	return this.parseErrorConstructorExprInner(errorKeyword, false)
+func (b *BallerinaParser) parseErrorConstructorExpr(errorKeyword tree.STNode) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_ERROR_CONSTRUCTOR)
+	return b.parseErrorConstructorExprInner(errorKeyword, false)
 }
 
-func (this *BallerinaParser) parseErrorConstructorExprAmbiguous(isAmbiguous bool) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_ERROR_CONSTRUCTOR)
-	errorKeyword := this.parseErrorKeyword()
-	return this.parseErrorConstructorExprInner(errorKeyword, isAmbiguous)
+func (b *BallerinaParser) parseErrorConstructorExprAmbiguous(isAmbiguous bool) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_ERROR_CONSTRUCTOR)
+	errorKeyword := b.parseErrorKeyword()
+	return b.parseErrorConstructorExprInner(errorKeyword, isAmbiguous)
 }
 
-func (this *BallerinaParser) parseErrorConstructorExprInner(errorKeyword tree.STNode, isAmbiguous bool) tree.STNode {
-	typeReference := this.parseErrorTypeReference()
-	openParen := this.parseArgListOpenParenthesis()
-	functionArgs := this.parseArgsList()
+func (b *BallerinaParser) parseErrorConstructorExprInner(errorKeyword tree.STNode, isAmbiguous bool) tree.STNode {
+	typeReference := b.parseErrorTypeReference()
+	openParen := b.parseArgListOpenParenthesis()
+	functionArgs := b.parseArgsList()
 	var errorArgs tree.STNode
 	if isAmbiguous {
 		errorArgs = functionArgs
 	} else {
-		errorArgs = this.getErrorArgList(functionArgs)
+		errorArgs = b.getErrorArgList(functionArgs)
 	}
-	closeParen := this.parseArgListCloseParenthesis()
-	this.endContext()
-	openParen = this.cloneWithDiagnosticIfListEmpty(errorArgs, openParen,
+	closeParen := b.parseArgListCloseParenthesis()
+	b.endContext()
+	openParen = b.cloneWithDiagnosticIfListEmpty(errorArgs, openParen,
 		&common.ERROR_MISSING_ARG_WITHIN_PARENTHESIS)
 	return tree.CreateErrorConstructorExpressionNode(errorKeyword, typeReference, openParen, errorArgs,
 		closeParen)
 }
 
-func (this *BallerinaParser) parseErrorTypeReference() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseErrorTypeReference() tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.OPEN_PAREN_TOKEN:
 		return tree.CreateEmptyNode()
 	default:
-		if this.isPredeclaredIdentifier(nextToken.Kind()) {
-			return this.parseTypeReference()
+		if b.isPredeclaredIdentifier(nextToken.Kind()) {
+			return b.parseTypeReference()
 		}
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_ERROR_CONSTRUCTOR_RHS)
-		return this.parseErrorTypeReference()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_ERROR_CONSTRUCTOR_RHS)
+		return b.parseErrorTypeReference()
 	}
 }
 
-func (this *BallerinaParser) getErrorArgList(functionArgs tree.STNode) tree.STNode {
+func (b *BallerinaParser) getErrorArgList(functionArgs tree.STNode) tree.STNode {
 	argList, ok := functionArgs.(*tree.STNodeList)
 	if !ok {
 		panic("expected *tree.STNodeList")
@@ -5211,38 +5211,38 @@ func (this *BallerinaParser) getErrorArgList(functionArgs tree.STNode) tree.STNo
 			}
 			diagnosticErrorCode = &common.ERROR_ADDITIONAL_POSITIONAL_ARG_IN_ERROR_CONSTRUCTOR
 		}
-		this.updateLastNodeInListWithInvalidNode(errorArgList, leadingComma, nil)
-		this.updateLastNodeInListWithInvalidNode(errorArgList, arg, diagnosticErrorCode)
+		b.updateLastNodeInListWithInvalidNode(errorArgList, leadingComma, nil)
+		b.updateLastNodeInListWithInvalidNode(errorArgList, arg, diagnosticErrorCode)
 	}
 	return tree.CreateNodeList(errorArgList...)
 }
 
-func (this *BallerinaParser) parseArgsList() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_ARG_LIST)
-	token := this.peek()
-	if this.isEndOfParametersList(token.Kind()) {
+func (b *BallerinaParser) parseArgsList() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_ARG_LIST)
+	token := b.peek()
+	if b.isEndOfParametersList(token.Kind()) {
 		args := tree.CreateEmptyNodeList()
-		this.endContext()
+		b.endContext()
 		return args
 	}
-	firstArg := this.parseArgument()
-	argsList := this.parseArgList(firstArg)
-	this.endContext()
+	firstArg := b.parseArgument()
+	argsList := b.parseArgList(firstArg)
+	b.endContext()
 	return argsList
 }
 
-func (this *BallerinaParser) parseArgList(firstArg tree.STNode) tree.STNode {
+func (b *BallerinaParser) parseArgList(firstArg tree.STNode) tree.STNode {
 	var argsList []tree.STNode
 	argsList = append(argsList, firstArg)
 	lastValidArgKind := firstArg.Kind()
-	nextToken := this.peek()
-	for !this.isEndOfParametersList(nextToken.Kind()) {
-		argEnd := this.parseArgEnd()
+	nextToken := b.peek()
+	for !b.isEndOfParametersList(nextToken.Kind()) {
+		argEnd := b.parseArgEnd()
 		if argEnd == nil {
 			break
 		}
-		curArg := this.parseArgument()
-		errorCode := this.validateArgumentOrder(lastValidArgKind, curArg.Kind())
+		curArg := b.parseArgument()
+		errorCode := b.validateArgumentOrder(lastValidArgKind, curArg.Kind())
 		if errorCode == nil {
 			argsList = append(argsList, argEnd, curArg)
 			lastValidArgKind = curArg.Kind()
@@ -5268,19 +5268,19 @@ func (this *BallerinaParser) parseArgList(firstArg tree.STNode) tree.STNode {
 				curArg = tree.AddDiagnostic(curArg, errorCode)
 				argsList = append(argsList, argEnd, curArg)
 			} else {
-				argsList = this.updateLastNodeInListWithInvalidNode(argsList, argEnd, nil)
-				argsList = this.updateLastNodeInListWithInvalidNode(argsList, curArg, errorCode)
+				argsList = b.updateLastNodeInListWithInvalidNode(argsList, argEnd, nil)
+				argsList = b.updateLastNodeInListWithInvalidNode(argsList, curArg, errorCode)
 			}
 		} else {
-			argsList = this.updateLastNodeInListWithInvalidNode(argsList, argEnd, nil)
-			argsList = this.updateLastNodeInListWithInvalidNode(argsList, curArg, errorCode)
+			argsList = b.updateLastNodeInListWithInvalidNode(argsList, argEnd, nil)
+			argsList = b.updateLastNodeInListWithInvalidNode(argsList, curArg, errorCode)
 		}
-		nextToken = this.peek()
+		nextToken = b.peek()
 	}
 	return tree.CreateNodeList(argsList...)
 }
 
-func (this *BallerinaParser) validateArgumentOrder(prevArgKind common.SyntaxKind, curArgKind common.SyntaxKind) *common.DiagnosticErrorCode {
+func (b *BallerinaParser) validateArgumentOrder(prevArgKind common.SyntaxKind, curArgKind common.SyntaxKind) *common.DiagnosticErrorCode {
 	var errorCode *common.DiagnosticErrorCode
 	switch prevArgKind {
 	case common.POSITIONAL_ARG:
@@ -5299,120 +5299,120 @@ func (this *BallerinaParser) validateArgumentOrder(prevArgKind common.SyntaxKind
 	return errorCode
 }
 
-func (this *BallerinaParser) parseArgEnd() tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseArgEnd() tree.STNode {
+	switch b.peek().Kind() {
 	case common.COMMA_TOKEN:
-		return this.parseComma()
+		return b.parseComma()
 	case common.CLOSE_PAREN_TOKEN:
 		return nil
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_ARG_END)
-		return this.parseArgEnd()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_ARG_END)
+		return b.parseArgEnd()
 	}
 }
 
-func (this *BallerinaParser) parseArgument() tree.STNode {
+func (b *BallerinaParser) parseArgument() tree.STNode {
 	var arg tree.STNode
-	nextToken := this.peek()
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.ELLIPSIS_TOKEN:
-		ellipsis := this.consume()
-		expr := this.parseExpression()
+		ellipsis := b.consume()
+		expr := b.parseExpression()
 		arg = tree.CreateRestArgumentNode(ellipsis, expr)
 	case common.IDENTIFIER_TOKEN:
-		arg = this.parseNamedOrPositionalArg()
+		arg = b.parseNamedOrPositionalArg()
 	default:
-		if this.isValidExprStart(nextToken.Kind()) {
-			expr := this.parseExpression()
+		if b.isValidExprStart(nextToken.Kind()) {
+			expr := b.parseExpression()
 			arg = tree.CreatePositionalArgumentNode(expr)
 			break
 		}
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_ARG_START)
-		return this.parseArgument()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_ARG_START)
+		return b.parseArgument()
 	}
 	return arg
 }
 
-func (this *BallerinaParser) parseNamedOrPositionalArg() tree.STNode {
-	argNameOrExpr := this.parseTerminalExpression(true, false, false)
-	secondToken := this.peek()
+func (b *BallerinaParser) parseNamedOrPositionalArg() tree.STNode {
+	argNameOrExpr := b.parseTerminalExpression(true, false, false)
+	secondToken := b.peek()
 	switch secondToken.Kind() {
 	case common.EQUAL_TOKEN:
 		if argNameOrExpr.Kind() != common.SIMPLE_NAME_REFERENCE {
 			break
 		}
-		equal := this.parseAssignOp()
-		valExpr := this.parseExpression()
+		equal := b.parseAssignOp()
+		valExpr := b.parseExpression()
 		return tree.CreateNamedArgumentNode(argNameOrExpr, equal, valExpr)
 	case common.COMMA_TOKEN, common.CLOSE_PAREN_TOKEN:
 		return tree.CreatePositionalArgumentNode(argNameOrExpr)
 	}
-	argNameOrExpr = this.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, argNameOrExpr, true, false)
+	argNameOrExpr = b.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, argNameOrExpr, true, false)
 	return tree.CreatePositionalArgumentNode(argNameOrExpr)
 }
 
-func (this *BallerinaParser) parseObjectTypeDescriptor(objectKeyword tree.STNode, objectTypeQualifiers tree.STNode) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_OBJECT_TYPE_DESCRIPTOR)
-	openBrace := this.parseOpenBrace()
-	objectMemberDescriptors := this.parseObjectMembers(common.PARSER_RULE_CONTEXT_OBJECT_TYPE_MEMBER)
-	closeBrace := this.parseCloseBrace()
-	this.endContext()
+func (b *BallerinaParser) parseObjectTypeDescriptor(objectKeyword tree.STNode, objectTypeQualifiers tree.STNode) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_OBJECT_TYPE_DESCRIPTOR)
+	openBrace := b.parseOpenBrace()
+	objectMemberDescriptors := b.parseObjectMembers(common.PARSER_RULE_CONTEXT_OBJECT_TYPE_MEMBER)
+	closeBrace := b.parseCloseBrace()
+	b.endContext()
 	return tree.CreateObjectTypeDescriptorNode(objectTypeQualifiers, objectKeyword, openBrace,
 		objectMemberDescriptors, closeBrace)
 }
 
-func (this *BallerinaParser) parseObjectConstructorExpression(annots tree.STNode, qualifiers []tree.STNode) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR)
-	objectTypeQualifier := this.createObjectTypeQualNodeList(qualifiers)
-	objectKeyword := this.parseObjectKeyword()
-	typeReference := this.parseObjectConstructorTypeReference()
-	openBrace := this.parseOpenBrace()
-	objectMembers := this.parseObjectMembers(common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR_MEMBER)
-	closeBrace := this.parseCloseBrace()
-	this.endContext()
+func (b *BallerinaParser) parseObjectConstructorExpression(annots tree.STNode, qualifiers []tree.STNode) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR)
+	objectTypeQualifier := b.createObjectTypeQualNodeList(qualifiers)
+	objectKeyword := b.parseObjectKeyword()
+	typeReference := b.parseObjectConstructorTypeReference()
+	openBrace := b.parseOpenBrace()
+	objectMembers := b.parseObjectMembers(common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR_MEMBER)
+	closeBrace := b.parseCloseBrace()
+	b.endContext()
 	return tree.CreateObjectConstructorExpressionNode(annots,
 		objectTypeQualifier, objectKeyword, typeReference, openBrace, objectMembers, closeBrace)
 }
 
-func (this *BallerinaParser) parseObjectConstructorTypeReference() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseObjectConstructorTypeReference() tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.OPEN_BRACE_TOKEN:
 		return tree.CreateEmptyNode()
 	default:
-		if this.isPredeclaredIdentifier(nextToken.Kind()) {
-			return this.parseTypeReference()
+		if b.isPredeclaredIdentifier(nextToken.Kind()) {
+			return b.parseTypeReference()
 		}
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR_TYPE_REF)
-		return this.parseObjectConstructorTypeReference()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR_TYPE_REF)
+		return b.parseObjectConstructorTypeReference()
 	}
 }
 
-func (this *BallerinaParser) isPredeclaredIdentifier(tokenKind common.SyntaxKind) bool {
-	return ((tokenKind == common.IDENTIFIER_TOKEN) || this.isQualifiedIdentifierPredeclaredPrefix(tokenKind))
+func (b *BallerinaParser) isPredeclaredIdentifier(tokenKind common.SyntaxKind) bool {
+	return ((tokenKind == common.IDENTIFIER_TOKEN) || b.isQualifiedIdentifierPredeclaredPrefix(tokenKind))
 }
 
-func (this *BallerinaParser) parseObjectKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseObjectKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.OBJECT_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_OBJECT_KEYWORD)
-		return this.parseObjectKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_OBJECT_KEYWORD)
+		return b.parseObjectKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseObjectMembers(context common.ParserRuleContext) tree.STNode {
+func (b *BallerinaParser) parseObjectMembers(context common.ParserRuleContext) tree.STNode {
 	var objectMembers []tree.STNode
-	for !this.isEndOfObjectTypeNode() {
-		this.startContext(context)
-		member := this.parseObjectMember(context)
-		this.endContext()
+	for !b.isEndOfObjectTypeNode() {
+		b.startContext(context)
+		member := b.parseObjectMember(context)
+		b.endContext()
 		if member == nil {
 			break
 		}
 		if (context == common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR_MEMBER) && (member.Kind() == common.TYPE_REFERENCE) {
-			this.addInvalidNodeToNextToken(member, &common.ERROR_TYPE_INCLUSION_IN_OBJECT_CONSTRUCTOR)
+			b.addInvalidNodeToNextToken(member, &common.ERROR_TYPE_INCLUSION_IN_OBJECT_CONSTRUCTOR)
 		} else {
 			objectMembers = append(objectMembers, member)
 		}
@@ -5420,9 +5420,9 @@ func (this *BallerinaParser) parseObjectMembers(context common.ParserRuleContext
 	return tree.CreateNodeList(objectMembers...)
 }
 
-func (this *BallerinaParser) parseObjectMember(context common.ParserRuleContext) tree.STNode {
+func (b *BallerinaParser) parseObjectMember(context common.ParserRuleContext) tree.STNode {
 	var metadata tree.STNode
-	nextToken := this.peek()
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.EOF_TOKEN,
 		common.CLOSE_BRACE_TOKEN:
@@ -5439,12 +5439,12 @@ func (this *BallerinaParser) parseObjectMember(context common.ParserRuleContext)
 		metadata = tree.CreateEmptyNode()
 	case common.DOCUMENTATION_STRING,
 		common.AT_TOKEN:
-		metadata = this.parseMetaData()
+		metadata = b.parseMetaData()
 	case common.RETURN_KEYWORD:
-		this.addInvalidNodeToNextToken(this.consume(), &common.ERROR_INVALID_TOKEN)
-		return this.parseObjectMember(context)
+		b.addInvalidNodeToNextToken(b.consume(), &common.ERROR_INVALID_TOKEN)
+		return b.parseObjectMember(context)
 	default:
-		if this.isTypeStartingToken(nextToken.Kind()) {
+		if b.isTypeStartingToken(nextToken.Kind()) {
 			metadata = tree.CreateEmptyNode()
 			break
 		}
@@ -5454,17 +5454,17 @@ func (this *BallerinaParser) parseObjectMember(context common.ParserRuleContext)
 		} else {
 			recoveryCtx = common.PARSER_RULE_CONTEXT_CLASS_MEMBER_OR_OBJECT_MEMBER_START
 		}
-		solution := this.recoverWithBlockContext(this.peek(), recoveryCtx)
+		solution := b.recoverWithBlockContext(b.peek(), recoveryCtx)
 		if solution.Action == ACTION_KEEP {
 			metadata = tree.CreateEmptyNode()
 			break
 		}
-		return this.parseObjectMember(context)
+		return b.parseObjectMember(context)
 	}
-	return this.parseObjectMemberWithoutMeta(metadata, context)
+	return b.parseObjectMemberWithoutMeta(metadata, context)
 }
 
-func (this *BallerinaParser) parseObjectMemberWithoutMeta(metadata tree.STNode, context common.ParserRuleContext) tree.STNode {
+func (b *BallerinaParser) parseObjectMemberWithoutMeta(metadata tree.STNode, context common.ParserRuleContext) tree.STNode {
 	isObjectTypeDesc := (context == common.PARSER_RULE_CONTEXT_OBJECT_TYPE_MEMBER)
 	var recoveryCtx common.ParserRuleContext
 	if context == common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR_MEMBER {
@@ -5472,64 +5472,64 @@ func (this *BallerinaParser) parseObjectMemberWithoutMeta(metadata tree.STNode, 
 	} else {
 		recoveryCtx = common.PARSER_RULE_CONTEXT_CLASS_MEMBER_OR_OBJECT_MEMBER_WITHOUT_META
 	}
-	res, _ := this.parseObjectMemberWithoutMetaInner(metadata, nil, recoveryCtx, isObjectTypeDesc)
+	res, _ := b.parseObjectMemberWithoutMetaInner(metadata, nil, recoveryCtx, isObjectTypeDesc)
 	return res
 }
 
-func (this *BallerinaParser) parseObjectMemberWithoutMetaInner(metadata tree.STNode, qualifiers []tree.STNode, recoveryCtx common.ParserRuleContext, isObjectTypeDesc bool) (tree.STNode, []tree.STNode) {
-	qualifiers = this.parseObjectMemberQualifiers(qualifiers)
-	nextToken := this.peek()
+func (b *BallerinaParser) parseObjectMemberWithoutMetaInner(metadata tree.STNode, qualifiers []tree.STNode, recoveryCtx common.ParserRuleContext, isObjectTypeDesc bool) (tree.STNode, []tree.STNode) {
+	qualifiers = b.parseObjectMemberQualifiers(qualifiers)
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.EOF_TOKEN,
 		common.CLOSE_BRACE_TOKEN:
 		if (metadata != nil) || (len(qualifiers) > 0) {
-			return this.createMissingSimpleObjectFieldInner(metadata, qualifiers, isObjectTypeDesc)
+			return b.createMissingSimpleObjectFieldInner(metadata, qualifiers, isObjectTypeDesc)
 		}
 		return nil, nil
 	case common.PUBLIC_KEYWORD,
 		common.PRIVATE_KEYWORD:
-		this.reportInvalidQualifierList(qualifiers)
+		b.reportInvalidQualifierList(qualifiers)
 		var visibilityQualifier tree.STNode
-		visibilityQualifier = this.consume()
+		visibilityQualifier = b.consume()
 		if isObjectTypeDesc && (visibilityQualifier.Kind() == common.PRIVATE_KEYWORD) {
-			this.addInvalidNodeToNextToken(visibilityQualifier,
+			b.addInvalidNodeToNextToken(visibilityQualifier,
 				&common.ERROR_PRIVATE_QUALIFIER_IN_OBJECT_MEMBER_DESCRIPTOR)
 			visibilityQualifier = tree.CreateEmptyNode()
 		}
-		return this.parseObjectMethodOrField(metadata, visibilityQualifier, isObjectTypeDesc), qualifiers
+		return b.parseObjectMethodOrField(metadata, visibilityQualifier, isObjectTypeDesc), qualifiers
 	case common.FUNCTION_KEYWORD:
 		visibilityQualifier := tree.CreateEmptyNode()
-		return this.parseObjectMethodOrFuncTypeDesc(metadata, visibilityQualifier, qualifiers, isObjectTypeDesc), qualifiers
+		return b.parseObjectMethodOrFuncTypeDesc(metadata, visibilityQualifier, qualifiers, isObjectTypeDesc), qualifiers
 	case common.ASTERISK_TOKEN:
-		this.reportInvalidMetaData(metadata, "object ty inclusion")
-		this.reportInvalidQualifierList(qualifiers)
-		asterisk := this.consume()
-		ty := this.parseTypeReferenceInTypeInclusion()
-		semicolonToken := this.parseSemicolon()
+		b.reportInvalidMetaData(metadata, "object ty inclusion")
+		b.reportInvalidQualifierList(qualifiers)
+		asterisk := b.consume()
+		ty := b.parseTypeReferenceInTypeInclusion()
+		semicolonToken := b.parseSemicolon()
 		return tree.CreateTypeReferenceNode(asterisk, ty, semicolonToken), qualifiers
 	case common.IDENTIFIER_TOKEN:
-		if this.isObjectFieldStart() || nextToken.IsMissing() {
-			return this.parseObjectField(metadata, tree.CreateEmptyNode(), qualifiers, isObjectTypeDesc)
+		if b.isObjectFieldStart() || nextToken.IsMissing() {
+			return b.parseObjectField(metadata, tree.CreateEmptyNode(), qualifiers, isObjectTypeDesc)
 		}
-		if this.isObjectMethodStart(this.getNextNextToken()) {
-			this.addInvalidTokenToNextToken(this.errorHandler.ConsumeInvalidToken())
-			return this.parseObjectMemberWithoutMetaInner(metadata, qualifiers, recoveryCtx, isObjectTypeDesc)
+		if b.isObjectMethodStart(b.getNextNextToken()) {
+			b.addInvalidTokenToNextToken(b.errorHandler.ConsumeInvalidToken())
+			return b.parseObjectMemberWithoutMetaInner(metadata, qualifiers, recoveryCtx, isObjectTypeDesc)
 		}
 		fallthrough
 	default:
-		if this.isTypeStartingToken(nextToken.Kind()) && (nextToken.Kind() != common.IDENTIFIER_TOKEN) {
-			return this.parseObjectField(metadata, tree.CreateEmptyNode(), qualifiers, isObjectTypeDesc)
+		if b.isTypeStartingToken(nextToken.Kind()) && (nextToken.Kind() != common.IDENTIFIER_TOKEN) {
+			return b.parseObjectField(metadata, tree.CreateEmptyNode(), qualifiers, isObjectTypeDesc)
 		}
-		solution := this.recoverWithBlockContext(this.peek(), recoveryCtx)
+		solution := b.recoverWithBlockContext(b.peek(), recoveryCtx)
 		if solution.Action == ACTION_KEEP {
-			return this.parseObjectField(metadata, tree.CreateEmptyNode(), qualifiers, isObjectTypeDesc)
+			return b.parseObjectField(metadata, tree.CreateEmptyNode(), qualifiers, isObjectTypeDesc)
 		}
-		return this.parseObjectMemberWithoutMetaInner(metadata, qualifiers, recoveryCtx, isObjectTypeDesc)
+		return b.parseObjectMemberWithoutMetaInner(metadata, qualifiers, recoveryCtx, isObjectTypeDesc)
 	}
 }
 
-func (this *BallerinaParser) isObjectFieldStart() bool {
-	nextNextToken := this.getNextNextToken()
+func (b *BallerinaParser) isObjectFieldStart() bool {
+	nextNextToken := b.getNextNextToken()
 	switch nextNextToken.Kind() {
 	case common.ERROR_KEYWORD, // error-binding-pattern not allowed in fields
 		common.OPEN_BRACE_TOKEN:
@@ -5537,11 +5537,11 @@ func (this *BallerinaParser) isObjectFieldStart() bool {
 	case common.CLOSE_BRACE_TOKEN:
 		return true
 	default:
-		return this.isModuleVarDeclStart(1)
+		return b.isModuleVarDeclStart(1)
 	}
 }
 
-func (this *BallerinaParser) isObjectMethodStart(token tree.STToken) bool {
+func (b *BallerinaParser) isObjectMethodStart(token tree.STToken) bool {
 	switch token.Kind() {
 	case common.FUNCTION_KEYWORD,
 		common.REMOTE_KEYWORD,
@@ -5554,41 +5554,41 @@ func (this *BallerinaParser) isObjectMethodStart(token tree.STToken) bool {
 	}
 }
 
-func (this *BallerinaParser) parseObjectMethodOrField(metadata tree.STNode, visibilityQualifier tree.STNode, isObjectTypeDesc bool) tree.STNode {
-	result, _ := this.parseObjectMethodOrFieldInner(metadata, visibilityQualifier, nil, isObjectTypeDesc)
+func (b *BallerinaParser) parseObjectMethodOrField(metadata tree.STNode, visibilityQualifier tree.STNode, isObjectTypeDesc bool) tree.STNode {
+	result, _ := b.parseObjectMethodOrFieldInner(metadata, visibilityQualifier, nil, isObjectTypeDesc)
 	return result
 }
 
-func (this *BallerinaParser) parseObjectMethodOrFieldInner(metadata tree.STNode, visibilityQualifier tree.STNode, qualifiers []tree.STNode, isObjectTypeDesc bool) (tree.STNode, []tree.STNode) {
-	qualifiers = this.parseObjectMemberQualifiers(qualifiers)
-	nextToken := this.peekN(1)
-	nextNextToken := this.peekN(2)
+func (b *BallerinaParser) parseObjectMethodOrFieldInner(metadata tree.STNode, visibilityQualifier tree.STNode, qualifiers []tree.STNode, isObjectTypeDesc bool) (tree.STNode, []tree.STNode) {
+	qualifiers = b.parseObjectMemberQualifiers(qualifiers)
+	nextToken := b.peekN(1)
+	nextNextToken := b.peekN(2)
 	switch nextToken.Kind() {
 	case common.FUNCTION_KEYWORD:
-		return this.parseObjectMethodOrFuncTypeDesc(metadata, visibilityQualifier, qualifiers, isObjectTypeDesc), qualifiers
+		return b.parseObjectMethodOrFuncTypeDesc(metadata, visibilityQualifier, qualifiers, isObjectTypeDesc), qualifiers
 	case common.IDENTIFIER_TOKEN:
 		if nextNextToken.Kind() != common.OPEN_PAREN_TOKEN {
-			return this.parseObjectField(metadata, visibilityQualifier, qualifiers, isObjectTypeDesc)
+			return b.parseObjectField(metadata, visibilityQualifier, qualifiers, isObjectTypeDesc)
 		}
 	default:
-		if this.isTypeStartingToken(nextToken.Kind()) {
-			return this.parseObjectField(metadata, visibilityQualifier, qualifiers, isObjectTypeDesc)
+		if b.isTypeStartingToken(nextToken.Kind()) {
+			return b.parseObjectField(metadata, visibilityQualifier, qualifiers, isObjectTypeDesc)
 		}
 	}
-	this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_OBJECT_FUNC_OR_FIELD_WITHOUT_VISIBILITY)
-	return this.parseObjectMethodOrFieldInner(metadata, visibilityQualifier, qualifiers, isObjectTypeDesc)
+	b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_OBJECT_FUNC_OR_FIELD_WITHOUT_VISIBILITY)
+	return b.parseObjectMethodOrFieldInner(metadata, visibilityQualifier, qualifiers, isObjectTypeDesc)
 }
 
-func (this *BallerinaParser) parseObjectField(metadata tree.STNode, visibilityQualifier tree.STNode, qualifiers []tree.STNode, isObjectTypeDesc bool) (tree.STNode, []tree.STNode) {
-	objectFieldQualifiers, qualifiers := this.extractObjectFieldQualifiers(qualifiers, isObjectTypeDesc)
+func (b *BallerinaParser) parseObjectField(metadata tree.STNode, visibilityQualifier tree.STNode, qualifiers []tree.STNode, isObjectTypeDesc bool) (tree.STNode, []tree.STNode) {
+	objectFieldQualifiers, qualifiers := b.extractObjectFieldQualifiers(qualifiers, isObjectTypeDesc)
 	objectFieldQualNodeList := tree.CreateNodeList(objectFieldQualifiers...)
-	ty := this.parseTypeDescriptorWithQualifier(qualifiers, common.PARSER_RULE_CONTEXT_TYPE_DESC_BEFORE_IDENTIFIER)
-	fieldName := this.parseVariableName()
-	return this.parseObjectFieldRhs(metadata, visibilityQualifier, objectFieldQualNodeList, ty, fieldName,
+	ty := b.parseTypeDescriptorWithQualifier(qualifiers, common.PARSER_RULE_CONTEXT_TYPE_DESC_BEFORE_IDENTIFIER)
+	fieldName := b.parseVariableName()
+	return b.parseObjectFieldRhs(metadata, visibilityQualifier, objectFieldQualNodeList, ty, fieldName,
 		isObjectTypeDesc), qualifiers
 }
 
-func (this *BallerinaParser) extractObjectFieldQualifiers(qualifiers []tree.STNode, isObjectTypeDesc bool) ([]tree.STNode, []tree.STNode) {
+func (b *BallerinaParser) extractObjectFieldQualifiers(qualifiers []tree.STNode, isObjectTypeDesc bool) ([]tree.STNode, []tree.STNode) {
 	var objectFieldQualifiers []tree.STNode
 	if len(qualifiers) != 0 && (!isObjectTypeDesc) {
 		firstQualifier := qualifiers[0]
@@ -5600,8 +5600,8 @@ func (this *BallerinaParser) extractObjectFieldQualifiers(qualifiers []tree.STNo
 	return objectFieldQualifiers, qualifiers
 }
 
-func (this *BallerinaParser) parseObjectFieldRhs(metadata tree.STNode, visibilityQualifier tree.STNode, qualifiers tree.STNode, ty tree.STNode, fieldName tree.STNode, isObjectTypeDesc bool) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseObjectFieldRhs(metadata tree.STNode, visibilityQualifier tree.STNode, qualifiers tree.STNode, ty tree.STNode, fieldName tree.STNode, isObjectTypeDesc bool) tree.STNode {
+	nextToken := b.peek()
 	var equalsToken tree.STNode
 	var expression tree.STNode
 	var semicolonToken tree.STNode
@@ -5609,11 +5609,11 @@ func (this *BallerinaParser) parseObjectFieldRhs(metadata tree.STNode, visibilit
 	case common.SEMICOLON_TOKEN:
 		equalsToken = tree.CreateEmptyNode()
 		expression = tree.CreateEmptyNode()
-		semicolonToken = this.parseSemicolon()
+		semicolonToken = b.parseSemicolon()
 	case common.EQUAL_TOKEN:
-		equalsToken = this.parseAssignOp()
-		expression = this.parseExpression()
-		semicolonToken = this.parseSemicolon()
+		equalsToken = b.parseAssignOp()
+		expression = b.parseExpression()
+		semicolonToken = b.parseSemicolon()
 		if isObjectTypeDesc {
 			fieldName = tree.CloneWithTrailingInvalidNodeMinutiae(fieldName, equalsToken,
 				&common.ERROR_FIELD_INITIALIZATION_NOT_ALLOWED_IN_OBJECT_TYPE)
@@ -5622,45 +5622,45 @@ func (this *BallerinaParser) parseObjectFieldRhs(metadata tree.STNode, visibilit
 			expression = tree.CreateEmptyNode()
 		}
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_OBJECT_FIELD_RHS)
-		return this.parseObjectFieldRhs(metadata, visibilityQualifier, qualifiers, ty, fieldName,
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_OBJECT_FIELD_RHS)
+		return b.parseObjectFieldRhs(metadata, visibilityQualifier, qualifiers, ty, fieldName,
 			isObjectTypeDesc)
 	}
 	return tree.CreateObjectFieldNode(metadata, visibilityQualifier, qualifiers, ty, fieldName,
 		equalsToken, expression, semicolonToken)
 }
 
-func (this *BallerinaParser) parseObjectMethodOrFuncTypeDesc(metadata tree.STNode, visibilityQualifier tree.STNode, qualifiers []tree.STNode, isObjectTypeDesc bool) tree.STNode {
-	return this.parseFuncDefOrFuncTypeDesc(metadata, visibilityQualifier, qualifiers, true, isObjectTypeDesc)
+func (b *BallerinaParser) parseObjectMethodOrFuncTypeDesc(metadata tree.STNode, visibilityQualifier tree.STNode, qualifiers []tree.STNode, isObjectTypeDesc bool) tree.STNode {
+	return b.parseFuncDefOrFuncTypeDesc(metadata, visibilityQualifier, qualifiers, true, isObjectTypeDesc)
 }
 
-func (this *BallerinaParser) parseRelativeResourcePath() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_RELATIVE_RESOURCE_PATH)
+func (b *BallerinaParser) parseRelativeResourcePath() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_RELATIVE_RESOURCE_PATH)
 	var pathElementList []tree.STNode
-	nextToken := this.peek()
+	nextToken := b.peek()
 	if nextToken.Kind() == common.DOT_TOKEN {
-		pathElementList = append(pathElementList, this.consume())
-		this.endContext()
+		pathElementList = append(pathElementList, b.consume())
+		b.endContext()
 		return tree.CreateNodeList(pathElementList...)
 	}
-	pathSegment := this.parseResourcePathSegment(true)
+	pathSegment := b.parseResourcePathSegment(true)
 	pathElementList = append(pathElementList, pathSegment)
 	var leadingSlash tree.STNode
-	for !this.isEndRelativeResourcePath(nextToken.Kind()) {
-		leadingSlash = this.parseRelativeResourcePathEnd()
+	for !b.isEndRelativeResourcePath(nextToken.Kind()) {
+		leadingSlash = b.parseRelativeResourcePathEnd()
 		if leadingSlash == nil {
 			break
 		}
 		pathElementList = append(pathElementList, leadingSlash)
-		pathSegment = this.parseResourcePathSegment(false)
+		pathSegment = b.parseResourcePathSegment(false)
 		pathElementList = append(pathElementList, pathSegment)
-		nextToken = this.peek()
+		nextToken = b.peek()
 	}
-	this.endContext()
-	return this.createResourcePathNodeList(pathElementList)
+	b.endContext()
+	return b.createResourcePathNodeList(pathElementList)
 }
 
-func (this *BallerinaParser) isEndRelativeResourcePath(tokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isEndRelativeResourcePath(tokenKind common.SyntaxKind) bool {
 	switch tokenKind {
 	case common.EOF_TOKEN, common.OPEN_PAREN_TOKEN:
 		return true
@@ -5669,7 +5669,7 @@ func (this *BallerinaParser) isEndRelativeResourcePath(tokenKind common.SyntaxKi
 	}
 }
 
-func (this *BallerinaParser) createResourcePathNodeList(pathElementList []tree.STNode) tree.STNode {
+func (b *BallerinaParser) createResourcePathNodeList(pathElementList []tree.STNode) tree.STNode {
 	if len(pathElementList) == 0 {
 		return tree.CreateEmptyNodeList()
 	}
@@ -5682,8 +5682,8 @@ func (this *BallerinaParser) createResourcePathNodeList(pathElementList []tree.S
 		leadingSlash := pathElementList[i]
 		pathSegment := pathElementList[i+1]
 		if hasRestPram {
-			this.updateLastNodeInListWithInvalidNode(validatedList, leadingSlash, nil)
-			this.updateLastNodeInListWithInvalidNode(validatedList, pathSegment,
+			b.updateLastNodeInListWithInvalidNode(validatedList, leadingSlash, nil)
+			b.updateLastNodeInListWithInvalidNode(validatedList, pathSegment,
 				&common.ERROR_RESOURCE_PATH_SEGMENT_NOT_ALLOWED_AFTER_REST_PARAM)
 			continue
 		}
@@ -5694,31 +5694,31 @@ func (this *BallerinaParser) createResourcePathNodeList(pathElementList []tree.S
 	return tree.CreateNodeList(validatedList...)
 }
 
-func (this *BallerinaParser) parseResourcePathSegment(isFirstSegment bool) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseResourcePathSegment(isFirstSegment bool) tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.IDENTIFIER_TOKEN:
-		if ((isFirstSegment && nextToken.IsMissing()) && this.isInvalidNodeStackEmpty()) && (this.getNextNextToken().Kind() == common.SLASH_TOKEN) {
-			this.removeInsertedToken()
+		if ((isFirstSegment && nextToken.IsMissing()) && b.isInvalidNodeStackEmpty()) && (b.getNextNextToken().Kind() == common.SLASH_TOKEN) {
+			b.removeInsertedToken()
 			return tree.CreateMissingTokenWithDiagnostics(common.IDENTIFIER_TOKEN,
 				&common.ERROR_RESOURCE_PATH_CANNOT_BEGIN_WITH_SLASH)
 		}
-		return this.consume()
+		return b.consume()
 	case common.OPEN_BRACKET_TOKEN:
-		return this.parseResourcePathParameter()
+		return b.parseResourcePathParameter()
 	default:
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_RESOURCE_PATH_SEGMENT)
-		return this.parseResourcePathSegment(isFirstSegment)
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_RESOURCE_PATH_SEGMENT)
+		return b.parseResourcePathSegment(isFirstSegment)
 	}
 }
 
-func (this *BallerinaParser) parseResourcePathParameter() tree.STNode {
-	openBracket := this.parseOpenBracket()
-	annots := this.parseOptionalAnnotations()
-	ty := this.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_PATH_PARAM)
-	ellipsis := this.parseOptionalEllipsis()
-	paramName := this.parseOptionalPathParamName()
-	closeBracket := this.parseCloseBracket()
+func (b *BallerinaParser) parseResourcePathParameter() tree.STNode {
+	openBracket := b.parseOpenBracket()
+	annots := b.parseOptionalAnnotations()
+	ty := b.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_PATH_PARAM)
+	ellipsis := b.parseOptionalEllipsis()
+	paramName := b.parseOptionalPathParamName()
+	closeBracket := b.parseCloseBracket()
 	var pathPramKind common.SyntaxKind
 	if ellipsis == nil {
 		pathPramKind = common.RESOURCE_PATH_SEGMENT_PARAM
@@ -5729,313 +5729,313 @@ func (this *BallerinaParser) parseResourcePathParameter() tree.STNode {
 		paramName, closeBracket)
 }
 
-func (this *BallerinaParser) parseOptionalPathParamName() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseOptionalPathParamName() tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.IDENTIFIER_TOKEN:
-		return this.consume()
+		return b.consume()
 	case common.CLOSE_BRACKET_TOKEN:
 		return tree.CreateEmptyNode()
 	default:
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_OPTIONAL_PATH_PARAM_NAME)
-		return this.parseOptionalPathParamName()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_OPTIONAL_PATH_PARAM_NAME)
+		return b.parseOptionalPathParamName()
 	}
 }
 
-func (this *BallerinaParser) parseOptionalEllipsis() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseOptionalEllipsis() tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.ELLIPSIS_TOKEN:
-		return this.consume()
+		return b.consume()
 	case common.IDENTIFIER_TOKEN, common.CLOSE_BRACKET_TOKEN:
 		return tree.CreateEmptyNode()
 	default:
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_PATH_PARAM_ELLIPSIS)
-		return this.parseOptionalEllipsis()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_PATH_PARAM_ELLIPSIS)
+		return b.parseOptionalEllipsis()
 	}
 }
 
-func (this *BallerinaParser) parseRelativeResourcePathEnd() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseRelativeResourcePathEnd() tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.OPEN_PAREN_TOKEN, common.EOF_TOKEN:
 		return nil
 	case common.SLASH_TOKEN:
-		return this.consume()
+		return b.consume()
 	default:
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_RELATIVE_RESOURCE_PATH_END)
-		return this.parseRelativeResourcePathEnd()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_RELATIVE_RESOURCE_PATH_END)
+		return b.parseRelativeResourcePathEnd()
 	}
 }
 
-func (this *BallerinaParser) parseIfElseBlock() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_IF_BLOCK)
-	ifKeyword := this.parseIfKeyword()
-	condition := this.parseExpression()
-	ifBody := this.parseBlockNode()
-	this.endContext()
-	elseBody := this.parseElseBlock()
+func (b *BallerinaParser) parseIfElseBlock() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_IF_BLOCK)
+	ifKeyword := b.parseIfKeyword()
+	condition := b.parseExpression()
+	ifBody := b.parseBlockNode()
+	b.endContext()
+	elseBody := b.parseElseBlock()
 	return tree.CreateIfElseStatementNode(ifKeyword, condition, ifBody, elseBody)
 }
 
-func (this *BallerinaParser) parseIfKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseIfKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.IF_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_IF_KEYWORD)
-		return this.parseIfKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_IF_KEYWORD)
+		return b.parseIfKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseElseKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseElseKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.ELSE_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_ELSE_KEYWORD)
-		return this.parseElseKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_ELSE_KEYWORD)
+		return b.parseElseKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseBlockNode() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_BLOCK_STMT)
-	openBrace := this.parseOpenBrace()
-	stmts := this.parseStatements()
-	closeBrace := this.parseCloseBrace()
-	this.endContext()
+func (b *BallerinaParser) parseBlockNode() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_BLOCK_STMT)
+	openBrace := b.parseOpenBrace()
+	stmts := b.parseStatements()
+	closeBrace := b.parseCloseBrace()
+	b.endContext()
 	return tree.CreateBlockStatementNode(openBrace, stmts, closeBrace)
 }
 
-func (this *BallerinaParser) parseElseBlock() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseElseBlock() tree.STNode {
+	nextToken := b.peek()
 	if nextToken.Kind() != common.ELSE_KEYWORD {
 		return tree.CreateEmptyNode()
 	}
-	elseKeyword := this.parseElseKeyword()
-	elseBody := this.parseElseBody()
+	elseKeyword := b.parseElseKeyword()
+	elseBody := b.parseElseBody()
 	return tree.CreateElseBlockNode(elseKeyword, elseBody)
 }
 
-func (this *BallerinaParser) parseElseBody() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseElseBody() tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.IF_KEYWORD:
-		return this.parseIfElseBlock()
+		return b.parseIfElseBlock()
 	case common.OPEN_BRACE_TOKEN:
-		return this.parseBlockNode()
+		return b.parseBlockNode()
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_ELSE_BODY)
-		return this.parseElseBody()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_ELSE_BODY)
+		return b.parseElseBody()
 	}
 }
 
-func (this *BallerinaParser) parseDoStatement() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_DO_BLOCK)
-	doKeyword := this.parseDoKeyword()
-	doBody := this.parseBlockNode()
-	this.endContext()
-	onFailClause := this.parseOptionalOnFailClause()
+func (b *BallerinaParser) parseDoStatement() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_DO_BLOCK)
+	doKeyword := b.parseDoKeyword()
+	doBody := b.parseBlockNode()
+	b.endContext()
+	onFailClause := b.parseOptionalOnFailClause()
 	return tree.CreateDoStatementNode(doKeyword, doBody, onFailClause)
 }
 
-func (this *BallerinaParser) parseWhileStatement() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_WHILE_BLOCK)
-	whileKeyword := this.parseWhileKeyword()
-	condition := this.parseExpression()
-	whileBody := this.parseBlockNode()
-	this.endContext()
-	onFailClause := this.parseOptionalOnFailClause()
+func (b *BallerinaParser) parseWhileStatement() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_WHILE_BLOCK)
+	whileKeyword := b.parseWhileKeyword()
+	condition := b.parseExpression()
+	whileBody := b.parseBlockNode()
+	b.endContext()
+	onFailClause := b.parseOptionalOnFailClause()
 	return tree.CreateWhileStatementNode(whileKeyword, condition, whileBody, onFailClause)
 }
 
-func (this *BallerinaParser) parseWhileKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseWhileKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.WHILE_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_WHILE_KEYWORD)
-		return this.parseWhileKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_WHILE_KEYWORD)
+		return b.parseWhileKeyword()
 	}
 }
 
-func (this *BallerinaParser) parsePanicStatement() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_PANIC_STMT)
-	panicKeyword := this.parsePanicKeyword()
-	expression := this.parseExpression()
-	semicolon := this.parseSemicolon()
-	this.endContext()
+func (b *BallerinaParser) parsePanicStatement() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_PANIC_STMT)
+	panicKeyword := b.parsePanicKeyword()
+	expression := b.parseExpression()
+	semicolon := b.parseSemicolon()
+	b.endContext()
 	return tree.CreatePanicStatementNode(panicKeyword, expression, semicolon)
 }
 
-func (this *BallerinaParser) parsePanicKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parsePanicKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.PANIC_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_PANIC_KEYWORD)
-		return this.parsePanicKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_PANIC_KEYWORD)
+		return b.parsePanicKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseCheckExpression(isRhsExpr bool, allowActions bool, isInConditionalExpr bool) tree.STNode {
-	checkingKeyword := this.parseCheckingKeyword()
-	expr := this.parseExpressionWithConditional(OPERATOR_PRECEDENCE_EXPRESSION_ACTION, isRhsExpr, allowActions, isInConditionalExpr)
-	if this.isAction(expr) {
+func (b *BallerinaParser) parseCheckExpression(isRhsExpr bool, allowActions bool, isInConditionalExpr bool) tree.STNode {
+	checkingKeyword := b.parseCheckingKeyword()
+	expr := b.parseExpressionWithConditional(OPERATOR_PRECEDENCE_EXPRESSION_ACTION, isRhsExpr, allowActions, isInConditionalExpr)
+	if b.isAction(expr) {
 		return tree.CreateCheckExpressionNode(common.CHECK_ACTION, checkingKeyword, expr)
 	} else {
 		return tree.CreateCheckExpressionNode(common.CHECK_EXPRESSION, checkingKeyword, expr)
 	}
 }
 
-func (this *BallerinaParser) parseCheckingKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseCheckingKeyword() tree.STNode {
+	token := b.peek()
 	if (token.Kind() == common.CHECK_KEYWORD) || (token.Kind() == common.CHECKPANIC_KEYWORD) {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_CHECKING_KEYWORD)
-		return this.parseCheckingKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_CHECKING_KEYWORD)
+		return b.parseCheckingKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseContinueStatement() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_CONTINUE_STATEMENT)
-	continueKeyword := this.parseContinueKeyword()
-	semicolon := this.parseSemicolon()
-	this.endContext()
+func (b *BallerinaParser) parseContinueStatement() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_CONTINUE_STATEMENT)
+	continueKeyword := b.parseContinueKeyword()
+	semicolon := b.parseSemicolon()
+	b.endContext()
 	return tree.CreateContinueStatementNode(continueKeyword, semicolon)
 }
 
-func (this *BallerinaParser) parseContinueKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseContinueKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.CONTINUE_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_CONTINUE_KEYWORD)
-		return this.parseContinueKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_CONTINUE_KEYWORD)
+		return b.parseContinueKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseFailStatement() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_FAIL_STATEMENT)
-	failKeyword := this.parseFailKeyword()
-	expr := this.parseExpression()
-	semicolon := this.parseSemicolon()
-	this.endContext()
+func (b *BallerinaParser) parseFailStatement() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_FAIL_STATEMENT)
+	failKeyword := b.parseFailKeyword()
+	expr := b.parseExpression()
+	semicolon := b.parseSemicolon()
+	b.endContext()
 	return tree.CreateFailStatementNode(failKeyword, expr, semicolon)
 }
 
-func (this *BallerinaParser) parseFailKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseFailKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.FAIL_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_FAIL_KEYWORD)
-		return this.parseFailKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_FAIL_KEYWORD)
+		return b.parseFailKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseReturnStatement() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_RETURN_STMT)
-	returnKeyword := this.parseReturnKeyword()
-	returnRhs := this.parseReturnStatementRhs(returnKeyword)
-	this.endContext()
+func (b *BallerinaParser) parseReturnStatement() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_RETURN_STMT)
+	returnKeyword := b.parseReturnKeyword()
+	returnRhs := b.parseReturnStatementRhs(returnKeyword)
+	b.endContext()
 	return returnRhs
 }
 
-func (this *BallerinaParser) parseReturnKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseReturnKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.RETURN_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_RETURN_KEYWORD)
-		return this.parseReturnKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_RETURN_KEYWORD)
+		return b.parseReturnKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseBreakStatement() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_BREAK_STATEMENT)
-	breakKeyword := this.parseBreakKeyword()
-	semicolon := this.parseSemicolon()
-	this.endContext()
+func (b *BallerinaParser) parseBreakStatement() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_BREAK_STATEMENT)
+	breakKeyword := b.parseBreakKeyword()
+	semicolon := b.parseSemicolon()
+	b.endContext()
 	return tree.CreateBreakStatementNode(breakKeyword, semicolon)
 }
 
-func (this *BallerinaParser) parseBreakKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseBreakKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.BREAK_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_BREAK_KEYWORD)
-		return this.parseBreakKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_BREAK_KEYWORD)
+		return b.parseBreakKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseReturnStatementRhs(returnKeyword tree.STNode) tree.STNode {
+func (b *BallerinaParser) parseReturnStatementRhs(returnKeyword tree.STNode) tree.STNode {
 	var expr tree.STNode
-	token := this.peek()
+	token := b.peek()
 	switch token.Kind() {
 	case common.SEMICOLON_TOKEN:
 		expr = tree.CreateEmptyNode()
 	default:
-		expr = this.parseActionOrExpression()
+		expr = b.parseActionOrExpression()
 	}
-	semicolon := this.parseSemicolon()
+	semicolon := b.parseSemicolon()
 	return tree.CreateReturnStatementNode(returnKeyword, expr, semicolon)
 }
 
-func (this *BallerinaParser) parseMappingConstructorExpr() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_MAPPING_CONSTRUCTOR)
-	openBrace := this.parseOpenBrace()
-	fields := this.parseMappingConstructorFields()
-	closeBrace := this.parseCloseBrace()
-	this.endContext()
+func (b *BallerinaParser) parseMappingConstructorExpr() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_MAPPING_CONSTRUCTOR)
+	openBrace := b.parseOpenBrace()
+	fields := b.parseMappingConstructorFields()
+	closeBrace := b.parseCloseBrace()
+	b.endContext()
 	return tree.CreateMappingConstructorExpressionNode(openBrace, fields, closeBrace)
 }
 
-func (this *BallerinaParser) parseMappingConstructorFields() tree.STNode {
-	nextToken := this.peek()
-	if this.isEndOfMappingConstructor(nextToken.Kind()) {
+func (b *BallerinaParser) parseMappingConstructorFields() tree.STNode {
+	nextToken := b.peek()
+	if b.isEndOfMappingConstructor(nextToken.Kind()) {
 		return tree.CreateEmptyNodeList()
 	}
 	var fields []tree.STNode
-	field := this.parseMappingField(common.PARSER_RULE_CONTEXT_FIRST_MAPPING_FIELD)
+	field := b.parseMappingField(common.PARSER_RULE_CONTEXT_FIRST_MAPPING_FIELD)
 	if field != nil {
 		fields = append(fields, field)
 	}
-	return this.finishParseMappingConstructorFields(fields)
+	return b.finishParseMappingConstructorFields(fields)
 }
 
-func (this *BallerinaParser) finishParseMappingConstructorFields(fields []tree.STNode) tree.STNode {
+func (b *BallerinaParser) finishParseMappingConstructorFields(fields []tree.STNode) tree.STNode {
 	var nextToken tree.STToken
 	var mappingFieldEnd tree.STNode
-	nextToken = this.peek()
-	for !this.isEndOfMappingConstructor(nextToken.Kind()) {
-		mappingFieldEnd = this.parseMappingFieldEnd()
+	nextToken = b.peek()
+	for !b.isEndOfMappingConstructor(nextToken.Kind()) {
+		mappingFieldEnd = b.parseMappingFieldEnd()
 		if mappingFieldEnd == nil {
 			break
 		}
 		fields = append(fields, mappingFieldEnd)
-		field := this.parseMappingField(common.PARSER_RULE_CONTEXT_MAPPING_FIELD)
+		field := b.parseMappingField(common.PARSER_RULE_CONTEXT_MAPPING_FIELD)
 		fields = append(fields, field)
-		nextToken = this.peek()
+		nextToken = b.peek()
 	}
 	return tree.CreateNodeList(fields...)
 }
 
-func (this *BallerinaParser) parseMappingFieldEnd() tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseMappingFieldEnd() tree.STNode {
+	switch b.peek().Kind() {
 	case common.COMMA_TOKEN:
-		return this.parseComma()
+		return b.parseComma()
 	case common.CLOSE_BRACE_TOKEN:
 		return nil
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_MAPPING_FIELD_END)
-		return this.parseMappingFieldEnd()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_MAPPING_FIELD_END)
+		return b.parseMappingFieldEnd()
 	}
 }
 
-func (this *BallerinaParser) isEndOfMappingConstructor(tokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isEndOfMappingConstructor(tokenKind common.SyntaxKind) bool {
 	switch tokenKind {
 	case common.IDENTIFIER_TOKEN, common.READONLY_KEYWORD:
 		return false
@@ -6060,23 +6060,23 @@ func (this *BallerinaParser) isEndOfMappingConstructor(tokenKind common.SyntaxKi
 	}
 }
 
-func (this *BallerinaParser) parseMappingField(fieldContext common.ParserRuleContext) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseMappingField(fieldContext common.ParserRuleContext) tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.IDENTIFIER_TOKEN:
 		readonlyKeyword := tree.CreateEmptyNode()
-		return this.parseSpecificFieldWithOptionalValue(readonlyKeyword)
+		return b.parseSpecificFieldWithOptionalValue(readonlyKeyword)
 	case common.STRING_LITERAL_TOKEN:
 		readonlyKeyword := tree.CreateEmptyNode()
-		return this.parseQualifiedSpecificField(readonlyKeyword)
+		return b.parseQualifiedSpecificField(readonlyKeyword)
 	case common.READONLY_KEYWORD:
-		readonlyKeyword := this.parseReadonlyKeyword()
-		return this.parseSpecificField(readonlyKeyword)
+		readonlyKeyword := b.parseReadonlyKeyword()
+		return b.parseSpecificField(readonlyKeyword)
 	case common.OPEN_BRACKET_TOKEN:
-		return this.parseComputedField()
+		return b.parseComputedField()
 	case common.ELLIPSIS_TOKEN:
-		ellipsis := this.parseEllipsis()
-		expr := this.parseExpression()
+		ellipsis := b.parseEllipsis()
+		expr := b.parseExpression()
 		return tree.CreateSpreadFieldNode(ellipsis, expr)
 	case common.CLOSE_BRACE_TOKEN:
 		if fieldContext == common.PARSER_RULE_CONTEXT_FIRST_MAPPING_FIELD {
@@ -6084,119 +6084,119 @@ func (this *BallerinaParser) parseMappingField(fieldContext common.ParserRuleCon
 		}
 		fallthrough
 	default:
-		this.recoverWithBlockContext(nextToken, fieldContext)
-		return this.parseMappingField(fieldContext)
+		b.recoverWithBlockContext(nextToken, fieldContext)
+		return b.parseMappingField(fieldContext)
 	}
 }
 
-func (this *BallerinaParser) parseSpecificField(readonlyKeyword tree.STNode) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseSpecificField(readonlyKeyword tree.STNode) tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.STRING_LITERAL_TOKEN:
-		return this.parseQualifiedSpecificField(readonlyKeyword)
+		return b.parseQualifiedSpecificField(readonlyKeyword)
 	case common.IDENTIFIER_TOKEN:
-		return this.parseSpecificFieldWithOptionalValue(readonlyKeyword)
+		return b.parseSpecificFieldWithOptionalValue(readonlyKeyword)
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_SPECIFIC_FIELD)
-		return this.parseSpecificField(readonlyKeyword)
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_SPECIFIC_FIELD)
+		return b.parseSpecificField(readonlyKeyword)
 	}
 }
 
-func (this *BallerinaParser) parseQualifiedSpecificField(readonlyKeyword tree.STNode) tree.STNode {
-	key := this.parseStringLiteral()
-	colon := this.parseColon()
-	valueExpr := this.parseExpression()
+func (b *BallerinaParser) parseQualifiedSpecificField(readonlyKeyword tree.STNode) tree.STNode {
+	key := b.parseStringLiteral()
+	colon := b.parseColon()
+	valueExpr := b.parseExpression()
 	return tree.CreateSpecificFieldNode(readonlyKeyword, key, colon, valueExpr)
 }
 
-func (this *BallerinaParser) parseSpecificFieldWithOptionalValue(readonlyKeyword tree.STNode) tree.STNode {
-	key := this.parseIdentifier(common.PARSER_RULE_CONTEXT_MAPPING_FIELD_NAME)
-	return this.parseSpecificFieldRhs(readonlyKeyword, key)
+func (b *BallerinaParser) parseSpecificFieldWithOptionalValue(readonlyKeyword tree.STNode) tree.STNode {
+	key := b.parseIdentifier(common.PARSER_RULE_CONTEXT_MAPPING_FIELD_NAME)
+	return b.parseSpecificFieldRhs(readonlyKeyword, key)
 }
 
-func (this *BallerinaParser) parseSpecificFieldRhs(readonlyKeyword tree.STNode, key tree.STNode) tree.STNode {
+func (b *BallerinaParser) parseSpecificFieldRhs(readonlyKeyword tree.STNode, key tree.STNode) tree.STNode {
 	var colon tree.STNode
 	var valueExpr tree.STNode
-	nextToken := this.peek()
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.COLON_TOKEN:
-		colon = this.parseColon()
-		valueExpr = this.parseExpression()
+		colon = b.parseColon()
+		valueExpr = b.parseExpression()
 	case common.COMMA_TOKEN:
 		colon = tree.CreateEmptyNode()
 		valueExpr = tree.CreateEmptyNode()
 	default:
-		if this.isEndOfMappingConstructor(nextToken.Kind()) {
+		if b.isEndOfMappingConstructor(nextToken.Kind()) {
 			colon = tree.CreateEmptyNode()
 			valueExpr = tree.CreateEmptyNode()
 			break
 		}
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_SPECIFIC_FIELD_RHS)
-		return this.parseSpecificFieldRhs(readonlyKeyword, key)
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_SPECIFIC_FIELD_RHS)
+		return b.parseSpecificFieldRhs(readonlyKeyword, key)
 	}
 	return tree.CreateSpecificFieldNode(readonlyKeyword, key, colon, valueExpr)
 }
 
-func (this *BallerinaParser) parseStringLiteral() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseStringLiteral() tree.STNode {
+	token := b.peek()
 	var stringLiteral tree.STNode
 	if token.Kind() == common.STRING_LITERAL_TOKEN {
-		stringLiteral = this.consume()
+		stringLiteral = b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_STRING_LITERAL_TOKEN)
-		return this.parseStringLiteral()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_STRING_LITERAL_TOKEN)
+		return b.parseStringLiteral()
 	}
-	return this.parseBasicLiteralInner(stringLiteral)
+	return b.parseBasicLiteralInner(stringLiteral)
 }
 
-func (this *BallerinaParser) parseColon() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseColon() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.COLON_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_COLON)
-		return this.parseColon()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_COLON)
+		return b.parseColon()
 	}
 }
 
-func (this *BallerinaParser) parseReadonlyKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseReadonlyKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.READONLY_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_READONLY_KEYWORD)
-		return this.parseReadonlyKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_READONLY_KEYWORD)
+		return b.parseReadonlyKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseComputedField() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_COMPUTED_FIELD_NAME)
-	openBracket := this.parseOpenBracket()
-	fieldNameExpr := this.parseExpression()
-	closeBracket := this.parseCloseBracket()
-	this.endContext()
-	colon := this.parseColon()
-	valueExpr := this.parseExpression()
+func (b *BallerinaParser) parseComputedField() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_COMPUTED_FIELD_NAME)
+	openBracket := b.parseOpenBracket()
+	fieldNameExpr := b.parseExpression()
+	closeBracket := b.parseCloseBracket()
+	b.endContext()
+	colon := b.parseColon()
+	valueExpr := b.parseExpression()
 	return tree.CreateComputedNameFieldNode(openBracket, fieldNameExpr, closeBracket, colon, valueExpr)
 }
 
-func (this *BallerinaParser) parseOpenBracket() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseOpenBracket() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.OPEN_BRACKET_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_OPEN_BRACKET)
-		return this.parseOpenBracket()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_OPEN_BRACKET)
+		return b.parseOpenBracket()
 	}
 }
 
-func (this *BallerinaParser) parseCompoundAssignmentStmtRhs(lvExpr tree.STNode) tree.STNode {
-	binaryOperator := this.parseCompoundBinaryOperator()
-	equalsToken := this.parseAssignOp()
-	expr := this.parseActionOrExpression()
-	semicolon := this.parseSemicolon()
-	this.endContext()
-	lvExprValid := this.isValidLVExpr(lvExpr)
+func (b *BallerinaParser) parseCompoundAssignmentStmtRhs(lvExpr tree.STNode) tree.STNode {
+	binaryOperator := b.parseCompoundBinaryOperator()
+	equalsToken := b.parseAssignOp()
+	expr := b.parseActionOrExpression()
+	semicolon := b.parseSemicolon()
+	b.endContext()
+	lvExprValid := b.isValidLVExpr(lvExpr)
 	if !lvExprValid {
 		identifier := tree.CreateMissingToken(common.IDENTIFIER_TOKEN, nil)
 		simpleNameRef := tree.CreateSimpleNameReferenceNode(identifier)
@@ -6207,54 +6207,54 @@ func (this *BallerinaParser) parseCompoundAssignmentStmtRhs(lvExpr tree.STNode) 
 		semicolon)
 }
 
-func (this *BallerinaParser) parseCompoundBinaryOperator() tree.STNode {
-	token := this.peek()
-	if this.isCompoundAssignment(token.Kind()) {
-		return this.consume()
+func (b *BallerinaParser) parseCompoundBinaryOperator() tree.STNode {
+	token := b.peek()
+	if b.isCompoundAssignment(token.Kind()) {
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_COMPOUND_BINARY_OPERATOR)
-		return this.parseCompoundBinaryOperator()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_COMPOUND_BINARY_OPERATOR)
+		return b.parseCompoundBinaryOperator()
 	}
 }
 
-func (this *BallerinaParser) parseServiceDeclOrVarDecl(metadata tree.STNode, publicQualifier tree.STNode, qualifiers []tree.STNode) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_SERVICE_DECL)
-	serviceDeclQualList, qualifiers := this.extractServiceDeclQualifiers(qualifiers)
-	serviceKeyword, qualifiers := this.extractServiceKeyword(qualifiers)
-	typeDesc := this.parseServiceDeclTypeDescriptor(qualifiers)
+func (b *BallerinaParser) parseServiceDeclOrVarDecl(metadata tree.STNode, publicQualifier tree.STNode, qualifiers []tree.STNode) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_SERVICE_DECL)
+	serviceDeclQualList, qualifiers := b.extractServiceDeclQualifiers(qualifiers)
+	serviceKeyword, qualifiers := b.extractServiceKeyword(qualifiers)
+	typeDesc := b.parseServiceDeclTypeDescriptor(qualifiers)
 	if (typeDesc != nil) && (typeDesc.Kind() == common.OBJECT_TYPE_DESC) {
-		return this.finishParseServiceDeclOrVarDecl(metadata, publicQualifier, serviceDeclQualList, serviceKeyword,
+		return b.finishParseServiceDeclOrVarDecl(metadata, publicQualifier, serviceDeclQualList, serviceKeyword,
 			typeDesc)
 	} else {
-		return this.parseServiceDecl(metadata, publicQualifier, serviceDeclQualList, serviceKeyword, typeDesc)
+		return b.parseServiceDecl(metadata, publicQualifier, serviceDeclQualList, serviceKeyword, typeDesc)
 	}
 }
 
-func (this *BallerinaParser) finishParseServiceDeclOrVarDecl(metadata tree.STNode, publicQualifier tree.STNode, serviceDeclQualList []tree.STNode, serviceKeyword tree.STNode, typeDesc tree.STNode) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) finishParseServiceDeclOrVarDecl(metadata tree.STNode, publicQualifier tree.STNode, serviceDeclQualList []tree.STNode, serviceKeyword tree.STNode, typeDesc tree.STNode) tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.SLASH_TOKEN, common.ON_KEYWORD:
-		return this.parseServiceDecl(metadata, publicQualifier, serviceDeclQualList, serviceKeyword, typeDesc)
+		return b.parseServiceDecl(metadata, publicQualifier, serviceDeclQualList, serviceKeyword, typeDesc)
 	case common.OPEN_BRACKET_TOKEN,
 		common.IDENTIFIER_TOKEN,
 		common.OPEN_BRACE_TOKEN,
 		common.ERROR_KEYWORD:
-		this.endContext()
-		typeDesc = this.modifyObjectTypeDescWithALeadingQualifier(typeDesc, serviceKeyword)
+		b.endContext()
+		typeDesc = b.modifyObjectTypeDescWithALeadingQualifier(typeDesc, serviceKeyword)
 		if len(serviceDeclQualList) != 0 {
 			isolatedQualifier := serviceDeclQualList[0]
-			typeDesc = this.modifyObjectTypeDescWithALeadingQualifier(typeDesc, isolatedQualifier)
+			typeDesc = b.modifyObjectTypeDescWithALeadingQualifier(typeDesc, isolatedQualifier)
 		}
-		res, _ := this.parseVarDeclTypeDescRhsInner(typeDesc, metadata, publicQualifier, nil, true, true)
+		res, _ := b.parseVarDeclTypeDescRhsInner(typeDesc, metadata, publicQualifier, nil, true, true)
 		return res
 	default:
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_SERVICE_DECL_OR_VAR_DECL)
-		return this.finishParseServiceDeclOrVarDecl(metadata, publicQualifier, serviceDeclQualList, serviceKeyword,
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_SERVICE_DECL_OR_VAR_DECL)
+		return b.finishParseServiceDeclOrVarDecl(metadata, publicQualifier, serviceDeclQualList, serviceKeyword,
 			typeDesc)
 	}
 }
 
-func (this *BallerinaParser) extractServiceDeclQualifiers(qualifierList []tree.STNode) ([]tree.STNode, []tree.STNode) {
+func (b *BallerinaParser) extractServiceDeclQualifiers(qualifierList []tree.STNode) ([]tree.STNode, []tree.STNode) {
 	var validatedList []tree.STNode
 	i := 0
 	for ; i < len(qualifierList); i++ {
@@ -6264,8 +6264,8 @@ func (this *BallerinaParser) extractServiceDeclQualifiers(qualifierList []tree.S
 			qualifierList = qualifierList[i:]
 			break
 		}
-		if this.isSyntaxKindInList(validatedList, qualifier.Kind()) {
-			this.updateLastNodeInListWithInvalidNode(validatedList, qualifier,
+		if b.isSyntaxKindInList(validatedList, qualifier.Kind()) {
+			b.updateLastNodeInListWithInvalidNode(validatedList, qualifier,
 				&common.ERROR_DUPLICATE_QUALIFIER, tree.ToToken(tree.ToToken(qualifier)).Text())
 			continue
 		}
@@ -6274,17 +6274,17 @@ func (this *BallerinaParser) extractServiceDeclQualifiers(qualifierList []tree.S
 			continue
 		}
 		if len(qualifierList) == nextIndex {
-			this.addInvalidNodeToNextToken(qualifier, &common.ERROR_QUALIFIER_NOT_ALLOWED,
+			b.addInvalidNodeToNextToken(qualifier, &common.ERROR_QUALIFIER_NOT_ALLOWED,
 				tree.ToToken(tree.ToToken(qualifier)).Text())
 		} else {
-			this.updateANodeInListWithLeadingInvalidNode(qualifierList, nextIndex, qualifier,
+			b.updateANodeInListWithLeadingInvalidNode(qualifierList, nextIndex, qualifier,
 				&common.ERROR_QUALIFIER_NOT_ALLOWED, tree.ToToken(tree.ToToken(qualifier)).Text())
 		}
 	}
 	return validatedList, qualifierList
 }
 
-func (this *BallerinaParser) extractServiceKeyword(qualifierList []tree.STNode) (tree.STNode, []tree.STNode) {
+func (b *BallerinaParser) extractServiceKeyword(qualifierList []tree.STNode) (tree.STNode, []tree.STNode) {
 	if len(qualifierList) == 0 {
 		panic("assertion failed")
 	}
@@ -6296,10 +6296,10 @@ func (this *BallerinaParser) extractServiceKeyword(qualifierList []tree.STNode) 
 	return serviceKeyword, qualifierList
 }
 
-func (this *BallerinaParser) parseServiceDecl(metadata tree.STNode, publicQualifier tree.STNode, qualList []tree.STNode, serviceKeyword tree.STNode, serviceType tree.STNode) tree.STNode {
+func (b *BallerinaParser) parseServiceDecl(metadata tree.STNode, publicQualifier tree.STNode, qualList []tree.STNode, serviceKeyword tree.STNode, serviceType tree.STNode) tree.STNode {
 	if publicQualifier != nil {
 		if len(qualList) != 0 {
-			this.updateFirstNodeInListWithLeadingInvalidNode(qualList, publicQualifier,
+			b.updateFirstNodeInListWithLeadingInvalidNode(qualList, publicQualifier,
 				&common.ERROR_QUALIFIER_NOT_ALLOWED)
 		} else {
 			serviceKeyword = tree.CloneWithLeadingInvalidNodeMinutiae(serviceKeyword, publicQualifier,
@@ -6307,79 +6307,79 @@ func (this *BallerinaParser) parseServiceDecl(metadata tree.STNode, publicQualif
 		}
 	}
 	qualNodeList := tree.CreateNodeList(qualList...)
-	resourcePath := this.parseOptionalAbsolutePathOrStringLiteral()
-	onKeyword := this.parseOnKeyword()
-	expressionList := this.parseListeners()
-	openBrace := this.parseOpenBrace()
-	objectMembers := this.parseObjectMembers(common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR_MEMBER)
-	closeBrace := this.parseCloseBrace()
-	semicolon := this.parseOptionalSemicolon()
-	onKeyword = this.cloneWithDiagnosticIfListEmpty(expressionList, onKeyword, &common.ERROR_MISSING_EXPRESSION)
-	this.endContext()
+	resourcePath := b.parseOptionalAbsolutePathOrStringLiteral()
+	onKeyword := b.parseOnKeyword()
+	expressionList := b.parseListeners()
+	openBrace := b.parseOpenBrace()
+	objectMembers := b.parseObjectMembers(common.PARSER_RULE_CONTEXT_OBJECT_CONSTRUCTOR_MEMBER)
+	closeBrace := b.parseCloseBrace()
+	semicolon := b.parseOptionalSemicolon()
+	onKeyword = b.cloneWithDiagnosticIfListEmpty(expressionList, onKeyword, &common.ERROR_MISSING_EXPRESSION)
+	b.endContext()
 	return tree.CreateServiceDeclarationNode(metadata, qualNodeList, serviceKeyword, serviceType,
 		resourcePath, onKeyword, expressionList, openBrace, objectMembers, closeBrace, semicolon)
 }
 
-func (this *BallerinaParser) parseServiceDeclTypeDescriptor(qualifiers []tree.STNode) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseServiceDeclTypeDescriptor(qualifiers []tree.STNode) tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.SLASH_TOKEN,
 		common.ON_KEYWORD,
 		common.STRING_LITERAL_TOKEN:
-		this.reportInvalidQualifierList(qualifiers)
+		b.reportInvalidQualifierList(qualifiers)
 		return tree.CreateEmptyNode()
 	default:
-		if this.isTypeStartingToken(nextToken.Kind()) {
-			return this.parseTypeDescriptorWithQualifier(qualifiers, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_SERVICE)
+		if b.isTypeStartingToken(nextToken.Kind()) {
+			return b.parseTypeDescriptorWithQualifier(qualifiers, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_SERVICE)
 		}
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_OPTIONAL_SERVICE_DECL_TYPE)
-		return this.parseServiceDeclTypeDescriptor(qualifiers)
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_OPTIONAL_SERVICE_DECL_TYPE)
+		return b.parseServiceDeclTypeDescriptor(qualifiers)
 	}
 }
 
-func (this *BallerinaParser) parseOptionalAbsolutePathOrStringLiteral() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseOptionalAbsolutePathOrStringLiteral() tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.SLASH_TOKEN:
-		return this.parseAbsoluteResourcePath()
+		return b.parseAbsoluteResourcePath()
 	case common.STRING_LITERAL_TOKEN:
-		stringLiteralToken := this.consume()
-		stringLiteralNode := this.parseBasicLiteralInner(stringLiteralToken)
+		stringLiteralToken := b.consume()
+		stringLiteralNode := b.parseBasicLiteralInner(stringLiteralToken)
 		return tree.CreateNodeList(stringLiteralNode)
 	case common.ON_KEYWORD:
 		return tree.CreateEmptyNodeList()
 	default:
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_OPTIONAL_ABSOLUTE_PATH)
-		return this.parseOptionalAbsolutePathOrStringLiteral()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_OPTIONAL_ABSOLUTE_PATH)
+		return b.parseOptionalAbsolutePathOrStringLiteral()
 	}
 }
 
-func (this *BallerinaParser) parseAbsoluteResourcePath() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_ABSOLUTE_RESOURCE_PATH)
+func (b *BallerinaParser) parseAbsoluteResourcePath() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_ABSOLUTE_RESOURCE_PATH)
 	var identifierList []tree.STNode
-	nextToken := this.peek()
+	nextToken := b.peek()
 	var leadingSlash tree.STNode
 	isInitialSlash := true
-	for !this.isEndAbsoluteResourcePath(nextToken.Kind()) {
-		leadingSlash = this.parseAbsoluteResourcePathEnd(isInitialSlash)
+	for !b.isEndAbsoluteResourcePath(nextToken.Kind()) {
+		leadingSlash = b.parseAbsoluteResourcePathEnd(isInitialSlash)
 		if leadingSlash == nil {
 			break
 		}
 		identifierList = append(identifierList, leadingSlash)
-		nextToken = this.peek()
+		nextToken = b.peek()
 		if isInitialSlash && (nextToken.Kind() == common.ON_KEYWORD) {
 			break
 		}
 		isInitialSlash = false
-		leadingSlash = this.parseIdentifier(common.PARSER_RULE_CONTEXT_IDENTIFIER)
+		leadingSlash = b.parseIdentifier(common.PARSER_RULE_CONTEXT_IDENTIFIER)
 		identifierList = append(identifierList, leadingSlash)
-		nextToken = this.peek()
+		nextToken = b.peek()
 	}
-	this.endContext()
+	b.endContext()
 	return tree.CreateNodeList(identifierList...)
 }
 
-func (this *BallerinaParser) isEndAbsoluteResourcePath(tokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isEndAbsoluteResourcePath(tokenKind common.SyntaxKind) bool {
 	switch tokenKind {
 	case common.EOF_TOKEN, common.ON_KEYWORD:
 		return true
@@ -6388,13 +6388,13 @@ func (this *BallerinaParser) isEndAbsoluteResourcePath(tokenKind common.SyntaxKi
 	}
 }
 
-func (this *BallerinaParser) parseAbsoluteResourcePathEnd(isInitialSlash bool) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseAbsoluteResourcePathEnd(isInitialSlash bool) tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.ON_KEYWORD, common.EOF_TOKEN:
 		return nil
 	case common.SLASH_TOKEN:
-		return this.consume()
+		return b.consume()
 	default:
 		var context common.ParserRuleContext
 		if isInitialSlash {
@@ -6402,61 +6402,61 @@ func (this *BallerinaParser) parseAbsoluteResourcePathEnd(isInitialSlash bool) t
 		} else {
 			context = common.PARSER_RULE_CONTEXT_ABSOLUTE_RESOURCE_PATH_END
 		}
-		this.recoverWithBlockContext(nextToken, context)
-		return this.parseAbsoluteResourcePathEnd(isInitialSlash)
+		b.recoverWithBlockContext(nextToken, context)
+		return b.parseAbsoluteResourcePathEnd(isInitialSlash)
 	}
 }
 
 // MIGRATION-NOTE: this is used only recursively in Ballerina parser as well, left as is for now.
-func (this *BallerinaParser) parseServiceKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseServiceKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.SERVICE_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_SERVICE_KEYWORD)
-		return this.parseServiceKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_SERVICE_KEYWORD)
+		return b.parseServiceKeyword()
 	}
 }
 
-func (this *BallerinaParser) isCompoundAssignment(tokenKind common.SyntaxKind) bool {
-	return (isCompoundBinaryOperator(tokenKind) && (this.getNextNextToken().Kind() == common.EQUAL_TOKEN))
+func (b *BallerinaParser) isCompoundAssignment(tokenKind common.SyntaxKind) bool {
+	return (isCompoundBinaryOperator(tokenKind) && (b.getNextNextToken().Kind() == common.EQUAL_TOKEN))
 }
 
-func (this *BallerinaParser) parseOnKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseOnKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.ON_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_ON_KEYWORD)
-		return this.parseOnKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_ON_KEYWORD)
+		return b.parseOnKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseListeners() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_LISTENERS_LIST)
+func (b *BallerinaParser) parseListeners() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_LISTENERS_LIST)
 	var listeners []tree.STNode
-	nextToken := this.peek()
-	if this.isEndOfListeners(nextToken.Kind()) {
-		this.endContext()
+	nextToken := b.peek()
+	if b.isEndOfListeners(nextToken.Kind()) {
+		b.endContext()
 		return tree.CreateEmptyNodeList()
 	}
-	expr := this.parseExpression()
+	expr := b.parseExpression()
 	listeners = append(listeners, expr)
 	var listenersMemberEnd tree.STNode
-	for !this.isEndOfListeners(this.peek().Kind()) {
-		listenersMemberEnd = this.parseListenersMemberEnd()
+	for !b.isEndOfListeners(b.peek().Kind()) {
+		listenersMemberEnd = b.parseListenersMemberEnd()
 		if listenersMemberEnd == nil {
 			break
 		}
 		listeners = append(listeners, listenersMemberEnd)
-		expr = this.parseExpression()
+		expr = b.parseExpression()
 		listeners = append(listeners, expr)
 	}
-	this.endContext()
+	b.endContext()
 	return tree.CreateNodeList(listeners...)
 }
 
-func (this *BallerinaParser) isEndOfListeners(tokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isEndOfListeners(tokenKind common.SyntaxKind) bool {
 	switch tokenKind {
 	case common.OPEN_BRACE_TOKEN, common.EOF_TOKEN:
 		return true
@@ -6465,23 +6465,23 @@ func (this *BallerinaParser) isEndOfListeners(tokenKind common.SyntaxKind) bool 
 	}
 }
 
-func (this *BallerinaParser) parseListenersMemberEnd() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseListenersMemberEnd() tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.COMMA_TOKEN:
-		return this.parseComma()
+		return b.parseComma()
 	case common.OPEN_BRACE_TOKEN:
 		return nil
 	default:
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_LISTENERS_LIST_END)
-		return this.parseListenersMemberEnd()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_LISTENERS_LIST_END)
+		return b.parseListenersMemberEnd()
 	}
 }
 
-func (this *BallerinaParser) isServiceDeclStart(currentContext common.ParserRuleContext, lookahead int) bool {
-	switch this.peekN(lookahead + 1).Kind() {
+func (b *BallerinaParser) isServiceDeclStart(currentContext common.ParserRuleContext, lookahead int) bool {
+	switch b.peekN(lookahead + 1).Kind() {
 	case common.IDENTIFIER_TOKEN:
-		tokenAfterIdentifier := this.peekN(lookahead + 2).Kind()
+		tokenAfterIdentifier := b.peekN(lookahead + 2).Kind()
 		switch tokenAfterIdentifier {
 		case common.ON_KEYWORD,
 			// service foo on ...
@@ -6503,84 +6503,84 @@ func (this *BallerinaParser) isServiceDeclStart(currentContext common.ParserRule
 	}
 }
 
-func (this *BallerinaParser) parseListenerDeclaration(metadata tree.STNode, qualifier tree.STNode) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_LISTENER_DECL)
-	listenerKeyword := this.parseListenerKeyword()
-	if this.peek().Kind() == common.IDENTIFIER_TOKEN {
-		listenerDecl := this.parseConstantOrListenerDeclWithOptionalType(metadata, qualifier, listenerKeyword, true)
-		this.endContext()
+func (b *BallerinaParser) parseListenerDeclaration(metadata tree.STNode, qualifier tree.STNode) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_LISTENER_DECL)
+	listenerKeyword := b.parseListenerKeyword()
+	if b.peek().Kind() == common.IDENTIFIER_TOKEN {
+		listenerDecl := b.parseConstantOrListenerDeclWithOptionalType(metadata, qualifier, listenerKeyword, true)
+		b.endContext()
 		return listenerDecl
 	}
-	typeDesc := this.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_BEFORE_IDENTIFIER)
-	variableName := this.parseVariableName()
-	equalsToken := this.parseAssignOp()
-	initializer := this.parseExpression()
-	semicolonToken := this.parseSemicolon()
-	this.endContext()
+	typeDesc := b.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_BEFORE_IDENTIFIER)
+	variableName := b.parseVariableName()
+	equalsToken := b.parseAssignOp()
+	initializer := b.parseExpression()
+	semicolonToken := b.parseSemicolon()
+	b.endContext()
 	return tree.CreateListenerDeclarationNode(metadata, qualifier, listenerKeyword, typeDesc, variableName,
 		equalsToken, initializer, semicolonToken)
 }
 
-func (this *BallerinaParser) parseListenerKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseListenerKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.LISTENER_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_LISTENER_KEYWORD)
-		return this.parseListenerKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_LISTENER_KEYWORD)
+		return b.parseListenerKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseConstantDeclaration(metadata tree.STNode, qualifier tree.STNode) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_CONSTANT_DECL)
-	constKeyword := this.parseConstantKeyword()
-	return this.parseConstDecl(metadata, qualifier, constKeyword)
+func (b *BallerinaParser) parseConstantDeclaration(metadata tree.STNode, qualifier tree.STNode) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_CONSTANT_DECL)
+	constKeyword := b.parseConstantKeyword()
+	return b.parseConstDecl(metadata, qualifier, constKeyword)
 }
 
-func (this *BallerinaParser) parseConstDecl(metadata tree.STNode, qualifier tree.STNode, constKeyword tree.STNode) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseConstDecl(metadata tree.STNode, qualifier tree.STNode, constKeyword tree.STNode) tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.ANNOTATION_KEYWORD:
-		this.endContext()
-		return this.parseAnnotationDeclaration(metadata, qualifier, constKeyword)
+		b.endContext()
+		return b.parseAnnotationDeclaration(metadata, qualifier, constKeyword)
 	case common.IDENTIFIER_TOKEN:
-		constantDecl := this.parseConstantOrListenerDeclWithOptionalType(metadata, qualifier, constKeyword, false)
-		this.endContext()
+		constantDecl := b.parseConstantOrListenerDeclWithOptionalType(metadata, qualifier, constKeyword, false)
+		b.endContext()
 		return constantDecl
 	default:
-		if this.isTypeStartingToken(nextToken.Kind()) {
+		if b.isTypeStartingToken(nextToken.Kind()) {
 			break
 		}
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_CONST_DECL_TYPE)
-		return this.parseConstDecl(metadata, qualifier, constKeyword)
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_CONST_DECL_TYPE)
+		return b.parseConstDecl(metadata, qualifier, constKeyword)
 	}
-	typeDesc := this.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_BEFORE_IDENTIFIER)
-	variableName := this.parseVariableName()
-	equalsToken := this.parseAssignOp()
-	initializer := this.parseExpression()
-	semicolonToken := this.parseSemicolon()
-	this.endContext()
+	typeDesc := b.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_BEFORE_IDENTIFIER)
+	variableName := b.parseVariableName()
+	equalsToken := b.parseAssignOp()
+	initializer := b.parseExpression()
+	semicolonToken := b.parseSemicolon()
+	b.endContext()
 	return tree.CreateConstantDeclarationNode(metadata, qualifier, constKeyword, typeDesc, variableName,
 		equalsToken, initializer, semicolonToken)
 }
 
-func (this *BallerinaParser) parseConstantOrListenerDeclWithOptionalType(metadata tree.STNode, qualifier tree.STNode, constKeyword tree.STNode, isListener bool) tree.STNode {
-	varNameOrTypeName := this.parseStatementStartIdentifier()
-	return this.parseConstantOrListenerDeclRhs(metadata, qualifier, constKeyword, varNameOrTypeName, isListener)
+func (b *BallerinaParser) parseConstantOrListenerDeclWithOptionalType(metadata tree.STNode, qualifier tree.STNode, constKeyword tree.STNode, isListener bool) tree.STNode {
+	varNameOrTypeName := b.parseStatementStartIdentifier()
+	return b.parseConstantOrListenerDeclRhs(metadata, qualifier, constKeyword, varNameOrTypeName, isListener)
 }
 
-func (this *BallerinaParser) parseConstantOrListenerDeclRhs(metadata tree.STNode, qualifier tree.STNode, keyword tree.STNode, typeOrVarName tree.STNode, isListener bool) tree.STNode {
+func (b *BallerinaParser) parseConstantOrListenerDeclRhs(metadata tree.STNode, qualifier tree.STNode, keyword tree.STNode, typeOrVarName tree.STNode, isListener bool) tree.STNode {
 	if typeOrVarName.Kind() == common.QUALIFIED_NAME_REFERENCE {
 		ty := typeOrVarName
-		variableName := this.parseVariableName()
-		return this.parseListenerOrConstRhs(metadata, qualifier, keyword, isListener, ty, variableName)
+		variableName := b.parseVariableName()
+		return b.parseListenerOrConstRhs(metadata, qualifier, keyword, isListener, ty, variableName)
 	}
 	var ty tree.STNode
 	var variableName tree.STNode
-	switch this.peek().Kind() {
+	switch b.peek().Kind() {
 	case common.IDENTIFIER_TOKEN:
 		ty = typeOrVarName
-		variableName = this.parseVariableName()
+		variableName = b.parseVariableName()
 	case common.EQUAL_TOKEN:
 		simpleNameNode, ok := typeOrVarName.(*tree.STSimpleNameReferenceNode)
 		if !ok {
@@ -6589,16 +6589,16 @@ func (this *BallerinaParser) parseConstantOrListenerDeclRhs(metadata tree.STNode
 		variableName = simpleNameNode.Name
 		ty = tree.CreateEmptyNode()
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_CONST_DECL_RHS)
-		return this.parseConstantOrListenerDeclRhs(metadata, qualifier, keyword, typeOrVarName, isListener)
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_CONST_DECL_RHS)
+		return b.parseConstantOrListenerDeclRhs(metadata, qualifier, keyword, typeOrVarName, isListener)
 	}
-	return this.parseListenerOrConstRhs(metadata, qualifier, keyword, isListener, ty, variableName)
+	return b.parseListenerOrConstRhs(metadata, qualifier, keyword, isListener, ty, variableName)
 }
 
-func (this *BallerinaParser) parseListenerOrConstRhs(metadata tree.STNode, qualifier tree.STNode, keyword tree.STNode, isListener bool, ty tree.STNode, variableName tree.STNode) tree.STNode {
-	equalsToken := this.parseAssignOp()
-	initializer := this.parseExpression()
-	semicolonToken := this.parseSemicolon()
+func (b *BallerinaParser) parseListenerOrConstRhs(metadata tree.STNode, qualifier tree.STNode, keyword tree.STNode, isListener bool, ty tree.STNode, variableName tree.STNode) tree.STNode {
+	equalsToken := b.parseAssignOp()
+	initializer := b.parseExpression()
+	semicolonToken := b.parseSemicolon()
 	if isListener {
 		return tree.CreateListenerDeclarationNode(metadata, qualifier, keyword, ty, variableName,
 			equalsToken, initializer, semicolonToken)
@@ -6607,79 +6607,79 @@ func (this *BallerinaParser) parseListenerOrConstRhs(metadata tree.STNode, quali
 		equalsToken, initializer, semicolonToken)
 }
 
-func (this *BallerinaParser) parseConstantKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseConstantKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.CONST_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_CONST_KEYWORD)
-		return this.parseConstantKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_CONST_KEYWORD)
+		return b.parseConstantKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseTypeofExpression(isRhsExpr bool, isInConditionalExpr bool) tree.STNode {
-	typeofKeyword := this.parseTypeofKeyword()
-	expr := this.parseExpressionWithConditional(OPERATOR_PRECEDENCE_UNARY, isRhsExpr, false, isInConditionalExpr)
+func (b *BallerinaParser) parseTypeofExpression(isRhsExpr bool, isInConditionalExpr bool) tree.STNode {
+	typeofKeyword := b.parseTypeofKeyword()
+	expr := b.parseExpressionWithConditional(OPERATOR_PRECEDENCE_UNARY, isRhsExpr, false, isInConditionalExpr)
 	return tree.CreateTypeofExpressionNode(typeofKeyword, expr)
 }
 
-func (this *BallerinaParser) parseTypeofKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseTypeofKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.TYPEOF_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_TYPEOF_KEYWORD)
-		return this.parseTypeofKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_TYPEOF_KEYWORD)
+		return b.parseTypeofKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseOptionalTypeDescriptor(typeDescriptorNode tree.STNode) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_OPTIONAL_TYPE_DESCRIPTOR)
-	questionMarkToken := this.parseQuestionMark()
-	this.endContext()
-	return this.createOptionalTypeDesc(typeDescriptorNode, questionMarkToken)
+func (b *BallerinaParser) parseOptionalTypeDescriptor(typeDescriptorNode tree.STNode) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_OPTIONAL_TYPE_DESCRIPTOR)
+	questionMarkToken := b.parseQuestionMark()
+	b.endContext()
+	return b.createOptionalTypeDesc(typeDescriptorNode, questionMarkToken)
 }
 
-func (this *BallerinaParser) createOptionalTypeDesc(typeDescNode tree.STNode, questionMarkToken tree.STNode) tree.STNode {
+func (b *BallerinaParser) createOptionalTypeDesc(typeDescNode tree.STNode, questionMarkToken tree.STNode) tree.STNode {
 	if typeDescNode.Kind() == common.UNION_TYPE_DESC {
 		unionTypeDesc, ok := typeDescNode.(*tree.STUnionTypeDescriptorNode)
 		if !ok {
 			panic("expected tree.STUnionTypeDescriptorNode")
 		}
-		middleTypeDesc := this.createOptionalTypeDesc(unionTypeDesc.RightTypeDesc, questionMarkToken)
-		typeDescNode = this.mergeTypesWithUnion(unionTypeDesc.LeftTypeDesc, unionTypeDesc.PipeToken, middleTypeDesc)
+		middleTypeDesc := b.createOptionalTypeDesc(unionTypeDesc.RightTypeDesc, questionMarkToken)
+		typeDescNode = b.mergeTypesWithUnion(unionTypeDesc.LeftTypeDesc, unionTypeDesc.PipeToken, middleTypeDesc)
 	} else if typeDescNode.Kind() == common.INTERSECTION_TYPE_DESC {
 		intersectionTypeDesc, ok := typeDescNode.(*tree.STIntersectionTypeDescriptorNode)
 		if !ok {
 			panic("expected tree.STIntersectionTypeDescriptorNode")
 		}
-		middleTypeDesc := this.createOptionalTypeDesc(intersectionTypeDesc.RightTypeDesc, questionMarkToken)
-		typeDescNode = this.mergeTypesWithIntersection(intersectionTypeDesc.LeftTypeDesc,
+		middleTypeDesc := b.createOptionalTypeDesc(intersectionTypeDesc.RightTypeDesc, questionMarkToken)
+		typeDescNode = b.mergeTypesWithIntersection(intersectionTypeDesc.LeftTypeDesc,
 			intersectionTypeDesc.BitwiseAndToken, middleTypeDesc)
 	} else {
-		typeDescNode = this.validateForUsageOfVar(typeDescNode)
+		typeDescNode = b.validateForUsageOfVar(typeDescNode)
 		typeDescNode = tree.CreateOptionalTypeDescriptorNode(typeDescNode, questionMarkToken)
 	}
 	return typeDescNode
 }
 
-func (this *BallerinaParser) parseUnaryExpression(isRhsExpr bool, isInConditionalExpr bool) tree.STNode {
-	unaryOperator := this.parseUnaryOperator()
-	expr := this.parseExpressionWithConditional(OPERATOR_PRECEDENCE_UNARY, isRhsExpr, false, isInConditionalExpr)
+func (b *BallerinaParser) parseUnaryExpression(isRhsExpr bool, isInConditionalExpr bool) tree.STNode {
+	unaryOperator := b.parseUnaryOperator()
+	expr := b.parseExpressionWithConditional(OPERATOR_PRECEDENCE_UNARY, isRhsExpr, false, isInConditionalExpr)
 	return tree.CreateUnaryExpressionNode(unaryOperator, expr)
 }
 
-func (this *BallerinaParser) parseUnaryOperator() tree.STNode {
-	token := this.peek()
-	if this.isUnaryOperator(token.Kind()) {
-		return this.consume()
+func (b *BallerinaParser) parseUnaryOperator() tree.STNode {
+	token := b.peek()
+	if b.isUnaryOperator(token.Kind()) {
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_UNARY_OPERATOR)
-		return this.parseUnaryOperator()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_UNARY_OPERATOR)
+		return b.parseUnaryOperator()
 	}
 }
 
-func (this *BallerinaParser) isUnaryOperator(kind common.SyntaxKind) bool {
+func (b *BallerinaParser) isUnaryOperator(kind common.SyntaxKind) bool {
 	switch kind {
 	case common.PLUS_TOKEN, common.MINUS_TOKEN, common.NEGATION_TOKEN, common.EXCLAMATION_MARK_TOKEN:
 		return true
@@ -6688,17 +6688,17 @@ func (this *BallerinaParser) isUnaryOperator(kind common.SyntaxKind) bool {
 	}
 }
 
-func (this *BallerinaParser) parseArrayTypeDescriptor(memberTypeDesc tree.STNode) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_ARRAY_TYPE_DESCRIPTOR)
-	openBracketToken := this.parseOpenBracket()
-	arrayLengthNode := this.parseArrayLength()
-	closeBracketToken := this.parseCloseBracket()
-	this.endContext()
-	return this.createArrayTypeDesc(memberTypeDesc, openBracketToken, arrayLengthNode, closeBracketToken)
+func (b *BallerinaParser) parseArrayTypeDescriptor(memberTypeDesc tree.STNode) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_ARRAY_TYPE_DESCRIPTOR)
+	openBracketToken := b.parseOpenBracket()
+	arrayLengthNode := b.parseArrayLength()
+	closeBracketToken := b.parseCloseBracket()
+	b.endContext()
+	return b.createArrayTypeDesc(memberTypeDesc, openBracketToken, arrayLengthNode, closeBracketToken)
 }
 
-func (this *BallerinaParser) createArrayTypeDesc(memberTypeDesc tree.STNode, openBracketToken tree.STNode, arrayLengthNode tree.STNode, closeBracketToken tree.STNode) tree.STNode {
-	memberTypeDesc = this.validateForUsageOfVar(memberTypeDesc)
+func (b *BallerinaParser) createArrayTypeDesc(memberTypeDesc tree.STNode, openBracketToken tree.STNode, arrayLengthNode tree.STNode, closeBracketToken tree.STNode) tree.STNode {
+	memberTypeDesc = b.validateForUsageOfVar(memberTypeDesc)
 	if arrayLengthNode != nil {
 		switch arrayLengthNode.Kind() {
 		case common.ASTERISK_LITERAL,
@@ -6737,91 +6737,91 @@ func (this *BallerinaParser) createArrayTypeDesc(memberTypeDesc tree.STNode, ope
 	return tree.CreateArrayTypeDescriptorNode(memberTypeDesc, arrayDimensionNodeList)
 }
 
-func (this *BallerinaParser) parseArrayLength() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseArrayLength() tree.STNode {
+	token := b.peek()
 	switch token.Kind() {
 	case common.DECIMAL_INTEGER_LITERAL_TOKEN,
 		common.HEX_INTEGER_LITERAL_TOKEN,
 		common.ASTERISK_TOKEN:
-		return this.parseBasicLiteral()
+		return b.parseBasicLiteral()
 	case common.CLOSE_BRACKET_TOKEN:
 		return tree.CreateEmptyNode()
 	case common.IDENTIFIER_TOKEN:
-		return this.parseQualifiedIdentifier(common.PARSER_RULE_CONTEXT_ARRAY_LENGTH)
+		return b.parseQualifiedIdentifier(common.PARSER_RULE_CONTEXT_ARRAY_LENGTH)
 	default:
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_ARRAY_LENGTH)
-		return this.parseArrayLength()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_ARRAY_LENGTH)
+		return b.parseArrayLength()
 	}
 }
 
-func (this *BallerinaParser) parseOptionalAnnotations() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_ANNOTATIONS)
+func (b *BallerinaParser) parseOptionalAnnotations() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_ANNOTATIONS)
 	var annotList []tree.STNode
-	nextToken := this.peek()
+	nextToken := b.peek()
 	for nextToken.Kind() == common.AT_TOKEN {
-		annotList = append(annotList, this.parseAnnotation())
-		nextToken = this.peek()
+		annotList = append(annotList, b.parseAnnotation())
+		nextToken = b.peek()
 	}
-	this.endContext()
+	b.endContext()
 	return tree.CreateNodeList(annotList...)
 }
 
-func (this *BallerinaParser) parseAnnotations() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_ANNOTATIONS)
+func (b *BallerinaParser) parseAnnotations() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_ANNOTATIONS)
 	var annotList []tree.STNode
-	annotList = append(annotList, this.parseAnnotation())
-	for this.peek().Kind() == common.AT_TOKEN {
-		annotList = append(annotList, this.parseAnnotation())
+	annotList = append(annotList, b.parseAnnotation())
+	for b.peek().Kind() == common.AT_TOKEN {
+		annotList = append(annotList, b.parseAnnotation())
 	}
-	this.endContext()
+	b.endContext()
 	return tree.CreateNodeList(annotList...)
 }
 
-func (this *BallerinaParser) parseAnnotation() tree.STNode {
-	atToken := this.parseAtToken()
+func (b *BallerinaParser) parseAnnotation() tree.STNode {
+	atToken := b.parseAtToken()
 	var annotReference tree.STNode
-	if this.isPredeclaredIdentifier(this.peek().Kind()) {
-		annotReference = this.parseQualifiedIdentifier(common.PARSER_RULE_CONTEXT_ANNOT_REFERENCE)
+	if b.isPredeclaredIdentifier(b.peek().Kind()) {
+		annotReference = b.parseQualifiedIdentifier(common.PARSER_RULE_CONTEXT_ANNOT_REFERENCE)
 	} else {
 		annotReference = tree.CreateMissingToken(common.IDENTIFIER_TOKEN, nil)
 		annotReference = tree.CreateSimpleNameReferenceNode(annotReference)
 	}
 	var annotValue tree.STNode
-	if this.peek().Kind() == common.OPEN_BRACE_TOKEN {
-		annotValue = this.parseMappingConstructorExpr()
+	if b.peek().Kind() == common.OPEN_BRACE_TOKEN {
+		annotValue = b.parseMappingConstructorExpr()
 	} else {
 		annotValue = tree.CreateEmptyNode()
 	}
 	return tree.CreateAnnotationNode(atToken, annotReference, annotValue)
 }
 
-func (this *BallerinaParser) parseAtToken() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseAtToken() tree.STNode {
+	nextToken := b.peek()
 	if nextToken.Kind() == common.AT_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_AT)
-		return this.parseAtToken()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_AT)
+		return b.parseAtToken()
 	}
 }
 
-func (this *BallerinaParser) parseMetaData() tree.STNode {
+func (b *BallerinaParser) parseMetaData() tree.STNode {
 	var docString tree.STNode
 	var annotations tree.STNode
-	switch this.peek().Kind() {
+	switch b.peek().Kind() {
 	case common.DOCUMENTATION_STRING:
-		docString = this.parseMarkdownDocumentation()
-		annotations = this.parseOptionalAnnotations()
+		docString = b.parseMarkdownDocumentation()
+		annotations = b.parseOptionalAnnotations()
 	case common.AT_TOKEN:
 		docString = tree.CreateEmptyNode()
-		annotations = this.parseOptionalAnnotations()
+		annotations = b.parseOptionalAnnotations()
 	default:
 		return tree.CreateEmptyNode()
 	}
-	return this.createMetadata(docString, annotations)
+	return b.createMetadata(docString, annotations)
 }
 
-func (this *BallerinaParser) createMetadata(docString tree.STNode, annotations tree.STNode) tree.STNode {
+func (b *BallerinaParser) createMetadata(docString tree.STNode, annotations tree.STNode) tree.STNode {
 	if (annotations == nil) && (docString == nil) {
 		return tree.CreateEmptyNode()
 	} else {
@@ -6829,72 +6829,72 @@ func (this *BallerinaParser) createMetadata(docString tree.STNode, annotations t
 	}
 }
 
-func (this *BallerinaParser) parseTypeTestExpression(lhsExpr tree.STNode, isInConditionalExpr bool) tree.STNode {
-	isOrNotIsKeyword := this.parseIsOrNotIsKeyword()
-	typeDescriptor := this.parseTypeDescriptorInExpression(isInConditionalExpr)
+func (b *BallerinaParser) parseTypeTestExpression(lhsExpr tree.STNode, isInConditionalExpr bool) tree.STNode {
+	isOrNotIsKeyword := b.parseIsOrNotIsKeyword()
+	typeDescriptor := b.parseTypeDescriptorInExpression(isInConditionalExpr)
 	return tree.CreateTypeTestExpressionNode(lhsExpr, isOrNotIsKeyword, typeDescriptor)
 }
 
-func (this *BallerinaParser) parseIsOrNotIsKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseIsOrNotIsKeyword() tree.STNode {
+	token := b.peek()
 	if (token.Kind() == common.IS_KEYWORD) || (token.Kind() == common.NOT_IS_KEYWORD) {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_IS_KEYWORD)
-		return this.parseIsOrNotIsKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_IS_KEYWORD)
+		return b.parseIsOrNotIsKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseLocalTypeDefinitionStatement(annots tree.STNode) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_LOCAL_TYPE_DEFINITION_STMT)
-	typeKeyword := this.parseTypeKeyword()
-	typeName := this.parseTypeName()
-	typeDescriptor := this.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_DEF)
-	semicolon := this.parseSemicolon()
-	this.endContext()
+func (b *BallerinaParser) parseLocalTypeDefinitionStatement(annots tree.STNode) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_LOCAL_TYPE_DEFINITION_STMT)
+	typeKeyword := b.parseTypeKeyword()
+	typeName := b.parseTypeName()
+	typeDescriptor := b.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_DEF)
+	semicolon := b.parseSemicolon()
+	b.endContext()
 	return tree.CreateLocalTypeDefinitionStatementNode(annots, typeKeyword, typeName, typeDescriptor,
 		semicolon)
 }
 
-func (this *BallerinaParser) parseExpressionStatement(annots tree.STNode) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_EXPRESSION_STATEMENT)
-	expression := this.parseActionOrExpressionInLhs(annots)
-	return this.getExpressionAsStatement(expression)
+func (b *BallerinaParser) parseExpressionStatement(annots tree.STNode) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_EXPRESSION_STATEMENT)
+	expression := b.parseActionOrExpressionInLhs(annots)
+	return b.getExpressionAsStatement(expression)
 }
 
-func (this *BallerinaParser) parseStatementStartWithExpr(annots tree.STNode) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_AMBIGUOUS_STMT)
-	expr := this.parseActionOrExpressionInLhs(annots)
-	return this.parseStatementStartWithExprRhs(expr)
+func (b *BallerinaParser) parseStatementStartWithExpr(annots tree.STNode) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_AMBIGUOUS_STMT)
+	expr := b.parseActionOrExpressionInLhs(annots)
+	return b.parseStatementStartWithExprRhs(expr)
 }
 
-func (this *BallerinaParser) parseStatementStartWithExprRhs(expression tree.STNode) tree.STNode {
-	nextTokenKind := this.peek().Kind()
-	if this.isAction(expression) || (nextTokenKind == common.SEMICOLON_TOKEN) {
-		return this.getExpressionAsStatement(expression)
+func (b *BallerinaParser) parseStatementStartWithExprRhs(expression tree.STNode) tree.STNode {
+	nextTokenKind := b.peek().Kind()
+	if b.isAction(expression) || (nextTokenKind == common.SEMICOLON_TOKEN) {
+		return b.getExpressionAsStatement(expression)
 	}
 	switch nextTokenKind {
 	case common.EQUAL_TOKEN:
-		this.switchContext(common.PARSER_RULE_CONTEXT_ASSIGNMENT_STMT)
-		return this.parseAssignmentStmtRhs(expression)
+		b.switchContext(common.PARSER_RULE_CONTEXT_ASSIGNMENT_STMT)
+		return b.parseAssignmentStmtRhs(expression)
 	case common.IDENTIFIER_TOKEN:
 		fallthrough
 	default:
-		if this.isCompoundAssignment(nextTokenKind) {
-			return this.parseCompoundAssignmentStmtRhs(expression)
+		if b.isCompoundAssignment(nextTokenKind) {
+			return b.parseCompoundAssignmentStmtRhs(expression)
 		}
 		var context common.ParserRuleContext
-		if this.isPossibleExpressionStatement(expression) {
+		if b.isPossibleExpressionStatement(expression) {
 			context = common.PARSER_RULE_CONTEXT_EXPR_STMT_RHS
 		} else {
 			context = common.PARSER_RULE_CONTEXT_STMT_START_WITH_EXPR_RHS
 		}
-		this.recoverWithBlockContext(this.peek(), context)
-		return this.parseStatementStartWithExprRhs(expression)
+		b.recoverWithBlockContext(b.peek(), context)
+		return b.parseStatementStartWithExprRhs(expression)
 	}
 }
 
-func (this *BallerinaParser) isPossibleExpressionStatement(expression tree.STNode) bool {
+func (b *BallerinaParser) isPossibleExpressionStatement(expression tree.STNode) bool {
 	switch expression.Kind() {
 	case common.METHOD_CALL,
 		common.FUNCTION_CALL,
@@ -6917,13 +6917,13 @@ func (this *BallerinaParser) isPossibleExpressionStatement(expression tree.STNod
 	}
 }
 
-func (this *BallerinaParser) getExpressionAsStatement(expression tree.STNode) tree.STNode {
+func (b *BallerinaParser) getExpressionAsStatement(expression tree.STNode) tree.STNode {
 	switch expression.Kind() {
 	case common.METHOD_CALL,
 		common.FUNCTION_CALL:
-		return this.parseCallStatement(expression)
+		return b.parseCallStatement(expression)
 	case common.CHECK_EXPRESSION:
-		return this.parseCheckStatement(expression)
+		return b.parseCheckStatement(expression)
 	case common.REMOTE_METHOD_CALL_ACTION,
 		common.CHECK_ACTION,
 		common.BRACED_ACTION,
@@ -6937,11 +6937,11 @@ func (this *BallerinaParser) getExpressionAsStatement(expression tree.STNode) tr
 		common.QUERY_ACTION,
 		common.COMMIT_ACTION,
 		common.CLIENT_RESOURCE_ACCESS_ACTION:
-		return this.parseActionStatement(expression)
+		return b.parseActionStatement(expression)
 	default:
-		semicolon := this.parseSemicolon()
-		this.endContext()
-		expression = this.getExpression(expression)
+		semicolon := b.parseSemicolon()
+		b.endContext()
+		expression = b.getExpression(expression)
 		exprStmt := tree.CreateExpressionStatementNode(common.INVALID_EXPRESSION_STATEMENT,
 			expression, semicolon)
 		exprStmt = tree.AddDiagnostic(exprStmt, &common.ERROR_INVALID_EXPRESSION_STATEMENT)
@@ -6949,14 +6949,14 @@ func (this *BallerinaParser) getExpressionAsStatement(expression tree.STNode) tr
 	}
 }
 
-func (this *BallerinaParser) parseArrayTypeDescriptorNode(indexedExpr tree.STIndexedExpressionNode) tree.STNode {
-	memberTypeDesc := this.getTypeDescFromExpr(indexedExpr.ContainerExpression)
+func (b *BallerinaParser) parseArrayTypeDescriptorNode(indexedExpr tree.STIndexedExpressionNode) tree.STNode {
+	memberTypeDesc := b.getTypeDescFromExpr(indexedExpr.ContainerExpression)
 	lengthExprs, ok := indexedExpr.KeyExpression.(*tree.STNodeList)
 	if !ok {
 		panic("expected tree.STNodeList")
 	}
 	if lengthExprs.IsEmpty() {
-		return this.createArrayTypeDesc(memberTypeDesc, indexedExpr.OpenBracket, tree.CreateEmptyNode(),
+		return b.createArrayTypeDesc(memberTypeDesc, indexedExpr.OpenBracket, tree.CreateEmptyNode(),
 			indexedExpr.CloseBracket)
 	}
 	lengthExpr := lengthExprs.Get(0)
@@ -6967,7 +6967,7 @@ func (this *BallerinaParser) parseArrayTypeDescriptorNode(indexedExpr tree.STInd
 			panic("expected tree.STSimpleNameReferenceNode")
 		}
 		if nameRef.Name.IsMissing() {
-			return this.createArrayTypeDesc(memberTypeDesc, indexedExpr.OpenBracket, tree.CreateEmptyNode(),
+			return b.createArrayTypeDesc(memberTypeDesc, indexedExpr.OpenBracket, tree.CreateEmptyNode(),
 				indexedExpr.CloseBracket)
 		}
 	case common.ASTERISK_LITERAL,
@@ -6989,112 +6989,112 @@ func (this *BallerinaParser) parseArrayTypeDescriptorNode(indexedExpr tree.STInd
 		indexedExpr = *newIndexedExpr
 		lengthExpr = tree.CreateEmptyNode()
 	}
-	return this.createArrayTypeDesc(memberTypeDesc, indexedExpr.OpenBracket, lengthExpr, indexedExpr.CloseBracket)
+	return b.createArrayTypeDesc(memberTypeDesc, indexedExpr.OpenBracket, lengthExpr, indexedExpr.CloseBracket)
 }
 
-func (this *BallerinaParser) parseCallStatement(expression tree.STNode) tree.STNode {
-	return this.parseCallStatementOrCheckStatement(expression)
+func (b *BallerinaParser) parseCallStatement(expression tree.STNode) tree.STNode {
+	return b.parseCallStatementOrCheckStatement(expression)
 }
 
-func (this *BallerinaParser) parseCheckStatement(expression tree.STNode) tree.STNode {
-	return this.parseCallStatementOrCheckStatement(expression)
+func (b *BallerinaParser) parseCheckStatement(expression tree.STNode) tree.STNode {
+	return b.parseCallStatementOrCheckStatement(expression)
 }
 
-func (this *BallerinaParser) parseCallStatementOrCheckStatement(expression tree.STNode) tree.STNode {
-	semicolon := this.parseSemicolon()
-	this.endContext()
+func (b *BallerinaParser) parseCallStatementOrCheckStatement(expression tree.STNode) tree.STNode {
+	semicolon := b.parseSemicolon()
+	b.endContext()
 	return tree.CreateExpressionStatementNode(common.CALL_STATEMENT, expression, semicolon)
 }
 
-func (this *BallerinaParser) parseActionStatement(action tree.STNode) tree.STNode {
-	semicolon := this.parseSemicolon()
-	this.endContext()
+func (b *BallerinaParser) parseActionStatement(action tree.STNode) tree.STNode {
+	semicolon := b.parseSemicolon()
+	b.endContext()
 	return tree.CreateExpressionStatementNode(common.ACTION_STATEMENT, action, semicolon)
 }
 
-func (this *BallerinaParser) parseClientResourceAccessAction(expression tree.STNode, rightArrow tree.STNode, slashToken tree.STNode, isRhsExpr bool, isInMatchGuard bool) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_CLIENT_RESOURCE_ACCESS_ACTION)
-	resourceAccessPath := this.parseOptionalResourceAccessPath(isRhsExpr, isInMatchGuard)
-	resourceAccessMethodDot := this.parseOptionalResourceAccessMethodDot(isRhsExpr, isInMatchGuard)
+func (b *BallerinaParser) parseClientResourceAccessAction(expression tree.STNode, rightArrow tree.STNode, slashToken tree.STNode, isRhsExpr bool, isInMatchGuard bool) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_CLIENT_RESOURCE_ACCESS_ACTION)
+	resourceAccessPath := b.parseOptionalResourceAccessPath(isRhsExpr, isInMatchGuard)
+	resourceAccessMethodDot := b.parseOptionalResourceAccessMethodDot(isRhsExpr, isInMatchGuard)
 	resourceAccessMethodName := tree.CreateEmptyNode()
 	if resourceAccessMethodDot != nil {
-		resourceAccessMethodName = tree.CreateSimpleNameReferenceNode(this.parseFunctionName())
+		resourceAccessMethodName = tree.CreateSimpleNameReferenceNode(b.parseFunctionName())
 	}
-	resourceMethodCallArgList := this.parseOptionalResourceAccessActionArgList(isRhsExpr, isInMatchGuard)
-	this.endContext()
+	resourceMethodCallArgList := b.parseOptionalResourceAccessActionArgList(isRhsExpr, isInMatchGuard)
+	b.endContext()
 	return tree.CreateClientResourceAccessActionNode(expression, rightArrow, slashToken,
 		resourceAccessPath, resourceAccessMethodDot, resourceAccessMethodName, resourceMethodCallArgList)
 }
 
-func (this *BallerinaParser) parseOptionalResourceAccessPath(isRhsExpr bool, isInMatchGuard bool) tree.STNode {
+func (b *BallerinaParser) parseOptionalResourceAccessPath(isRhsExpr bool, isInMatchGuard bool) tree.STNode {
 	resourceAccessPath := tree.CreateEmptyNodeList()
-	nextToken := this.peek()
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.IDENTIFIER_TOKEN,
 		common.OPEN_BRACKET_TOKEN:
-		resourceAccessPath = this.parseResourceAccessPath(isRhsExpr, isInMatchGuard)
+		resourceAccessPath = b.parseResourceAccessPath(isRhsExpr, isInMatchGuard)
 	case common.DOT_TOKEN,
 		common.OPEN_PAREN_TOKEN:
 		break
 	default:
-		if this.isEndOfActionOrExpression(nextToken, isRhsExpr, isInMatchGuard) {
+		if b.isEndOfActionOrExpression(nextToken, isRhsExpr, isInMatchGuard) {
 			break
 		}
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_OPTIONAL_RESOURCE_ACCESS_PATH)
-		return this.parseOptionalResourceAccessPath(isRhsExpr, isInMatchGuard)
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_OPTIONAL_RESOURCE_ACCESS_PATH)
+		return b.parseOptionalResourceAccessPath(isRhsExpr, isInMatchGuard)
 	}
 	return resourceAccessPath
 }
 
-func (this *BallerinaParser) parseOptionalResourceAccessMethodDot(isRhsExpr bool, isInMatchGuard bool) tree.STNode {
+func (b *BallerinaParser) parseOptionalResourceAccessMethodDot(isRhsExpr bool, isInMatchGuard bool) tree.STNode {
 	dotToken := tree.CreateEmptyNode()
-	nextToken := this.peek()
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.DOT_TOKEN:
-		dotToken = this.consume()
+		dotToken = b.consume()
 	case common.OPEN_PAREN_TOKEN:
 		break
 	default:
-		if this.isEndOfActionOrExpression(nextToken, isRhsExpr, isInMatchGuard) {
+		if b.isEndOfActionOrExpression(nextToken, isRhsExpr, isInMatchGuard) {
 			break
 		}
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_OPTIONAL_RESOURCE_ACCESS_METHOD)
-		return this.parseOptionalResourceAccessMethodDot(isRhsExpr, isInMatchGuard)
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_OPTIONAL_RESOURCE_ACCESS_METHOD)
+		return b.parseOptionalResourceAccessMethodDot(isRhsExpr, isInMatchGuard)
 	}
 	return dotToken
 }
 
-func (this *BallerinaParser) parseOptionalResourceAccessActionArgList(isRhsExpr bool, isInMatchGuard bool) tree.STNode {
+func (b *BallerinaParser) parseOptionalResourceAccessActionArgList(isRhsExpr bool, isInMatchGuard bool) tree.STNode {
 	argList := tree.CreateEmptyNode()
-	nextToken := this.peek()
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.OPEN_PAREN_TOKEN:
-		argList = this.parseParenthesizedArgList()
+		argList = b.parseParenthesizedArgList()
 	default:
-		if this.isEndOfActionOrExpression(nextToken, isRhsExpr, isInMatchGuard) {
+		if b.isEndOfActionOrExpression(nextToken, isRhsExpr, isInMatchGuard) {
 			break
 		}
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_OPTIONAL_RESOURCE_ACCESS_ACTION_ARG_LIST)
-		return this.parseOptionalResourceAccessActionArgList(isRhsExpr, isInMatchGuard)
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_OPTIONAL_RESOURCE_ACCESS_ACTION_ARG_LIST)
+		return b.parseOptionalResourceAccessActionArgList(isRhsExpr, isInMatchGuard)
 	}
 	return argList
 }
 
-func (this *BallerinaParser) parseResourceAccessPath(isRhsExpr bool, isInMatchGuard bool) tree.STNode {
+func (b *BallerinaParser) parseResourceAccessPath(isRhsExpr bool, isInMatchGuard bool) tree.STNode {
 	var pathSegmentList []tree.STNode
-	pathSegment := this.parseResourceAccessSegment()
+	pathSegment := b.parseResourceAccessSegment()
 	pathSegmentList = append(pathSegmentList, pathSegment)
 	var leadingSlash tree.STNode
 	previousPathSegmentNode := pathSegment
-	for !this.isEndOfResourceAccessPathSegments(this.peek(), isRhsExpr, isInMatchGuard) {
-		leadingSlash = this.parseResourceAccessSegmentRhs(isRhsExpr, isInMatchGuard)
+	for !b.isEndOfResourceAccessPathSegments(b.peek(), isRhsExpr, isInMatchGuard) {
+		leadingSlash = b.parseResourceAccessSegmentRhs(isRhsExpr, isInMatchGuard)
 		if leadingSlash == nil {
 			break
 		}
-		pathSegment = this.parseResourceAccessSegment()
+		pathSegment = b.parseResourceAccessSegment()
 		if previousPathSegmentNode.Kind() == common.RESOURCE_ACCESS_REST_SEGMENT {
-			this.updateLastNodeInListWithInvalidNode(pathSegmentList, leadingSlash, nil)
-			this.updateLastNodeInListWithInvalidNode(pathSegmentList, pathSegment,
+			b.updateLastNodeInListWithInvalidNode(pathSegmentList, leadingSlash, nil)
+			b.updateLastNodeInListWithInvalidNode(pathSegmentList, pathSegment,
 				&common.RESOURCE_ACCESS_SEGMENT_IS_NOT_ALLOWED_AFTER_REST_SEGMENT)
 		} else {
 			pathSegmentList = append(pathSegmentList, leadingSlash)
@@ -7105,106 +7105,106 @@ func (this *BallerinaParser) parseResourceAccessPath(isRhsExpr bool, isInMatchGu
 	return tree.CreateNodeList(pathSegmentList...)
 }
 
-func (this *BallerinaParser) parseResourceAccessSegment() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseResourceAccessSegment() tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.IDENTIFIER_TOKEN:
-		return this.consume()
+		return b.consume()
 	case common.OPEN_BRACKET_TOKEN:
-		return this.parseComputedOrResourceAccessRestSegment(this.consume())
+		return b.parseComputedOrResourceAccessRestSegment(b.consume())
 	default:
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_RESOURCE_ACCESS_PATH_SEGMENT)
-		return this.parseResourceAccessSegment()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_RESOURCE_ACCESS_PATH_SEGMENT)
+		return b.parseResourceAccessSegment()
 	}
 }
 
-func (this *BallerinaParser) parseComputedOrResourceAccessRestSegment(openBracket tree.STNode) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseComputedOrResourceAccessRestSegment(openBracket tree.STNode) tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.ELLIPSIS_TOKEN:
-		ellipsisToken := this.consume()
-		expression := this.parseExpression()
-		closeBracketToken := this.parseCloseBracket()
+		ellipsisToken := b.consume()
+		expression := b.parseExpression()
+		closeBracketToken := b.parseCloseBracket()
 		return tree.CreateResourceAccessRestSegmentNode(openBracket, ellipsisToken,
 			expression, closeBracketToken)
 	default:
-		if this.isValidExprStart(nextToken.Kind()) {
-			expression := this.parseExpression()
-			closeBracketToken := this.parseCloseBracket()
+		if b.isValidExprStart(nextToken.Kind()) {
+			expression := b.parseExpression()
+			closeBracketToken := b.parseCloseBracket()
 			return tree.CreateComputedResourceAccessSegmentNode(openBracket, expression,
 				closeBracketToken)
 		}
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_COMPUTED_SEGMENT_OR_REST_SEGMENT)
-		return this.parseComputedOrResourceAccessRestSegment(openBracket)
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_COMPUTED_SEGMENT_OR_REST_SEGMENT)
+		return b.parseComputedOrResourceAccessRestSegment(openBracket)
 	}
 }
 
-func (this *BallerinaParser) parseResourceAccessSegmentRhs(isRhsExpr bool, isInMatchGuard bool) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseResourceAccessSegmentRhs(isRhsExpr bool, isInMatchGuard bool) tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.SLASH_TOKEN:
-		return this.consume()
+		return b.consume()
 	default:
-		if this.isEndOfResourceAccessPathSegments(nextToken, isRhsExpr, isInMatchGuard) {
+		if b.isEndOfResourceAccessPathSegments(nextToken, isRhsExpr, isInMatchGuard) {
 			return nil
 		}
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_RESOURCE_ACCESS_SEGMENT_RHS)
-		return this.parseResourceAccessSegmentRhs(isRhsExpr, isInMatchGuard)
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_RESOURCE_ACCESS_SEGMENT_RHS)
+		return b.parseResourceAccessSegmentRhs(isRhsExpr, isInMatchGuard)
 	}
 }
 
-func (this *BallerinaParser) isEndOfResourceAccessPathSegments(nextToken tree.STToken, isRhsExpr bool, isInMatchGuard bool) bool {
+func (b *BallerinaParser) isEndOfResourceAccessPathSegments(nextToken tree.STToken, isRhsExpr bool, isInMatchGuard bool) bool {
 	switch nextToken.Kind() {
 	case common.DOT_TOKEN, common.OPEN_PAREN_TOKEN:
 		return true
 	default:
-		return this.isEndOfActionOrExpression(nextToken, isRhsExpr, isInMatchGuard)
+		return b.isEndOfActionOrExpression(nextToken, isRhsExpr, isInMatchGuard)
 	}
 }
 
-func (this *BallerinaParser) parseRemoteMethodCallOrClientResourceAccessOrAsyncSendAction(expression tree.STNode, isRhsExpr bool, isInMatchGuard bool) tree.STNode {
-	rightArrow := this.parseRightArrow()
-	return this.parseClientResourceAccessOrAsyncSendActionRhs(expression, rightArrow, isRhsExpr, isInMatchGuard)
+func (b *BallerinaParser) parseRemoteMethodCallOrClientResourceAccessOrAsyncSendAction(expression tree.STNode, isRhsExpr bool, isInMatchGuard bool) tree.STNode {
+	rightArrow := b.parseRightArrow()
+	return b.parseClientResourceAccessOrAsyncSendActionRhs(expression, rightArrow, isRhsExpr, isInMatchGuard)
 }
 
-func (this *BallerinaParser) parseClientResourceAccessOrAsyncSendActionRhs(expression tree.STNode, rightArrow tree.STNode, isRhsExpr bool, isInMatchGuard bool) tree.STNode {
+func (b *BallerinaParser) parseClientResourceAccessOrAsyncSendActionRhs(expression tree.STNode, rightArrow tree.STNode, isRhsExpr bool, isInMatchGuard bool) tree.STNode {
 	var name tree.STNode
-	nextToken := this.peek()
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.FUNCTION_KEYWORD:
-		functionKeyword := this.consume()
+		functionKeyword := b.consume()
 		name = tree.CreateSimpleNameReferenceNode(functionKeyword)
-		return this.parseAsyncSendAction(expression, rightArrow, name)
+		return b.parseAsyncSendAction(expression, rightArrow, name)
 	case common.CONTINUE_KEYWORD,
 		common.COMMIT_KEYWORD:
-		name = this.getKeywordAsSimpleNameRef()
+		name = b.getKeywordAsSimpleNameRef()
 	case common.SLASH_TOKEN:
-		slashToken := this.consume()
-		return this.parseClientResourceAccessAction(expression, rightArrow, slashToken, isRhsExpr, isInMatchGuard)
+		slashToken := b.consume()
+		return b.parseClientResourceAccessAction(expression, rightArrow, slashToken, isRhsExpr, isInMatchGuard)
 	default:
 		if nextToken.Kind() == common.IDENTIFIER_TOKEN {
-			nextNextToken := this.getNextNextToken()
-			if ((nextNextToken.Kind() == common.OPEN_PAREN_TOKEN) || this.isEndOfActionOrExpression(nextNextToken, isRhsExpr, isInMatchGuard)) || nextToken.IsMissing() {
-				name = tree.CreateSimpleNameReferenceNode(this.parseFunctionName())
+			nextNextToken := b.getNextNextToken()
+			if ((nextNextToken.Kind() == common.OPEN_PAREN_TOKEN) || b.isEndOfActionOrExpression(nextNextToken, isRhsExpr, isInMatchGuard)) || nextToken.IsMissing() {
+				name = tree.CreateSimpleNameReferenceNode(b.parseFunctionName())
 				break
 			}
 		}
-		token := this.peek()
-		solution := this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_REMOTE_OR_RESOURCE_CALL_OR_ASYNC_SEND_RHS)
+		token := b.peek()
+		solution := b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_REMOTE_OR_RESOURCE_CALL_OR_ASYNC_SEND_RHS)
 		if solution.Action == ACTION_KEEP {
-			name = tree.CreateSimpleNameReferenceNode(this.parseFunctionName())
+			name = tree.CreateSimpleNameReferenceNode(b.parseFunctionName())
 			break
 		}
-		return this.parseClientResourceAccessOrAsyncSendActionRhs(expression, rightArrow, isRhsExpr, isInMatchGuard)
+		return b.parseClientResourceAccessOrAsyncSendActionRhs(expression, rightArrow, isRhsExpr, isInMatchGuard)
 	}
-	return this.parseRemoteCallOrAsyncSendEnd(expression, rightArrow, name)
+	return b.parseRemoteCallOrAsyncSendEnd(expression, rightArrow, name)
 }
 
-func (this *BallerinaParser) parseRemoteCallOrAsyncSendEnd(expression tree.STNode, rightArrow tree.STNode, name tree.STNode) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseRemoteCallOrAsyncSendEnd(expression tree.STNode, rightArrow tree.STNode, name tree.STNode) tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.OPEN_PAREN_TOKEN:
-		return this.parseRemoteMethodCallAction(expression, rightArrow, name)
+		return b.parseRemoteMethodCallAction(expression, rightArrow, name)
 	case common.SEMICOLON_TOKEN,
 		common.CLOSE_PAREN_TOKEN,
 		common.OPEN_BRACE_TOKEN,
@@ -7217,57 +7217,57 @@ func (this *BallerinaParser) parseRemoteCallOrAsyncSendEnd(expression tree.STNod
 		common.ORDER_KEYWORD,
 		common.LIMIT_KEYWORD,
 		common.SELECT_KEYWORD:
-		return this.parseAsyncSendAction(expression, rightArrow, name)
+		return b.parseAsyncSendAction(expression, rightArrow, name)
 	default:
 		if isGroupOrCollectKeyword(nextToken) {
-			return this.parseAsyncSendAction(expression, rightArrow, name)
+			return b.parseAsyncSendAction(expression, rightArrow, name)
 		}
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_REMOTE_CALL_OR_ASYNC_SEND_END)
-		return this.parseRemoteCallOrAsyncSendEnd(expression, rightArrow, name)
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_REMOTE_CALL_OR_ASYNC_SEND_END)
+		return b.parseRemoteCallOrAsyncSendEnd(expression, rightArrow, name)
 	}
 }
 
-func (this *BallerinaParser) parseAsyncSendAction(expression tree.STNode, rightArrow tree.STNode, peerWorker tree.STNode) tree.STNode {
+func (b *BallerinaParser) parseAsyncSendAction(expression tree.STNode, rightArrow tree.STNode, peerWorker tree.STNode) tree.STNode {
 	return tree.CreateAsyncSendActionNode(expression, rightArrow, peerWorker)
 }
 
-func (this *BallerinaParser) parseRemoteMethodCallAction(expression tree.STNode, rightArrow tree.STNode, name tree.STNode) tree.STNode {
-	openParenToken := this.parseArgListOpenParenthesis()
-	arguments := this.parseArgsList()
-	closeParenToken := this.parseArgListCloseParenthesis()
+func (b *BallerinaParser) parseRemoteMethodCallAction(expression tree.STNode, rightArrow tree.STNode, name tree.STNode) tree.STNode {
+	openParenToken := b.parseArgListOpenParenthesis()
+	arguments := b.parseArgsList()
+	closeParenToken := b.parseArgListCloseParenthesis()
 	return tree.CreateRemoteMethodCallActionNode(expression, rightArrow, name, openParenToken, arguments,
 		closeParenToken)
 }
 
-func (this *BallerinaParser) parseRightArrow() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseRightArrow() tree.STNode {
+	nextToken := b.peek()
 	if nextToken.Kind() == common.RIGHT_ARROW_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_RIGHT_ARROW)
-		return this.parseRightArrow()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_RIGHT_ARROW)
+		return b.parseRightArrow()
 	}
 }
 
-func (this *BallerinaParser) parseMapTypeDescriptor(mapKeyword tree.STNode) tree.STNode {
-	typeParameter := this.parseTypeParameter()
+func (b *BallerinaParser) parseMapTypeDescriptor(mapKeyword tree.STNode) tree.STNode {
+	typeParameter := b.parseTypeParameter()
 	return tree.CreateMapTypeDescriptorNode(mapKeyword, typeParameter)
 }
 
-func (this *BallerinaParser) parseParameterizedTypeDescriptor(keywordToken tree.STNode) tree.STNode {
+func (b *BallerinaParser) parseParameterizedTypeDescriptor(keywordToken tree.STNode) tree.STNode {
 	var typeParamNode tree.STNode
-	nextToken := this.peek()
+	nextToken := b.peek()
 	if nextToken.Kind() == common.LT_TOKEN {
-		typeParamNode = this.parseTypeParameter()
+		typeParamNode = b.parseTypeParameter()
 	} else {
 		typeParamNode = tree.CreateEmptyNode()
 	}
-	parameterizedTypeDescKind := this.getParameterizedTypeDescKind(keywordToken)
+	parameterizedTypeDescKind := b.getParameterizedTypeDescKind(keywordToken)
 	return tree.CreateParameterizedTypeDescriptorNode(parameterizedTypeDescKind, keywordToken,
 		typeParamNode)
 }
 
-func (this *BallerinaParser) getParameterizedTypeDescKind(keywordToken tree.STNode) common.SyntaxKind {
+func (b *BallerinaParser) getParameterizedTypeDescKind(keywordToken tree.STNode) common.SyntaxKind {
 	switch keywordToken.Kind() {
 	case common.TYPEDESC_KEYWORD:
 		return common.TYPEDESC_TYPE_DESC
@@ -7280,93 +7280,93 @@ func (this *BallerinaParser) getParameterizedTypeDescKind(keywordToken tree.STNo
 	}
 }
 
-func (this *BallerinaParser) parseGTToken() tree.STToken {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseGTToken() tree.STToken {
+	nextToken := b.peek()
 	if nextToken.Kind() == common.GT_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_GT)
-		return this.parseGTToken()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_GT)
+		return b.parseGTToken()
 	}
 }
 
-func (this *BallerinaParser) parseLTToken() tree.STToken {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseLTToken() tree.STToken {
+	nextToken := b.peek()
 	if nextToken.Kind() == common.LT_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_LT)
-		return this.parseLTToken()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_LT)
+		return b.parseLTToken()
 	}
 }
 
-func (this *BallerinaParser) parseNilLiteral() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_NIL_LITERAL)
-	openParenthesisToken := this.parseOpenParenthesis()
-	closeParenthesisToken := this.parseCloseParenthesis()
-	this.endContext()
+func (b *BallerinaParser) parseNilLiteral() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_NIL_LITERAL)
+	openParenthesisToken := b.parseOpenParenthesis()
+	closeParenthesisToken := b.parseCloseParenthesis()
+	b.endContext()
 	return tree.CreateNilLiteralNode(openParenthesisToken, closeParenthesisToken)
 }
 
-func (this *BallerinaParser) parseAnnotationDeclaration(metadata tree.STNode, qualifier tree.STNode, constKeyword tree.STNode) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_ANNOTATION_DECL)
-	annotationKeyword := this.parseAnnotationKeyword()
-	annotDecl := this.parseAnnotationDeclFromType(metadata, qualifier, constKeyword, annotationKeyword)
-	this.endContext()
+func (b *BallerinaParser) parseAnnotationDeclaration(metadata tree.STNode, qualifier tree.STNode, constKeyword tree.STNode) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_ANNOTATION_DECL)
+	annotationKeyword := b.parseAnnotationKeyword()
+	annotDecl := b.parseAnnotationDeclFromType(metadata, qualifier, constKeyword, annotationKeyword)
+	b.endContext()
 	return annotDecl
 }
 
-func (this *BallerinaParser) parseAnnotationKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseAnnotationKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.ANNOTATION_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_ANNOTATION_KEYWORD)
-		return this.parseAnnotationKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_ANNOTATION_KEYWORD)
+		return b.parseAnnotationKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseAnnotationDeclFromType(metadata tree.STNode, qualifier tree.STNode, constKeyword tree.STNode, annotationKeyword tree.STNode) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseAnnotationDeclFromType(metadata tree.STNode, qualifier tree.STNode, constKeyword tree.STNode, annotationKeyword tree.STNode) tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.IDENTIFIER_TOKEN:
-		return this.parseAnnotationDeclWithOptionalType(metadata, qualifier, constKeyword, annotationKeyword)
+		return b.parseAnnotationDeclWithOptionalType(metadata, qualifier, constKeyword, annotationKeyword)
 	default:
-		if this.isTypeStartingToken(nextToken.Kind()) {
+		if b.isTypeStartingToken(nextToken.Kind()) {
 			break
 		}
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_ANNOT_DECL_OPTIONAL_TYPE)
-		return this.parseAnnotationDeclFromType(metadata, qualifier, constKeyword, annotationKeyword)
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_ANNOT_DECL_OPTIONAL_TYPE)
+		return b.parseAnnotationDeclFromType(metadata, qualifier, constKeyword, annotationKeyword)
 	}
-	typeDesc := this.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_ANNOTATION_DECL)
-	annotTag := this.parseAnnotationTag()
-	return this.parseAnnotationDeclAttachPoints(metadata, qualifier, constKeyword, annotationKeyword, typeDesc,
+	typeDesc := b.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_ANNOTATION_DECL)
+	annotTag := b.parseAnnotationTag()
+	return b.parseAnnotationDeclAttachPoints(metadata, qualifier, constKeyword, annotationKeyword, typeDesc,
 		annotTag)
 }
 
-func (this *BallerinaParser) parseAnnotationTag() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseAnnotationTag() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.IDENTIFIER_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_ANNOTATION_TAG)
-		return this.parseAnnotationTag()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_ANNOTATION_TAG)
+		return b.parseAnnotationTag()
 	}
 }
 
-func (this *BallerinaParser) parseAnnotationDeclWithOptionalType(metadata tree.STNode, qualifier tree.STNode, constKeyword tree.STNode, annotationKeyword tree.STNode) tree.STNode {
-	typeDescOrAnnotTag := this.parseQualifiedIdentifier(common.PARSER_RULE_CONTEXT_ANNOT_DECL_OPTIONAL_TYPE)
+func (b *BallerinaParser) parseAnnotationDeclWithOptionalType(metadata tree.STNode, qualifier tree.STNode, constKeyword tree.STNode, annotationKeyword tree.STNode) tree.STNode {
+	typeDescOrAnnotTag := b.parseQualifiedIdentifier(common.PARSER_RULE_CONTEXT_ANNOT_DECL_OPTIONAL_TYPE)
 	if typeDescOrAnnotTag.Kind() == common.QUALIFIED_NAME_REFERENCE {
-		annotTag := this.parseAnnotationTag()
-		return this.parseAnnotationDeclAttachPoints(metadata, qualifier, constKeyword, annotationKeyword,
+		annotTag := b.parseAnnotationTag()
+		return b.parseAnnotationDeclAttachPoints(metadata, qualifier, constKeyword, annotationKeyword,
 			typeDescOrAnnotTag, annotTag)
 	}
-	nextToken := this.peek()
-	if (nextToken.Kind() == common.IDENTIFIER_TOKEN) || this.isValidTypeContinuationToken(nextToken) {
-		typeDesc := this.parseComplexTypeDescriptor(typeDescOrAnnotTag,
+	nextToken := b.peek()
+	if (nextToken.Kind() == common.IDENTIFIER_TOKEN) || b.isValidTypeContinuationToken(nextToken) {
+		typeDesc := b.parseComplexTypeDescriptor(typeDescOrAnnotTag,
 			common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_ANNOTATION_DECL, false)
-		annotTag := this.parseAnnotationTag()
-		return this.parseAnnotationDeclAttachPoints(metadata, qualifier, constKeyword, annotationKeyword, typeDesc,
+		annotTag := b.parseAnnotationTag()
+		return b.parseAnnotationDeclAttachPoints(metadata, qualifier, constKeyword, annotationKeyword, typeDesc,
 			annotTag)
 	}
 	simplenameNode, ok := typeDescOrAnnotTag.(*tree.STSimpleNameReferenceNode)
@@ -7374,71 +7374,71 @@ func (this *BallerinaParser) parseAnnotationDeclWithOptionalType(metadata tree.S
 		panic("parseAnnotationDeclWithOptionalType: expected STSimpleNameReferenceNode")
 	}
 	annotTag := simplenameNode.Name
-	return this.parseAnnotationDeclRhs(metadata, qualifier, constKeyword, annotationKeyword, annotTag)
+	return b.parseAnnotationDeclRhs(metadata, qualifier, constKeyword, annotationKeyword, annotTag)
 }
 
-func (this *BallerinaParser) parseAnnotationDeclRhs(metadata tree.STNode, qualifier tree.STNode, constKeyword tree.STNode, annotationKeyword tree.STNode, typeDescOrAnnotTag tree.STNode) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseAnnotationDeclRhs(metadata tree.STNode, qualifier tree.STNode, constKeyword tree.STNode, annotationKeyword tree.STNode, typeDescOrAnnotTag tree.STNode) tree.STNode {
+	nextToken := b.peek()
 	var typeDesc tree.STNode
 	var annotTag tree.STNode
 	switch nextToken.Kind() {
 	case common.IDENTIFIER_TOKEN:
 		typeDesc = typeDescOrAnnotTag
-		annotTag = this.parseAnnotationTag()
+		annotTag = b.parseAnnotationTag()
 	case common.SEMICOLON_TOKEN,
 		common.ON_KEYWORD:
 		typeDesc = tree.CreateEmptyNode()
 		annotTag = typeDescOrAnnotTag
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_ANNOT_DECL_RHS)
-		return this.parseAnnotationDeclRhs(metadata, qualifier, constKeyword, annotationKeyword, typeDescOrAnnotTag)
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_ANNOT_DECL_RHS)
+		return b.parseAnnotationDeclRhs(metadata, qualifier, constKeyword, annotationKeyword, typeDescOrAnnotTag)
 	}
-	return this.parseAnnotationDeclAttachPoints(metadata, qualifier, constKeyword, annotationKeyword, typeDesc,
+	return b.parseAnnotationDeclAttachPoints(metadata, qualifier, constKeyword, annotationKeyword, typeDesc,
 		annotTag)
 }
 
-func (this *BallerinaParser) parseAnnotationDeclAttachPoints(metadata tree.STNode, qualifier tree.STNode, constKeyword tree.STNode, annotationKeyword tree.STNode, typeDesc tree.STNode, annotTag tree.STNode) tree.STNode {
+func (b *BallerinaParser) parseAnnotationDeclAttachPoints(metadata tree.STNode, qualifier tree.STNode, constKeyword tree.STNode, annotationKeyword tree.STNode, typeDesc tree.STNode, annotTag tree.STNode) tree.STNode {
 	var onKeyword tree.STNode
 	var attachPoints tree.STNode
-	nextToken := this.peek()
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.SEMICOLON_TOKEN:
 		onKeyword = tree.CreateEmptyNode()
 		attachPoints = tree.CreateEmptyNodeList()
 	case common.ON_KEYWORD:
-		onKeyword = this.parseOnKeyword()
-		attachPoints = this.parseAnnotationAttachPoints()
-		onKeyword = this.cloneWithDiagnosticIfListEmpty(attachPoints, onKeyword,
+		onKeyword = b.parseOnKeyword()
+		attachPoints = b.parseAnnotationAttachPoints()
+		onKeyword = b.cloneWithDiagnosticIfListEmpty(attachPoints, onKeyword,
 			&common.ERROR_MISSING_ANNOTATION_ATTACH_POINT)
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_ANNOT_OPTIONAL_ATTACH_POINTS)
-		return this.parseAnnotationDeclAttachPoints(metadata, qualifier, constKeyword, annotationKeyword, typeDesc,
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_ANNOT_OPTIONAL_ATTACH_POINTS)
+		return b.parseAnnotationDeclAttachPoints(metadata, qualifier, constKeyword, annotationKeyword, typeDesc,
 			annotTag)
 	}
-	semicolonToken := this.parseSemicolon()
+	semicolonToken := b.parseSemicolon()
 	return tree.CreateAnnotationDeclarationNode(metadata, qualifier, constKeyword, annotationKeyword,
 		typeDesc, annotTag, onKeyword, attachPoints, semicolonToken)
 }
 
-func (this *BallerinaParser) parseAnnotationAttachPoints() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_ANNOT_ATTACH_POINTS_LIST)
+func (b *BallerinaParser) parseAnnotationAttachPoints() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_ANNOT_ATTACH_POINTS_LIST)
 	var attachPoints []tree.STNode
-	nextToken := this.peek()
-	if this.isEndAnnotAttachPointList(nextToken.Kind()) {
-		this.endContext()
+	nextToken := b.peek()
+	if b.isEndAnnotAttachPointList(nextToken.Kind()) {
+		b.endContext()
 		return tree.CreateEmptyNodeList()
 	}
-	attachPoint := this.parseAnnotationAttachPoint()
+	attachPoint := b.parseAnnotationAttachPoint()
 	attachPoints = append(attachPoints, attachPoint)
-	nextToken = this.peek()
+	nextToken = b.peek()
 	var leadingComma tree.STNode
-	for !this.isEndAnnotAttachPointList(nextToken.Kind()) {
-		leadingComma = this.parseAttachPointEnd()
+	for !b.isEndAnnotAttachPointList(nextToken.Kind()) {
+		leadingComma = b.parseAttachPointEnd()
 		if leadingComma == nil {
 			break
 		}
 		attachPoints = append(attachPoints, leadingComma)
-		attachPoint = this.parseAnnotationAttachPoint()
+		attachPoint = b.parseAnnotationAttachPoint()
 		if attachPoint == nil {
 			missingAttachPointIdent := tree.CreateMissingToken(common.TYPE_KEYWORD, nil)
 			identList := tree.CreateNodeList(missingAttachPointIdent)
@@ -7449,30 +7449,30 @@ func (this *BallerinaParser) parseAnnotationAttachPoints() tree.STNode {
 			break
 		}
 		attachPoints = append(attachPoints, attachPoint)
-		nextToken = this.peek()
+		nextToken = b.peek()
 	}
-	if (tree.LastToken(attachPoint).IsMissing() && (this.tokenReader.Peek().Kind() == common.IDENTIFIER_TOKEN)) && (!this.tokenReader.Head().HasTrailingNewLine()) {
-		nextNonVirtualToken := this.tokenReader.Read()
-		this.updateLastNodeInListWithInvalidNode(attachPoints, nextNonVirtualToken,
+	if (tree.LastToken(attachPoint).IsMissing() && (b.tokenReader.Peek().Kind() == common.IDENTIFIER_TOKEN)) && (!b.tokenReader.Head().HasTrailingNewLine()) {
+		nextNonVirtualToken := b.tokenReader.Read()
+		b.updateLastNodeInListWithInvalidNode(attachPoints, nextNonVirtualToken,
 			&common.ERROR_INVALID_TOKEN, nextNonVirtualToken.Text())
 	}
-	this.endContext()
+	b.endContext()
 	return tree.CreateNodeList(attachPoints...)
 }
 
-func (this *BallerinaParser) parseAttachPointEnd() tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseAttachPointEnd() tree.STNode {
+	switch b.peek().Kind() {
 	case common.SEMICOLON_TOKEN:
 		return nil
 	case common.COMMA_TOKEN:
-		return this.consume()
+		return b.consume()
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_ATTACH_POINT_END)
-		return this.parseAttachPointEnd()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_ATTACH_POINT_END)
+		return b.parseAttachPointEnd()
 	}
 }
 
-func (this *BallerinaParser) isEndAnnotAttachPointList(tokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isEndAnnotAttachPointList(tokenKind common.SyntaxKind) bool {
 	switch tokenKind {
 	case common.EOF_TOKEN, common.SEMICOLON_TOKEN:
 		return true
@@ -7481,8 +7481,8 @@ func (this *BallerinaParser) isEndAnnotAttachPointList(tokenKind common.SyntaxKi
 	}
 }
 
-func (this *BallerinaParser) parseAnnotationAttachPoint() tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseAnnotationAttachPoint() tree.STNode {
+	switch b.peek().Kind() {
 	case common.EOF_TOKEN:
 		return nil
 	case common.ANNOTATION_KEYWORD,
@@ -7492,8 +7492,8 @@ func (this *BallerinaParser) parseAnnotationAttachPoint() tree.STNode {
 		common.LISTENER_KEYWORD,
 		common.WORKER_KEYWORD,
 		common.SOURCE_KEYWORD:
-		sourceKeyword := this.parseSourceKeyword()
-		return this.parseAttachPointIdent(sourceKeyword)
+		sourceKeyword := b.parseSourceKeyword()
+		return b.parseAttachPointIdent(sourceKeyword)
 	case common.OBJECT_KEYWORD,
 		common.TYPE_KEYWORD,
 		common.FUNCTION_KEYWORD,
@@ -7504,33 +7504,33 @@ func (this *BallerinaParser) parseAnnotationAttachPoint() tree.STNode {
 		common.RECORD_KEYWORD,
 		common.CLASS_KEYWORD:
 		sourceKeyword := tree.CreateEmptyNode()
-		firstIdent := this.consume()
-		return this.parseDualAttachPointIdent(sourceKeyword, firstIdent)
+		firstIdent := b.consume()
+		return b.parseDualAttachPointIdent(sourceKeyword, firstIdent)
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_ATTACH_POINT)
-		return this.parseAnnotationAttachPoint()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_ATTACH_POINT)
+		return b.parseAnnotationAttachPoint()
 	}
 }
 
-func (this *BallerinaParser) parseSourceKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseSourceKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.SOURCE_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_SOURCE_KEYWORD)
-		return this.parseSourceKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_SOURCE_KEYWORD)
+		return b.parseSourceKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseAttachPointIdent(sourceKeyword tree.STNode) tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseAttachPointIdent(sourceKeyword tree.STNode) tree.STNode {
+	switch b.peek().Kind() {
 	case common.ANNOTATION_KEYWORD,
 		common.EXTERNAL_KEYWORD,
 		common.VAR_KEYWORD,
 		common.CONST_KEYWORD,
 		common.LISTENER_KEYWORD,
 		common.WORKER_KEYWORD:
-		firstIdent := this.consume()
+		firstIdent := b.consume()
 		identList := tree.CreateNodeList(firstIdent)
 		return tree.CreateAnnotationAttachPointNode(sourceKeyword, identList)
 	case common.OBJECT_KEYWORD,
@@ -7543,25 +7543,25 @@ func (this *BallerinaParser) parseAttachPointIdent(sourceKeyword tree.STNode) tr
 		common.SERVICE_KEYWORD,
 		common.FIELD_KEYWORD,
 		common.CLASS_KEYWORD:
-		firstIdent := this.consume()
-		return this.parseDualAttachPointIdent(sourceKeyword, firstIdent)
+		firstIdent := b.consume()
+		return b.parseDualAttachPointIdent(sourceKeyword, firstIdent)
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_ATTACH_POINT_IDENT)
-		return this.parseAttachPointIdent(sourceKeyword)
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_ATTACH_POINT_IDENT)
+		return b.parseAttachPointIdent(sourceKeyword)
 	}
 }
 
-func (this *BallerinaParser) parseDualAttachPointIdent(sourceKeyword tree.STNode, firstIdent tree.STNode) tree.STNode {
+func (b *BallerinaParser) parseDualAttachPointIdent(sourceKeyword tree.STNode, firstIdent tree.STNode) tree.STNode {
 	var secondIdent tree.STNode
 	switch firstIdent.Kind() {
 	case common.OBJECT_KEYWORD:
-		secondIdent = this.parseIdentAfterObjectIdent()
+		secondIdent = b.parseIdentAfterObjectIdent()
 	case common.RESOURCE_KEYWORD:
-		secondIdent = this.parseFunctionIdent()
+		secondIdent = b.parseFunctionIdent()
 	case common.RECORD_KEYWORD:
-		secondIdent = this.parseFieldIdent()
+		secondIdent = b.parseFieldIdent()
 	case common.SERVICE_KEYWORD:
-		return this.parseServiceAttachPoint(sourceKeyword, firstIdent)
+		return b.parseServiceAttachPoint(sourceKeyword, firstIdent)
 	case common.TYPE_KEYWORD, common.FUNCTION_KEYWORD, common.PARAMETER_KEYWORD,
 		common.RETURN_KEYWORD, common.FIELD_KEYWORD, common.CLASS_KEYWORD:
 		fallthrough
@@ -7573,23 +7573,23 @@ func (this *BallerinaParser) parseDualAttachPointIdent(sourceKeyword tree.STNode
 	return tree.CreateAnnotationAttachPointNode(sourceKeyword, identList)
 }
 
-func (this *BallerinaParser) parseRemoteIdent() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseRemoteIdent() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.REMOTE_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_REMOTE_IDENT)
-		return this.parseRemoteIdent()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_REMOTE_IDENT)
+		return b.parseRemoteIdent()
 	}
 }
 
-func (this *BallerinaParser) parseServiceAttachPoint(sourceKeyword tree.STNode, firstIdent tree.STNode) tree.STNode {
+func (b *BallerinaParser) parseServiceAttachPoint(sourceKeyword tree.STNode, firstIdent tree.STNode) tree.STNode {
 	var identList tree.STNode
-	token := this.peek()
+	token := b.peek()
 	switch token.Kind() {
 	case common.REMOTE_KEYWORD:
-		secondIdent := this.parseRemoteIdent()
-		thirdIdent := this.parseFunctionIdent()
+		secondIdent := b.parseRemoteIdent()
+		thirdIdent := b.parseFunctionIdent()
 		identList = tree.CreateNodeList(firstIdent, secondIdent, thirdIdent)
 		return tree.CreateAnnotationAttachPointNode(sourceKeyword, identList)
 	case common.COMMA_TOKEN,
@@ -7597,67 +7597,67 @@ func (this *BallerinaParser) parseServiceAttachPoint(sourceKeyword tree.STNode, 
 		identList = tree.CreateNodeList(firstIdent)
 		return tree.CreateAnnotationAttachPointNode(sourceKeyword, identList)
 	default:
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_SERVICE_IDENT_RHS)
-		return this.parseServiceAttachPoint(sourceKeyword, firstIdent)
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_SERVICE_IDENT_RHS)
+		return b.parseServiceAttachPoint(sourceKeyword, firstIdent)
 	}
 }
 
-func (this *BallerinaParser) parseIdentAfterObjectIdent() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseIdentAfterObjectIdent() tree.STNode {
+	token := b.peek()
 	switch token.Kind() {
 	case common.FUNCTION_KEYWORD, common.FIELD_KEYWORD:
-		return this.consume()
+		return b.consume()
 	default:
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_IDENT_AFTER_OBJECT_IDENT)
-		return this.parseIdentAfterObjectIdent()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_IDENT_AFTER_OBJECT_IDENT)
+		return b.parseIdentAfterObjectIdent()
 	}
 }
 
-func (this *BallerinaParser) parseFunctionIdent() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseFunctionIdent() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.FUNCTION_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_FUNCTION_IDENT)
-		return this.parseFunctionIdent()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_FUNCTION_IDENT)
+		return b.parseFunctionIdent()
 	}
 }
 
-func (this *BallerinaParser) parseFieldIdent() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseFieldIdent() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.FIELD_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_FIELD_IDENT)
-		return this.parseFieldIdent()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_FIELD_IDENT)
+		return b.parseFieldIdent()
 	}
 }
 
-func (this *BallerinaParser) parseXMLNamespaceDeclaration(isModuleVar bool) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_XML_NAMESPACE_DECLARATION)
-	xmlnsKeyword := this.parseXMLNSKeyword()
-	namespaceUri := this.parseSimpleConstExpr()
-	for !this.isValidXMLNameSpaceURI(namespaceUri) {
+func (b *BallerinaParser) parseXMLNamespaceDeclaration(isModuleVar bool) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_XML_NAMESPACE_DECLARATION)
+	xmlnsKeyword := b.parseXMLNSKeyword()
+	namespaceUri := b.parseSimpleConstExpr()
+	for !b.isValidXMLNameSpaceURI(namespaceUri) {
 		xmlnsKeyword = tree.CloneWithTrailingInvalidNodeMinutiae(xmlnsKeyword, namespaceUri,
 			&common.ERROR_INVALID_XML_NAMESPACE_URI)
-		namespaceUri = this.parseSimpleConstExpr()
+		namespaceUri = b.parseSimpleConstExpr()
 	}
-	xmlnsDecl := this.parseXMLDeclRhs(xmlnsKeyword, namespaceUri, isModuleVar)
-	this.endContext()
+	xmlnsDecl := b.parseXMLDeclRhs(xmlnsKeyword, namespaceUri, isModuleVar)
+	b.endContext()
 	return xmlnsDecl
 }
 
-func (this *BallerinaParser) parseXMLNSKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseXMLNSKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.XMLNS_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_XMLNS_KEYWORD)
-		return this.parseXMLNSKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_XMLNS_KEYWORD)
+		return b.parseXMLNSKeyword()
 	}
 }
 
-func (this *BallerinaParser) isValidXMLNameSpaceURI(expr tree.STNode) bool {
+func (b *BallerinaParser) isValidXMLNameSpaceURI(expr tree.STNode) bool {
 	switch expr.Kind() {
 	case common.STRING_LITERAL, common.QUALIFIED_NAME_REFERENCE, common.SIMPLE_NAME_REFERENCE:
 		return true
@@ -7666,15 +7666,15 @@ func (this *BallerinaParser) isValidXMLNameSpaceURI(expr tree.STNode) bool {
 	}
 }
 
-func (this *BallerinaParser) parseSimpleConstExpr() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_CONSTANT_EXPRESSION)
-	expr := this.parseSimpleConstExprInternal()
-	this.endContext()
+func (b *BallerinaParser) parseSimpleConstExpr() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_CONSTANT_EXPRESSION)
+	expr := b.parseSimpleConstExprInternal()
+	b.endContext()
 	return expr
 }
 
-func (this *BallerinaParser) parseSimpleConstExprInternal() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseSimpleConstExprInternal() tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.STRING_LITERAL_TOKEN,
 		common.DECIMAL_INTEGER_LITERAL_TOKEN,
@@ -7684,34 +7684,34 @@ func (this *BallerinaParser) parseSimpleConstExprInternal() tree.STNode {
 		common.TRUE_KEYWORD,
 		common.FALSE_KEYWORD,
 		common.NULL_KEYWORD:
-		return this.parseBasicLiteral()
+		return b.parseBasicLiteral()
 	case common.PLUS_TOKEN, common.MINUS_TOKEN:
-		return this.parseSignedIntOrFloat()
+		return b.parseSignedIntOrFloat()
 	case common.OPEN_PAREN_TOKEN:
-		return this.parseNilLiteral()
+		return b.parseNilLiteral()
 	default:
-		if this.isPredeclaredIdentifier(nextToken.Kind()) {
-			return this.parseQualifiedIdentifier(common.PARSER_RULE_CONTEXT_VARIABLE_REF)
+		if b.isPredeclaredIdentifier(nextToken.Kind()) {
+			return b.parseQualifiedIdentifier(common.PARSER_RULE_CONTEXT_VARIABLE_REF)
 		}
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_CONSTANT_EXPRESSION_START)
-		return this.parseSimpleConstExprInternal()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_CONSTANT_EXPRESSION_START)
+		return b.parseSimpleConstExprInternal()
 	}
 }
 
-func (this *BallerinaParser) parseXMLDeclRhs(xmlnsKeyword tree.STNode, namespaceUri tree.STNode, isModuleVar bool) tree.STNode {
+func (b *BallerinaParser) parseXMLDeclRhs(xmlnsKeyword tree.STNode, namespaceUri tree.STNode, isModuleVar bool) tree.STNode {
 	asKeyword := tree.CreateEmptyNode()
 	namespacePrefix := tree.CreateEmptyNode()
-	switch this.peek().Kind() {
+	switch b.peek().Kind() {
 	case common.AS_KEYWORD:
-		asKeyword = this.parseAsKeyword()
-		namespacePrefix = this.parseNamespacePrefix()
+		asKeyword = b.parseAsKeyword()
+		namespacePrefix = b.parseNamespacePrefix()
 	case common.SEMICOLON_TOKEN:
 		break
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_XML_NAMESPACE_PREFIX_DECL)
-		return this.parseXMLDeclRhs(xmlnsKeyword, namespaceUri, isModuleVar)
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_XML_NAMESPACE_PREFIX_DECL)
+		return b.parseXMLDeclRhs(xmlnsKeyword, namespaceUri, isModuleVar)
 	}
-	semicolon := this.parseSemicolon()
+	semicolon := b.parseSemicolon()
 	if isModuleVar {
 		return tree.CreateModuleXMLNamespaceDeclarationNode(xmlnsKeyword, namespaceUri, asKeyword,
 			namespacePrefix, semicolon)
@@ -7720,49 +7720,49 @@ func (this *BallerinaParser) parseXMLDeclRhs(xmlnsKeyword tree.STNode, namespace
 		semicolon)
 }
 
-func (this *BallerinaParser) parseNamespacePrefix() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseNamespacePrefix() tree.STNode {
+	nextToken := b.peek()
 	if nextToken.Kind() == common.IDENTIFIER_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_NAMESPACE_PREFIX)
-		return this.parseNamespacePrefix()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_NAMESPACE_PREFIX)
+		return b.parseNamespacePrefix()
 	}
 }
 
-func (this *BallerinaParser) parseNamedWorkerDeclaration(annots tree.STNode, qualifiers []tree.STNode) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_NAMED_WORKER_DECL)
-	transactionalKeyword := this.getTransactionalKeyword(qualifiers)
-	workerKeyword := this.parseWorkerKeyword()
-	workerName := this.parseWorkerName()
-	returnTypeDesc := this.parseReturnTypeDescriptor()
-	workerBody := this.parseBlockNode()
-	this.endContext()
-	onFailClause := this.parseOptionalOnFailClause()
+func (b *BallerinaParser) parseNamedWorkerDeclaration(annots tree.STNode, qualifiers []tree.STNode) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_NAMED_WORKER_DECL)
+	transactionalKeyword := b.getTransactionalKeyword(qualifiers)
+	workerKeyword := b.parseWorkerKeyword()
+	workerName := b.parseWorkerName()
+	returnTypeDesc := b.parseReturnTypeDescriptor()
+	workerBody := b.parseBlockNode()
+	b.endContext()
+	onFailClause := b.parseOptionalOnFailClause()
 	return tree.CreateNamedWorkerDeclarationNode(annots, transactionalKeyword, workerKeyword, workerName,
 		returnTypeDesc, workerBody, onFailClause)
 }
 
-func (this *BallerinaParser) getTransactionalKeyword(qualifierList []tree.STNode) tree.STNode {
+func (b *BallerinaParser) getTransactionalKeyword(qualifierList []tree.STNode) tree.STNode {
 	var validatedList []tree.STNode
 	i := 0
 	for ; i < len(qualifierList); i++ {
 		qualifier := qualifierList[i]
 		nextIndex := (i + 1)
-		if this.isSyntaxKindInList(validatedList, qualifier.Kind()) {
+		if b.isSyntaxKindInList(validatedList, qualifier.Kind()) {
 			qualifierToken, ok := qualifier.(tree.STToken)
 			if !ok {
 				panic("expected STToken")
 			}
-			this.updateLastNodeInListWithInvalidNode(validatedList, qualifier,
+			b.updateLastNodeInListWithInvalidNode(validatedList, qualifier,
 				&common.ERROR_DUPLICATE_QUALIFIER, qualifierToken.Text())
 		} else if qualifier.Kind() == common.TRANSACTIONAL_KEYWORD {
 			validatedList = append(validatedList, qualifier)
 		} else if len(qualifierList) == nextIndex {
-			this.addInvalidNodeToNextToken(qualifier, &common.ERROR_QUALIFIER_NOT_ALLOWED,
+			b.addInvalidNodeToNextToken(qualifier, &common.ERROR_QUALIFIER_NOT_ALLOWED,
 				tree.ToToken(qualifier).Text())
 		} else {
-			this.updateANodeInListWithLeadingInvalidNode(qualifierList, nextIndex, qualifier,
+			b.updateANodeInListWithLeadingInvalidNode(qualifierList, nextIndex, qualifier,
 				&common.ERROR_QUALIFIER_NOT_ALLOWED, tree.ToToken(qualifier).Text())
 		}
 	}
@@ -7775,84 +7775,84 @@ func (this *BallerinaParser) getTransactionalKeyword(qualifierList []tree.STNode
 	return transactionalKeyword
 }
 
-func (this *BallerinaParser) parseReturnTypeDescriptor() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseReturnTypeDescriptor() tree.STNode {
+	token := b.peek()
 	if token.Kind() != common.RETURNS_KEYWORD {
 		return tree.CreateEmptyNode()
 	}
-	returnsKeyword := this.consume()
-	annot := this.parseOptionalAnnotations()
-	ty := this.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_RETURN_TYPE_DESC)
+	returnsKeyword := b.consume()
+	annot := b.parseOptionalAnnotations()
+	ty := b.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_RETURN_TYPE_DESC)
 	return tree.CreateReturnTypeDescriptorNode(returnsKeyword, annot, ty)
 }
 
-func (this *BallerinaParser) parseWorkerKeyword() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseWorkerKeyword() tree.STNode {
+	nextToken := b.peek()
 	if nextToken.Kind() == common.WORKER_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_WORKER_KEYWORD)
-		return this.parseWorkerKeyword()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_WORKER_KEYWORD)
+		return b.parseWorkerKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseWorkerName() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseWorkerName() tree.STNode {
+	nextToken := b.peek()
 	if nextToken.Kind() == common.IDENTIFIER_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_WORKER_NAME)
-		return this.parseWorkerName()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_WORKER_NAME)
+		return b.parseWorkerName()
 	}
 }
 
-func (this *BallerinaParser) parseLockStatement() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_LOCK_STMT)
-	lockKeyword := this.parseLockKeyword()
-	blockStatement := this.parseBlockNode()
-	this.endContext()
-	onFailClause := this.parseOptionalOnFailClause()
+func (b *BallerinaParser) parseLockStatement() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_LOCK_STMT)
+	lockKeyword := b.parseLockKeyword()
+	blockStatement := b.parseBlockNode()
+	b.endContext()
+	onFailClause := b.parseOptionalOnFailClause()
 	return tree.CreateLockStatementNode(lockKeyword, blockStatement, onFailClause)
 }
 
-func (this *BallerinaParser) parseLockKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseLockKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.LOCK_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_LOCK_KEYWORD)
-		return this.parseLockKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_LOCK_KEYWORD)
+		return b.parseLockKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseUnionTypeDescriptor(leftTypeDesc tree.STNode, context common.ParserRuleContext, isTypedBindingPattern bool) tree.STNode {
-	pipeToken := this.consume()
-	rightTypeDesc := this.parseTypeDescriptorInternalWithPrecedence(nil, context, isTypedBindingPattern, false,
+func (b *BallerinaParser) parseUnionTypeDescriptor(leftTypeDesc tree.STNode, context common.ParserRuleContext, isTypedBindingPattern bool) tree.STNode {
+	pipeToken := b.consume()
+	rightTypeDesc := b.parseTypeDescriptorInternalWithPrecedence(nil, context, isTypedBindingPattern, false,
 		TYPE_PRECEDENCE_UNION)
-	return this.mergeTypesWithUnion(leftTypeDesc, pipeToken, rightTypeDesc)
+	return b.mergeTypesWithUnion(leftTypeDesc, pipeToken, rightTypeDesc)
 }
 
-func (this *BallerinaParser) createUnionTypeDesc(leftTypeDesc tree.STNode, pipeToken tree.STNode, rightTypeDesc tree.STNode) tree.STNode {
-	leftTypeDesc = this.validateForUsageOfVar(leftTypeDesc)
-	rightTypeDesc = this.validateForUsageOfVar(rightTypeDesc)
+func (b *BallerinaParser) createUnionTypeDesc(leftTypeDesc tree.STNode, pipeToken tree.STNode, rightTypeDesc tree.STNode) tree.STNode {
+	leftTypeDesc = b.validateForUsageOfVar(leftTypeDesc)
+	rightTypeDesc = b.validateForUsageOfVar(rightTypeDesc)
 	return tree.CreateUnionTypeDescriptorNode(leftTypeDesc, pipeToken, rightTypeDesc)
 }
 
-func (this *BallerinaParser) parsePipeToken() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parsePipeToken() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.PIPE_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_PIPE)
-		return this.parsePipeToken()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_PIPE)
+		return b.parsePipeToken()
 	}
 }
 
-func (this *BallerinaParser) isTypeStartingToken(nodeKind common.SyntaxKind) bool {
-	return isTypeStartingToken(nodeKind, this.getNextNextToken())
+func (b *BallerinaParser) isTypeStartingToken(nodeKind common.SyntaxKind) bool {
+	return isTypeStartingToken(nodeKind, b.getNextNextToken())
 }
 
-func (this *BallerinaParser) isSimpleTypeInExpression(nodeKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isSimpleTypeInExpression(nodeKind common.SyntaxKind) bool {
 	switch nodeKind {
 	case common.VAR_KEYWORD, common.READONLY_KEYWORD:
 		return false
@@ -7861,31 +7861,31 @@ func (this *BallerinaParser) isSimpleTypeInExpression(nodeKind common.SyntaxKind
 	}
 }
 
-func (this *BallerinaParser) isQualifiedIdentifierPredeclaredPrefix(nodeKind common.SyntaxKind) bool {
-	return (isPredeclaredPrefix(nodeKind) && (this.getNextNextToken().Kind() == common.COLON_TOKEN))
+func (b *BallerinaParser) isQualifiedIdentifierPredeclaredPrefix(nodeKind common.SyntaxKind) bool {
+	return (isPredeclaredPrefix(nodeKind) && (b.getNextNextToken().Kind() == common.COLON_TOKEN))
 }
 
-func (this *BallerinaParser) parseForkKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseForkKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.FORK_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_FORK_KEYWORD)
-		return this.parseForkKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_FORK_KEYWORD)
+		return b.parseForkKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseForkStatement() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_FORK_STMT)
-	forkKeyword := this.parseForkKeyword()
-	openBrace := this.parseOpenBrace()
+func (b *BallerinaParser) parseForkStatement() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_FORK_STMT)
+	forkKeyword := b.parseForkKeyword()
+	openBrace := b.parseOpenBrace()
 	var workers []tree.STNode
-	for !this.isEndOfStatements() {
-		stmt := this.parseStatement()
+	for !b.isEndOfStatements() {
+		stmt := b.parseStatement()
 		if stmt == nil {
 			break
 		}
-		if this.validateStatement(stmt) {
+		if b.validateStatement(stmt) {
 			continue
 		}
 		switch stmt.Kind() {
@@ -7896,90 +7896,90 @@ func (this *BallerinaParser) parseForkStatement() tree.STNode {
 				openBrace = tree.CloneWithTrailingInvalidNodeMinutiae(openBrace, stmt,
 					&common.ERROR_ONLY_NAMED_WORKERS_ALLOWED_HERE)
 			} else {
-				this.updateLastNodeInListWithInvalidNode(workers, stmt,
+				b.updateLastNodeInListWithInvalidNode(workers, stmt,
 					&common.ERROR_ONLY_NAMED_WORKERS_ALLOWED_HERE)
 			}
 		}
 	}
 	namedWorkerDeclarations := tree.CreateNodeList(workers...)
-	closeBrace := this.parseCloseBrace()
-	this.endContext()
+	closeBrace := b.parseCloseBrace()
+	b.endContext()
 	forkStmt := tree.CreateForkStatementNode(forkKeyword, openBrace, namedWorkerDeclarations, closeBrace)
-	if this.isNodeListEmpty(namedWorkerDeclarations) {
+	if b.isNodeListEmpty(namedWorkerDeclarations) {
 		return tree.AddDiagnostic(forkStmt,
 			&common.ERROR_MISSING_NAMED_WORKER_DECLARATION_IN_FORK_STMT)
 	}
 	return forkStmt
 }
 
-func (this *BallerinaParser) parseTrapExpression(isRhsExpr bool, allowActions bool, isInConditionalExpr bool) tree.STNode {
-	trapKeyword := this.parseTrapKeyword()
-	expr := this.parseExpressionWithConditional(OPERATOR_PRECEDENCE_TRAP, isRhsExpr, allowActions, isInConditionalExpr)
-	if this.isAction(expr) {
+func (b *BallerinaParser) parseTrapExpression(isRhsExpr bool, allowActions bool, isInConditionalExpr bool) tree.STNode {
+	trapKeyword := b.parseTrapKeyword()
+	expr := b.parseExpressionWithConditional(OPERATOR_PRECEDENCE_TRAP, isRhsExpr, allowActions, isInConditionalExpr)
+	if b.isAction(expr) {
 		return tree.CreateTrapExpressionNode(common.TRAP_ACTION, trapKeyword, expr)
 	}
 	return tree.CreateTrapExpressionNode(common.TRAP_EXPRESSION, trapKeyword, expr)
 }
 
-func (this *BallerinaParser) parseTrapKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseTrapKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.TRAP_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_TRAP_KEYWORD)
-		return this.parseTrapKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_TRAP_KEYWORD)
+		return b.parseTrapKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseListConstructorExpr() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_LIST_CONSTRUCTOR)
-	openBracket := this.parseOpenBracket()
-	listMembers := this.parseListMembers()
-	closeBracket := this.parseCloseBracket()
-	this.endContext()
+func (b *BallerinaParser) parseListConstructorExpr() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_LIST_CONSTRUCTOR)
+	openBracket := b.parseOpenBracket()
+	listMembers := b.parseListMembers()
+	closeBracket := b.parseCloseBracket()
+	b.endContext()
 	return tree.CreateListConstructorExpressionNode(openBracket, listMembers, closeBracket)
 }
 
-func (this *BallerinaParser) parseListMembers() tree.STNode {
+func (b *BallerinaParser) parseListMembers() tree.STNode {
 	var listMembers []tree.STNode
-	if this.isEndOfListConstructor(this.peek().Kind()) {
+	if b.isEndOfListConstructor(b.peek().Kind()) {
 		return tree.CreateEmptyNodeList()
 	}
-	listMember := this.parseListMember()
+	listMember := b.parseListMember()
 	listMembers = append(listMembers, listMember)
-	return this.parseListMembersInner(listMembers)
+	return b.parseListMembersInner(listMembers)
 }
 
-func (this *BallerinaParser) parseListMembersInner(listMembers []tree.STNode) tree.STNode {
+func (b *BallerinaParser) parseListMembersInner(listMembers []tree.STNode) tree.STNode {
 	var listConstructorMemberEnd tree.STNode
-	for !this.isEndOfListConstructor(this.peek().Kind()) {
-		listConstructorMemberEnd = this.parseListConstructorMemberEnd()
+	for !b.isEndOfListConstructor(b.peek().Kind()) {
+		listConstructorMemberEnd = b.parseListConstructorMemberEnd()
 		if listConstructorMemberEnd == nil {
 			break
 		}
 		listMembers = append(listMembers, listConstructorMemberEnd)
-		listMember := this.parseListMember()
+		listMember := b.parseListMember()
 		listMembers = append(listMembers, listMember)
 	}
 	return tree.CreateNodeList(listMembers...)
 }
 
-func (this *BallerinaParser) parseListMember() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseListMember() tree.STNode {
+	nextToken := b.peek()
 	if nextToken.Kind() == common.ELLIPSIS_TOKEN {
-		return this.parseSpreadMember()
+		return b.parseSpreadMember()
 	} else {
-		return this.parseExpression()
+		return b.parseExpression()
 	}
 }
 
-func (this *BallerinaParser) parseSpreadMember() tree.STNode {
-	ellipsis := this.parseEllipsis()
-	expr := this.parseExpression()
+func (b *BallerinaParser) parseSpreadMember() tree.STNode {
+	ellipsis := b.parseEllipsis()
+	expr := b.parseExpression()
 	return tree.CreateSpreadMemberNode(ellipsis, expr)
 }
 
-func (this *BallerinaParser) isEndOfListConstructor(tokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isEndOfListConstructor(tokenKind common.SyntaxKind) bool {
 	switch tokenKind {
 	case common.EOF_TOKEN, common.CLOSE_BRACKET_TOKEN:
 		return true
@@ -7988,196 +7988,196 @@ func (this *BallerinaParser) isEndOfListConstructor(tokenKind common.SyntaxKind)
 	}
 }
 
-func (this *BallerinaParser) parseListConstructorMemberEnd() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseListConstructorMemberEnd() tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.COMMA_TOKEN:
-		return this.consume()
+		return b.consume()
 	case common.CLOSE_BRACKET_TOKEN:
 		return nil
 	default:
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_LIST_CONSTRUCTOR_MEMBER_END)
-		return this.parseListConstructorMemberEnd()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_LIST_CONSTRUCTOR_MEMBER_END)
+		return b.parseListConstructorMemberEnd()
 	}
 }
 
-func (this *BallerinaParser) parseForEachStatement() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_FOREACH_STMT)
-	forEachKeyword := this.parseForEachKeyword()
-	typedBindingPattern := this.parseTypedBindingPatternWithContext(common.PARSER_RULE_CONTEXT_FOREACH_STMT)
-	inKeyword := this.parseInKeyword()
-	actionOrExpr := this.parseActionOrExpression()
-	blockStatement := this.parseBlockNode()
-	this.endContext()
-	onFailClause := this.parseOptionalOnFailClause()
+func (b *BallerinaParser) parseForEachStatement() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_FOREACH_STMT)
+	forEachKeyword := b.parseForEachKeyword()
+	typedBindingPattern := b.parseTypedBindingPatternWithContext(common.PARSER_RULE_CONTEXT_FOREACH_STMT)
+	inKeyword := b.parseInKeyword()
+	actionOrExpr := b.parseActionOrExpression()
+	blockStatement := b.parseBlockNode()
+	b.endContext()
+	onFailClause := b.parseOptionalOnFailClause()
 	return tree.CreateForEachStatementNode(forEachKeyword, typedBindingPattern, inKeyword, actionOrExpr,
 		blockStatement, onFailClause)
 }
 
-func (this *BallerinaParser) parseForEachKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseForEachKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.FOREACH_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_FOREACH_KEYWORD)
-		return this.parseForEachKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_FOREACH_KEYWORD)
+		return b.parseForEachKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseInKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseInKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.IN_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_IN_KEYWORD)
-		return this.parseInKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_IN_KEYWORD)
+		return b.parseInKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseTypeCastExpr(isRhsExpr bool, allowActions bool, isInConditionalExpr bool) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_TYPE_CAST)
-	ltToken := this.parseLTToken()
-	return this.parseTypeCastExprInner(ltToken, isRhsExpr, allowActions, isInConditionalExpr)
+func (b *BallerinaParser) parseTypeCastExpr(isRhsExpr bool, allowActions bool, isInConditionalExpr bool) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_TYPE_CAST)
+	ltToken := b.parseLTToken()
+	return b.parseTypeCastExprInner(ltToken, isRhsExpr, allowActions, isInConditionalExpr)
 }
 
-func (this *BallerinaParser) parseTypeCastExprInner(ltToken tree.STNode, isRhsExpr bool, allowActions bool, isInConditionalExpr bool) tree.STNode {
-	typeCastParam := this.parseTypeCastParam()
-	gtToken := this.parseGTToken()
-	this.endContext()
-	expression := this.parseExpressionWithConditional(OPERATOR_PRECEDENCE_EXPRESSION_ACTION, isRhsExpr, allowActions, isInConditionalExpr)
+func (b *BallerinaParser) parseTypeCastExprInner(ltToken tree.STNode, isRhsExpr bool, allowActions bool, isInConditionalExpr bool) tree.STNode {
+	typeCastParam := b.parseTypeCastParam()
+	gtToken := b.parseGTToken()
+	b.endContext()
+	expression := b.parseExpressionWithConditional(OPERATOR_PRECEDENCE_EXPRESSION_ACTION, isRhsExpr, allowActions, isInConditionalExpr)
 	return tree.CreateTypeCastExpressionNode(ltToken, typeCastParam, gtToken, expression)
 }
 
-func (this *BallerinaParser) parseTypeCastParam() tree.STNode {
+func (b *BallerinaParser) parseTypeCastParam() tree.STNode {
 	var annot tree.STNode
 	var ty tree.STNode
-	token := this.peek()
+	token := b.peek()
 	switch token.Kind() {
 	case common.AT_TOKEN:
-		annot = this.parseOptionalAnnotations()
-		token = this.peek()
-		if this.isTypeStartingToken(token.Kind()) {
-			ty = this.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_ANGLE_BRACKETS)
+		annot = b.parseOptionalAnnotations()
+		token = b.peek()
+		if b.isTypeStartingToken(token.Kind()) {
+			ty = b.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_ANGLE_BRACKETS)
 		} else {
 			ty = tree.CreateEmptyNode()
 		}
 	default:
 		annot = tree.CreateEmptyNode()
-		ty = this.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_ANGLE_BRACKETS)
+		ty = b.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_ANGLE_BRACKETS)
 	}
-	return tree.CreateTypeCastParamNode(this.getAnnotations(annot), ty)
+	return tree.CreateTypeCastParamNode(b.getAnnotations(annot), ty)
 }
 
-func (this *BallerinaParser) parseTableConstructorExprRhs(tableKeyword tree.STNode, keySpecifier tree.STNode) tree.STNode {
-	this.switchContext(common.PARSER_RULE_CONTEXT_TABLE_CONSTRUCTOR)
-	openBracket := this.parseOpenBracket()
-	rowList := this.parseRowList()
-	closeBracket := this.parseCloseBracket()
+func (b *BallerinaParser) parseTableConstructorExprRhs(tableKeyword tree.STNode, keySpecifier tree.STNode) tree.STNode {
+	b.switchContext(common.PARSER_RULE_CONTEXT_TABLE_CONSTRUCTOR)
+	openBracket := b.parseOpenBracket()
+	rowList := b.parseRowList()
+	closeBracket := b.parseCloseBracket()
 	return tree.CreateTableConstructorExpressionNode(tableKeyword, keySpecifier, openBracket, rowList,
 		closeBracket)
 }
 
-func (this *BallerinaParser) parseTableKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseTableKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.TABLE_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_TABLE_KEYWORD)
-		return this.parseTableKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_TABLE_KEYWORD)
+		return b.parseTableKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseRowList() tree.STNode {
-	nextToken := this.peek()
-	if this.isEndOfTableRowList(nextToken.Kind()) {
+func (b *BallerinaParser) parseRowList() tree.STNode {
+	nextToken := b.peek()
+	if b.isEndOfTableRowList(nextToken.Kind()) {
 		return tree.CreateEmptyNodeList()
 	}
 	var mappings []tree.STNode
-	mapExpr := this.parseMappingConstructorExpr()
+	mapExpr := b.parseMappingConstructorExpr()
 	mappings = append(mappings, mapExpr)
-	nextToken = this.peek()
+	nextToken = b.peek()
 	var rowEnd tree.STNode
-	for !this.isEndOfTableRowList(nextToken.Kind()) {
-		rowEnd = this.parseTableRowEnd()
+	for !b.isEndOfTableRowList(nextToken.Kind()) {
+		rowEnd = b.parseTableRowEnd()
 		if rowEnd == nil {
 			break
 		}
 		mappings = append(mappings, rowEnd)
-		mapExpr = this.parseMappingConstructorExpr()
+		mapExpr = b.parseMappingConstructorExpr()
 		mappings = append(mappings, mapExpr)
-		nextToken = this.peek()
+		nextToken = b.peek()
 	}
 	return tree.CreateNodeList(mappings...)
 }
 
-func (this *BallerinaParser) isEndOfTableRowList(tokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isEndOfTableRowList(tokenKind common.SyntaxKind) bool {
 	switch tokenKind {
 	case common.EOF_TOKEN, common.CLOSE_BRACKET_TOKEN:
 		return true
 	case common.COMMA_TOKEN, common.OPEN_BRACE_TOKEN:
 		return false
 	default:
-		return this.isEndOfMappingConstructor(tokenKind)
+		return b.isEndOfMappingConstructor(tokenKind)
 	}
 }
 
-func (this *BallerinaParser) parseTableRowEnd() tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseTableRowEnd() tree.STNode {
+	switch b.peek().Kind() {
 	case common.COMMA_TOKEN:
-		return this.parseComma()
+		return b.parseComma()
 	case common.CLOSE_BRACKET_TOKEN, common.EOF_TOKEN:
 		return nil
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_TABLE_ROW_END)
-		return this.parseTableRowEnd()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_TABLE_ROW_END)
+		return b.parseTableRowEnd()
 	}
 }
 
-func (this *BallerinaParser) parseKeySpecifier() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_KEY_SPECIFIER)
-	keyKeyword := this.parseKeyKeyword()
-	openParen := this.parseOpenParenthesis()
-	fieldNames := this.parseFieldNames()
-	closeParen := this.parseCloseParenthesis()
-	this.endContext()
+func (b *BallerinaParser) parseKeySpecifier() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_KEY_SPECIFIER)
+	keyKeyword := b.parseKeyKeyword()
+	openParen := b.parseOpenParenthesis()
+	fieldNames := b.parseFieldNames()
+	closeParen := b.parseCloseParenthesis()
+	b.endContext()
 	return tree.CreateKeySpecifierNode(keyKeyword, openParen, fieldNames, closeParen)
 }
 
-func (this *BallerinaParser) parseKeyKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseKeyKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.KEY_KEYWORD {
-		return this.consume()
+		return b.consume()
 	}
 	if isKeyKeyword(token) {
-		return this.getKeyKeyword(this.consume())
+		return b.getKeyKeyword(b.consume())
 	}
-	this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_KEY_KEYWORD)
-	return this.parseKeyKeyword()
+	b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_KEY_KEYWORD)
+	return b.parseKeyKeyword()
 }
 
-func (this *BallerinaParser) getKeyKeyword(token tree.STToken) tree.STNode {
+func (b *BallerinaParser) getKeyKeyword(token tree.STToken) tree.STNode {
 	return tree.CreateTokenWithDiagnostics(common.KEY_KEYWORD, token.LeadingMinutiae(), token.TrailingMinutiae(),
 		token.Diagnostics())
 }
 
-func (this *BallerinaParser) getUnderscoreKeyword(token tree.STToken) tree.STToken {
+func (b *BallerinaParser) getUnderscoreKeyword(token tree.STToken) tree.STToken {
 	return tree.CreateTokenWithDiagnostics(common.UNDERSCORE_KEYWORD, token.LeadingMinutiae(),
 		token.TrailingMinutiae(), token.Diagnostics())
 }
 
-func (this *BallerinaParser) parseNaturalKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseNaturalKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.NATURAL_KEYWORD {
-		return this.consume()
+		return b.consume()
 	}
-	if this.isNaturalKeyword(token) {
-		return this.getNaturalKeyword(this.consume())
+	if b.isNaturalKeyword(token) {
+		return b.getNaturalKeyword(b.consume())
 	}
-	this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_NATURAL_KEYWORD)
-	return this.parseNaturalKeyword()
+	b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_NATURAL_KEYWORD)
+	return b.parseNaturalKeyword()
 }
 
-func (this *BallerinaParser) isNaturalKeyword(node tree.STNode) bool {
+func (b *BallerinaParser) isNaturalKeyword(node tree.STNode) bool {
 	token, isToken := node.(tree.STToken)
 	if isToken {
 		return isNaturalKeyword(token)
@@ -8196,32 +8196,32 @@ func (this *BallerinaParser) isNaturalKeyword(node tree.STNode) bool {
 	return isNaturalKeyword(nameToken)
 }
 
-func (this *BallerinaParser) getNaturalKeyword(token tree.STToken) tree.STNode {
+func (b *BallerinaParser) getNaturalKeyword(token tree.STToken) tree.STNode {
 	return tree.CreateTokenWithDiagnostics(common.NATURAL_KEYWORD, token.LeadingMinutiae(), token.TrailingMinutiae(),
 		token.Diagnostics())
 }
 
-func (this *BallerinaParser) parseFieldNames() tree.STNode {
-	nextToken := this.peek()
-	if this.isEndOfFieldNamesList(nextToken.Kind()) {
+func (b *BallerinaParser) parseFieldNames() tree.STNode {
+	nextToken := b.peek()
+	if b.isEndOfFieldNamesList(nextToken.Kind()) {
 		return tree.CreateEmptyNodeList()
 	}
 	var fieldNames []tree.STNode
-	fieldName := this.parseVariableName()
+	fieldName := b.parseVariableName()
 	fieldNames = append(fieldNames, fieldName)
-	nextToken = this.peek()
+	nextToken = b.peek()
 	var leadingComma tree.STNode
-	for !this.isEndOfFieldNamesList(nextToken.Kind()) {
-		leadingComma = this.parseComma()
+	for !b.isEndOfFieldNamesList(nextToken.Kind()) {
+		leadingComma = b.parseComma()
 		fieldNames = append(fieldNames, leadingComma)
-		fieldName = this.parseVariableName()
+		fieldName = b.parseVariableName()
 		fieldNames = append(fieldNames, fieldName)
-		nextToken = this.peek()
+		nextToken = b.peek()
 	}
 	return tree.CreateNodeList(fieldNames...)
 }
 
-func (this *BallerinaParser) isEndOfFieldNamesList(tokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isEndOfFieldNamesList(tokenKind common.SyntaxKind) bool {
 	switch tokenKind {
 	case common.COMMA_TOKEN, common.IDENTIFIER_TOKEN:
 		return false
@@ -8230,133 +8230,133 @@ func (this *BallerinaParser) isEndOfFieldNamesList(tokenKind common.SyntaxKind) 
 	}
 }
 
-func (this *BallerinaParser) parseErrorKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseErrorKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.ERROR_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_ERROR_KEYWORD)
-		return this.parseErrorKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_ERROR_KEYWORD)
+		return b.parseErrorKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseStreamTypeDescriptor(streamKeywordToken tree.STNode) tree.STNode {
+func (b *BallerinaParser) parseStreamTypeDescriptor(streamKeywordToken tree.STNode) tree.STNode {
 	var streamTypeParamsNode tree.STNode
-	nextToken := this.peek()
+	nextToken := b.peek()
 	if nextToken.Kind() == common.LT_TOKEN {
-		streamTypeParamsNode = this.parseStreamTypeParamsNode()
+		streamTypeParamsNode = b.parseStreamTypeParamsNode()
 	} else {
 		streamTypeParamsNode = tree.CreateEmptyNode()
 	}
 	return tree.CreateStreamTypeDescriptorNode(streamKeywordToken, streamTypeParamsNode)
 }
 
-func (this *BallerinaParser) parseStreamTypeParamsNode() tree.STNode {
-	ltToken := this.parseLTToken()
-	this.startContext(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_STREAM_TYPE_DESC)
-	leftTypeDescNode := this.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_STREAM_TYPE_DESC)
-	streamTypedesc := this.parseStreamTypeParamsNodeInner(ltToken, leftTypeDescNode)
-	this.endContext()
+func (b *BallerinaParser) parseStreamTypeParamsNode() tree.STNode {
+	ltToken := b.parseLTToken()
+	b.startContext(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_STREAM_TYPE_DESC)
+	leftTypeDescNode := b.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_STREAM_TYPE_DESC)
+	streamTypedesc := b.parseStreamTypeParamsNodeInner(ltToken, leftTypeDescNode)
+	b.endContext()
 	return streamTypedesc
 }
 
-func (this *BallerinaParser) parseStreamTypeParamsNodeInner(ltToken tree.STNode, leftTypeDescNode tree.STNode) tree.STNode {
+func (b *BallerinaParser) parseStreamTypeParamsNodeInner(ltToken tree.STNode, leftTypeDescNode tree.STNode) tree.STNode {
 	var commaToken tree.STNode
 	var rightTypeDescNode tree.STNode
-	switch this.peek().Kind() {
+	switch b.peek().Kind() {
 	case common.COMMA_TOKEN:
-		commaToken = this.parseComma()
-		rightTypeDescNode = this.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_STREAM_TYPE_DESC)
+		commaToken = b.parseComma()
+		rightTypeDescNode = b.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_STREAM_TYPE_DESC)
 	case common.GT_TOKEN:
 		commaToken = tree.CreateEmptyNode()
 		rightTypeDescNode = tree.CreateEmptyNode()
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_STREAM_TYPE_FIRST_PARAM_RHS)
-		return this.parseStreamTypeParamsNodeInner(ltToken, leftTypeDescNode)
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_STREAM_TYPE_FIRST_PARAM_RHS)
+		return b.parseStreamTypeParamsNodeInner(ltToken, leftTypeDescNode)
 	}
-	gtToken := this.parseGTToken()
+	gtToken := b.parseGTToken()
 	return tree.CreateStreamTypeParamsNode(ltToken, leftTypeDescNode, commaToken, rightTypeDescNode,
 		gtToken)
 }
 
-func (this *BallerinaParser) parseLetExpression(isRhsExpr bool, isInConditionalExpr bool) tree.STNode {
-	letKeyword := this.parseLetKeyword()
-	letVarDeclarations := this.parseLetVarDeclarations(common.PARSER_RULE_CONTEXT_LET_EXPR_LET_VAR_DECL, isRhsExpr, false)
-	inKeyword := this.parseInKeyword()
-	letKeyword = this.cloneWithDiagnosticIfListEmpty(letVarDeclarations, letKeyword,
+func (b *BallerinaParser) parseLetExpression(isRhsExpr bool, isInConditionalExpr bool) tree.STNode {
+	letKeyword := b.parseLetKeyword()
+	letVarDeclarations := b.parseLetVarDeclarations(common.PARSER_RULE_CONTEXT_LET_EXPR_LET_VAR_DECL, isRhsExpr, false)
+	inKeyword := b.parseInKeyword()
+	letKeyword = b.cloneWithDiagnosticIfListEmpty(letVarDeclarations, letKeyword,
 		&common.ERROR_MISSING_LET_VARIABLE_DECLARATION)
-	expression := this.parseExpressionWithConditional(OPERATOR_PRECEDENCE_REMOTE_CALL_ACTION, isRhsExpr, false,
+	expression := b.parseExpressionWithConditional(OPERATOR_PRECEDENCE_REMOTE_CALL_ACTION, isRhsExpr, false,
 		isInConditionalExpr)
 	return tree.CreateLetExpressionNode(letKeyword, letVarDeclarations, inKeyword, expression)
 }
 
-func (this *BallerinaParser) parseLetKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseLetKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.LET_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_LET_KEYWORD)
-		return this.parseLetKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_LET_KEYWORD)
+		return b.parseLetKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseLetVarDeclarations(context common.ParserRuleContext, isRhsExpr bool, allowActions bool) tree.STNode {
-	this.startContext(context)
+func (b *BallerinaParser) parseLetVarDeclarations(context common.ParserRuleContext, isRhsExpr bool, allowActions bool) tree.STNode {
+	b.startContext(context)
 	var varDecls []tree.STNode
-	nextToken := this.peek()
-	if isEndOfLetVarDeclarations(nextToken, this.getNextNextToken()) {
-		this.endContext()
+	nextToken := b.peek()
+	if isEndOfLetVarDeclarations(nextToken, b.getNextNextToken()) {
+		b.endContext()
 		return tree.CreateEmptyNodeList()
 	}
-	varDec := this.parseLetVarDecl(context, isRhsExpr, allowActions)
+	varDec := b.parseLetVarDecl(context, isRhsExpr, allowActions)
 	varDecls = append(varDecls, varDec)
-	nextToken = this.peek()
+	nextToken = b.peek()
 	var leadingComma tree.STNode
-	for !isEndOfLetVarDeclarations(nextToken, this.getNextNextToken()) {
-		leadingComma = this.parseComma()
+	for !isEndOfLetVarDeclarations(nextToken, b.getNextNextToken()) {
+		leadingComma = b.parseComma()
 		varDecls = append(varDecls, leadingComma)
-		varDec = this.parseLetVarDecl(context, isRhsExpr, allowActions)
+		varDec = b.parseLetVarDecl(context, isRhsExpr, allowActions)
 		varDecls = append(varDecls, varDec)
-		nextToken = this.peek()
+		nextToken = b.peek()
 	}
-	this.endContext()
+	b.endContext()
 	return tree.CreateNodeList(varDecls...)
 }
 
-func (this *BallerinaParser) parseLetVarDecl(context common.ParserRuleContext, isRhsExpr bool, allowActions bool) tree.STNode {
-	annot := this.parseOptionalAnnotations()
-	typedBindingPattern := this.parseTypedBindingPatternWithContext(common.PARSER_RULE_CONTEXT_LET_EXPR_LET_VAR_DECL)
-	assign := this.parseAssignOp()
+func (b *BallerinaParser) parseLetVarDecl(context common.ParserRuleContext, isRhsExpr bool, allowActions bool) tree.STNode {
+	annot := b.parseOptionalAnnotations()
+	typedBindingPattern := b.parseTypedBindingPatternWithContext(common.PARSER_RULE_CONTEXT_LET_EXPR_LET_VAR_DECL)
+	assign := b.parseAssignOp()
 	var expression tree.STNode
 	if context == common.PARSER_RULE_CONTEXT_LET_CLAUSE_LET_VAR_DECL {
-		expression = this.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_QUERY, isRhsExpr, allowActions)
+		expression = b.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_QUERY, isRhsExpr, allowActions)
 	} else {
-		expression = this.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_ANON_FUNC_OR_LET, isRhsExpr, false)
+		expression = b.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_ANON_FUNC_OR_LET, isRhsExpr, false)
 	}
 	return tree.CreateLetVariableDeclarationNode(annot, typedBindingPattern, assign, expression)
 }
 
-func (this *BallerinaParser) parseTemplateExpression() tree.STNode {
+func (b *BallerinaParser) parseTemplateExpression() tree.STNode {
 	ty := tree.CreateEmptyNode()
-	startingBackTick := this.parseBacktickToken(common.PARSER_RULE_CONTEXT_TEMPLATE_START)
-	content := this.parseTemplateContent()
-	endingBackTick := this.parseBacktickToken(common.PARSER_RULE_CONTEXT_TEMPLATE_START)
+	startingBackTick := b.parseBacktickToken(common.PARSER_RULE_CONTEXT_TEMPLATE_START)
+	content := b.parseTemplateContent()
+	endingBackTick := b.parseBacktickToken(common.PARSER_RULE_CONTEXT_TEMPLATE_START)
 	return tree.CreateTemplateExpressionNode(common.RAW_TEMPLATE_EXPRESSION, ty, startingBackTick,
 		content, endingBackTick)
 }
 
-func (this *BallerinaParser) parseTemplateContent() tree.STNode {
+func (b *BallerinaParser) parseTemplateContent() tree.STNode {
 	var items []tree.STNode
-	nextToken := this.peek()
-	for !this.isEndOfBacktickContent(nextToken.Kind()) {
-		contentItem := this.parseTemplateItem()
+	nextToken := b.peek()
+	for !b.isEndOfBacktickContent(nextToken.Kind()) {
+		contentItem := b.parseTemplateItem()
 		items = append(items, contentItem)
-		nextToken = this.peek()
+		nextToken = b.peek()
 	}
 	return tree.CreateNodeList(items...)
 }
 
-func (this *BallerinaParser) isEndOfBacktickContent(kind common.SyntaxKind) bool {
+func (b *BallerinaParser) isEndOfBacktickContent(kind common.SyntaxKind) bool {
 	switch kind {
 	case common.EOF_TOKEN, common.BACKTICK_TOKEN:
 		return true
@@ -8365,67 +8365,67 @@ func (this *BallerinaParser) isEndOfBacktickContent(kind common.SyntaxKind) bool
 	}
 }
 
-func (this *BallerinaParser) parseTemplateItem() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseTemplateItem() tree.STNode {
+	nextToken := b.peek()
 	if nextToken.Kind() == common.INTERPOLATION_START_TOKEN {
-		return this.parseInterpolation()
+		return b.parseInterpolation()
 	}
 	if nextToken.Kind() != common.TEMPLATE_STRING {
-		nextToken = this.consume()
+		nextToken = b.consume()
 		return tree.CreateLiteralValueTokenWithDiagnostics(common.TEMPLATE_STRING,
 			nextToken.Text(), nextToken.LeadingMinutiae(), nextToken.TrailingMinutiae(),
 			nextToken.Diagnostics())
 	}
-	return this.consume()
+	return b.consume()
 }
 
-func (this *BallerinaParser) parseStringTemplateExpression() tree.STNode {
-	ty := this.parseStringKeyword()
-	startingBackTick := this.parseBacktickToken(common.PARSER_RULE_CONTEXT_TEMPLATE_START)
-	content := this.parseTemplateContent()
-	endingBackTick := this.parseBacktickToken(common.PARSER_RULE_CONTEXT_TEMPLATE_END)
+func (b *BallerinaParser) parseStringTemplateExpression() tree.STNode {
+	ty := b.parseStringKeyword()
+	startingBackTick := b.parseBacktickToken(common.PARSER_RULE_CONTEXT_TEMPLATE_START)
+	content := b.parseTemplateContent()
+	endingBackTick := b.parseBacktickToken(common.PARSER_RULE_CONTEXT_TEMPLATE_END)
 	return tree.CreateTemplateExpressionNode(common.STRING_TEMPLATE_EXPRESSION, ty, startingBackTick,
 		content, endingBackTick)
 }
 
-func (this *BallerinaParser) parseStringKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseStringKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.STRING_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_STRING_KEYWORD)
-		return this.parseStringKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_STRING_KEYWORD)
+		return b.parseStringKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseXMLTemplateExpression() tree.STNode {
-	xmlKeyword := this.parseXMLKeyword()
-	startingBackTick := this.parseBacktickToken(common.PARSER_RULE_CONTEXT_TEMPLATE_START)
+func (b *BallerinaParser) parseXMLTemplateExpression() tree.STNode {
+	xmlKeyword := b.parseXMLKeyword()
+	startingBackTick := b.parseBacktickToken(common.PARSER_RULE_CONTEXT_TEMPLATE_START)
 	if startingBackTick.IsMissing() {
-		return this.createMissingTemplateExpressionNode(xmlKeyword, common.XML_TEMPLATE_EXPRESSION)
+		return b.createMissingTemplateExpressionNode(xmlKeyword, common.XML_TEMPLATE_EXPRESSION)
 	}
-	content := this.parseTemplateContentAsXML()
-	endingBackTick := this.parseBacktickToken(common.PARSER_RULE_CONTEXT_TEMPLATE_END)
+	content := b.parseTemplateContentAsXML()
+	endingBackTick := b.parseBacktickToken(common.PARSER_RULE_CONTEXT_TEMPLATE_END)
 	return tree.CreateTemplateExpressionNode(common.XML_TEMPLATE_EXPRESSION, xmlKeyword,
 		startingBackTick, content, endingBackTick)
 }
 
-func (this *BallerinaParser) parseXMLKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseXMLKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.XML_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_XML_KEYWORD)
-		return this.parseXMLKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_XML_KEYWORD)
+		return b.parseXMLKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseTemplateContentAsXML() tree.STNode {
+func (b *BallerinaParser) parseTemplateContentAsXML() tree.STNode {
 	var expressions []tree.STNode
 	var xmlStringBuilder strings.Builder
-	nextToken := this.peek()
-	for !this.isEndOfBacktickContent(nextToken.Kind()) {
-		contentItem := this.parseTemplateItem()
+	nextToken := b.peek()
+	for !b.isEndOfBacktickContent(nextToken.Kind()) {
+		contentItem := b.parseTemplateItem()
 		if contentItem.Kind() == common.TEMPLATE_STRING {
 			contentToken, ok := contentItem.(tree.STToken)
 			if !ok {
@@ -8436,7 +8436,7 @@ func (this *BallerinaParser) parseTemplateContentAsXML() tree.STNode {
 			xmlStringBuilder.WriteString("${}")
 			expressions = append(expressions, contentItem) //nolint:staticcheck // TODO
 		}
-		nextToken = this.peek()
+		nextToken = b.peek()
 	}
 	// charReader := text.CharReaderFromText(xmlStringBuilder.String())
 	// tokenReader := nil
@@ -8445,19 +8445,19 @@ func (this *BallerinaParser) parseTemplateContentAsXML() tree.STNode {
 	panic("xml parser not implemented")
 }
 
-func (this *BallerinaParser) parseRegExpTemplateExpression() tree.STNode {
-	reKeyword := this.consume()
-	startingBackTick := this.parseBacktickToken(common.PARSER_RULE_CONTEXT_TEMPLATE_START)
+func (b *BallerinaParser) parseRegExpTemplateExpression() tree.STNode {
+	reKeyword := b.consume()
+	startingBackTick := b.parseBacktickToken(common.PARSER_RULE_CONTEXT_TEMPLATE_START)
 	if startingBackTick.IsMissing() {
-		return this.createMissingTemplateExpressionNode(reKeyword, common.REGEX_TEMPLATE_EXPRESSION)
+		return b.createMissingTemplateExpressionNode(reKeyword, common.REGEX_TEMPLATE_EXPRESSION)
 	}
-	content := this.parseTemplateContentAsRegExp()
-	endingBackTick := this.parseBacktickToken(common.PARSER_RULE_CONTEXT_TEMPLATE_END)
+	content := b.parseTemplateContentAsRegExp()
+	endingBackTick := b.parseBacktickToken(common.PARSER_RULE_CONTEXT_TEMPLATE_END)
 	return tree.CreateTemplateExpressionNode(common.REGEX_TEMPLATE_EXPRESSION, reKeyword,
 		startingBackTick, content, endingBackTick)
 }
 
-func (this *BallerinaParser) createMissingTemplateExpressionNode(reKeyword tree.STNode, kind common.SyntaxKind) tree.STNode {
+func (b *BallerinaParser) createMissingTemplateExpressionNode(reKeyword tree.STNode, kind common.SyntaxKind) tree.STNode {
 	startingBackTick := tree.CreateMissingToken(common.BACKTICK_TOKEN, nil)
 	endingBackTick := tree.CreateMissingToken(common.BACKTICK_TOKEN, nil)
 	content := tree.CreateEmptyNodeList()
@@ -8466,8 +8466,8 @@ func (this *BallerinaParser) createMissingTemplateExpressionNode(reKeyword tree.
 	return templateExpr
 }
 
-func (this *BallerinaParser) parseTemplateContentAsRegExp() tree.STNode {
-	this.tokenReader.StartMode(PARSER_MODE_REGEXP)
+func (b *BallerinaParser) parseTemplateContentAsRegExp() tree.STNode {
+	b.tokenReader.StartMode(PARSER_MODE_REGEXP)
 	panic("Regexp parser not implemented")
 	// expressions := make([]interface{}, 0)
 	// regExpStringBuilder := nil
@@ -8493,138 +8493,138 @@ func (this *BallerinaParser) parseTemplateContentAsRegExp() tree.STNode {
 	// return this.regExpParser.parse()
 }
 
-func (this *BallerinaParser) parseInterpolation() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_INTERPOLATION)
-	interpolStart := this.parseInterpolationStart()
-	expr := this.parseExpression()
-	for !this.isEndOfInterpolation() {
-		nextToken := this.consume()
+func (b *BallerinaParser) parseInterpolation() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_INTERPOLATION)
+	interpolStart := b.parseInterpolationStart()
+	expr := b.parseExpression()
+	for !b.isEndOfInterpolation() {
+		nextToken := b.consume()
 		expr = tree.CloneWithTrailingInvalidNodeMinutiae(expr, nextToken,
 			&common.ERROR_INVALID_TOKEN, nextToken.Text())
 	}
-	closeBrace := this.parseCloseBrace()
-	this.endContext()
+	closeBrace := b.parseCloseBrace()
+	b.endContext()
 	return tree.CreateInterpolationNode(interpolStart, expr, closeBrace)
 }
 
-func (this *BallerinaParser) isEndOfInterpolation() bool {
-	nextTokenKind := this.peek().Kind()
+func (b *BallerinaParser) isEndOfInterpolation() bool {
+	nextTokenKind := b.peek().Kind()
 	switch nextTokenKind {
 	case common.EOF_TOKEN, common.BACKTICK_TOKEN:
 		return true
 	default:
-		currentLexerMode := this.tokenReader.GetCurrentMode()
+		currentLexerMode := b.tokenReader.GetCurrentMode()
 		return (((nextTokenKind == common.CLOSE_BRACE_TOKEN) && (currentLexerMode != PARSER_MODE_INTERPOLATION)) && (currentLexerMode != PARSER_MODE_INTERPOLATION_BRACED_CONTENT))
 	}
 }
 
-func (this *BallerinaParser) parseInterpolationStart() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseInterpolationStart() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.INTERPOLATION_START_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_INTERPOLATION_START_TOKEN)
-		return this.parseInterpolationStart()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_INTERPOLATION_START_TOKEN)
+		return b.parseInterpolationStart()
 	}
 }
 
-func (this *BallerinaParser) parseBacktickToken(ctx common.ParserRuleContext) tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseBacktickToken(ctx common.ParserRuleContext) tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.BACKTICK_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, ctx)
-		return this.parseBacktickToken(ctx)
+		b.recoverWithBlockContext(token, ctx)
+		return b.parseBacktickToken(ctx)
 	}
 }
 
-func (this *BallerinaParser) parseTableTypeDescriptor(tableKeywordToken tree.STNode) tree.STNode {
-	rowTypeParameterNode := this.parseRowTypeParameter()
+func (b *BallerinaParser) parseTableTypeDescriptor(tableKeywordToken tree.STNode) tree.STNode {
+	rowTypeParameterNode := b.parseRowTypeParameter()
 	var keyConstraintNode tree.STNode
-	nextToken := this.peek()
+	nextToken := b.peek()
 	if isKeyKeyword(nextToken) {
-		keyKeywordToken := this.getKeyKeyword(this.consume())
-		keyConstraintNode = this.parseKeyConstraint(keyKeywordToken)
+		keyKeywordToken := b.getKeyKeyword(b.consume())
+		keyConstraintNode = b.parseKeyConstraint(keyKeywordToken)
 	} else {
 		keyConstraintNode = tree.CreateEmptyNode()
 	}
 	return tree.CreateTableTypeDescriptorNode(tableKeywordToken, rowTypeParameterNode, keyConstraintNode)
 }
 
-func (this *BallerinaParser) parseRowTypeParameter() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_ROW_TYPE_PARAM)
-	rowTypeParameterNode := this.parseTypeParameter()
-	this.endContext()
+func (b *BallerinaParser) parseRowTypeParameter() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_ROW_TYPE_PARAM)
+	rowTypeParameterNode := b.parseTypeParameter()
+	b.endContext()
 	return rowTypeParameterNode
 }
 
-func (this *BallerinaParser) parseTypeParameter() tree.STNode {
-	ltToken := this.parseLTToken()
-	typeNode := this.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_ANGLE_BRACKETS)
-	gtToken := this.parseGTToken()
+func (b *BallerinaParser) parseTypeParameter() tree.STNode {
+	ltToken := b.parseLTToken()
+	typeNode := b.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_ANGLE_BRACKETS)
+	gtToken := b.parseGTToken()
 	return tree.CreateTypeParameterNode(ltToken, typeNode, gtToken)
 }
 
-func (this *BallerinaParser) parseKeyConstraint(keyKeywordToken tree.STNode) tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseKeyConstraint(keyKeywordToken tree.STNode) tree.STNode {
+	switch b.peek().Kind() {
 	case common.OPEN_PAREN_TOKEN:
-		return this.parseKeySpecifierWithKeyKeywordToken(keyKeywordToken)
+		return b.parseKeySpecifierWithKeyKeywordToken(keyKeywordToken)
 	case common.LT_TOKEN:
-		return this.parseKeyTypeConstraint(keyKeywordToken)
+		return b.parseKeyTypeConstraint(keyKeywordToken)
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_KEY_CONSTRAINTS_RHS)
-		return this.parseKeyConstraint(keyKeywordToken)
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_KEY_CONSTRAINTS_RHS)
+		return b.parseKeyConstraint(keyKeywordToken)
 	}
 }
 
-func (this *BallerinaParser) parseKeySpecifierWithKeyKeywordToken(keyKeywordToken tree.STNode) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_KEY_SPECIFIER)
-	openParenToken := this.parseOpenParenthesis()
-	fieldNamesNode := this.parseFieldNames()
-	closeParenToken := this.parseCloseParenthesis()
-	this.endContext()
+func (b *BallerinaParser) parseKeySpecifierWithKeyKeywordToken(keyKeywordToken tree.STNode) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_KEY_SPECIFIER)
+	openParenToken := b.parseOpenParenthesis()
+	fieldNamesNode := b.parseFieldNames()
+	closeParenToken := b.parseCloseParenthesis()
+	b.endContext()
 	return tree.CreateKeySpecifierNode(keyKeywordToken, openParenToken, fieldNamesNode, closeParenToken)
 }
 
-func (this *BallerinaParser) parseKeyTypeConstraint(keyKeywordToken tree.STNode) tree.STNode {
-	typeParameterNode := this.parseTypeParameter()
+func (b *BallerinaParser) parseKeyTypeConstraint(keyKeywordToken tree.STNode) tree.STNode {
+	typeParameterNode := b.parseTypeParameter()
 	return tree.CreateKeyTypeConstraintNode(keyKeywordToken, typeParameterNode)
 }
 
-func (this *BallerinaParser) parseFunctionTypeDesc(qualifiers []tree.STNode) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_FUNC_TYPE_DESC)
-	functionKeyword := this.parseFunctionKeyword()
+func (b *BallerinaParser) parseFunctionTypeDesc(qualifiers []tree.STNode) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_FUNC_TYPE_DESC)
+	functionKeyword := b.parseFunctionKeyword()
 	hasFuncSignature := false
 	signature := tree.CreateEmptyNode()
-	if (this.peek().Kind() == common.OPEN_PAREN_TOKEN) || this.isSyntaxKindInList(qualifiers, common.TRANSACTIONAL_KEYWORD) {
-		signature = this.parseFuncSignature(true)
+	if (b.peek().Kind() == common.OPEN_PAREN_TOKEN) || b.isSyntaxKindInList(qualifiers, common.TRANSACTIONAL_KEYWORD) {
+		signature = b.parseFuncSignature(true)
 		hasFuncSignature = true
 	}
-	nodes := this.createFuncTypeQualNodeList(qualifiers, functionKeyword, hasFuncSignature)
+	nodes := b.createFuncTypeQualNodeList(qualifiers, functionKeyword, hasFuncSignature)
 	qualifierList := nodes[0]
 	functionKeyword = nodes[1]
-	this.endContext()
+	b.endContext()
 	return tree.CreateFunctionTypeDescriptorNode(qualifierList, functionKeyword, signature)
 }
 
-func (this *BallerinaParser) getLastNodeInList(nodeList []tree.STNode) tree.STNode {
+func (b *BallerinaParser) getLastNodeInList(nodeList []tree.STNode) tree.STNode {
 	return nodeList[len(nodeList)-1]
 }
 
-func (this *BallerinaParser) createFuncTypeQualNodeList(qualifierList []tree.STNode, functionKeyword tree.STNode, hasFuncSignature bool) []tree.STNode {
+func (b *BallerinaParser) createFuncTypeQualNodeList(qualifierList []tree.STNode, functionKeyword tree.STNode, hasFuncSignature bool) []tree.STNode {
 	var validatedList []tree.STNode
 	i := 0
 	for ; i < len(qualifierList); i++ {
 		qualifier := qualifierList[i]
 		nextIndex := (i + 1)
-		if this.isSyntaxKindInList(validatedList, qualifier.Kind()) {
+		if b.isSyntaxKindInList(validatedList, qualifier.Kind()) {
 			qualifierToken, ok := qualifier.(tree.STToken)
 			if !ok {
 				panic("createFuncTypeQualNodeList: expected STToken")
 			}
-			this.updateLastNodeInListWithInvalidNode(validatedList, qualifier,
+			b.updateLastNodeInListWithInvalidNode(validatedList, qualifier,
 				&common.ERROR_DUPLICATE_QUALIFIER, qualifierToken.Text())
-		} else if hasFuncSignature && this.isRegularFuncQual(qualifier.Kind()) {
+		} else if hasFuncSignature && b.isRegularFuncQual(qualifier.Kind()) {
 			validatedList = append(validatedList, qualifier)
 		} else if qualifier.Kind() == common.ISOLATED_KEYWORD {
 			validatedList = append(validatedList, qualifier)
@@ -8632,7 +8632,7 @@ func (this *BallerinaParser) createFuncTypeQualNodeList(qualifierList []tree.STN
 			functionKeyword = tree.CloneWithLeadingInvalidNodeMinutiae(functionKeyword, qualifier,
 				&common.ERROR_QUALIFIER_NOT_ALLOWED, tree.ToToken(qualifier).Text())
 		} else {
-			this.updateANodeInListWithLeadingInvalidNode(qualifierList, nextIndex, qualifier,
+			b.updateANodeInListWithLeadingInvalidNode(qualifierList, nextIndex, qualifier,
 				&common.ERROR_QUALIFIER_NOT_ALLOWED, tree.ToToken(qualifier).Text())
 		}
 	}
@@ -8640,7 +8640,7 @@ func (this *BallerinaParser) createFuncTypeQualNodeList(qualifierList []tree.STN
 	return []tree.STNode{nodeList, functionKeyword}
 }
 
-func (this *BallerinaParser) isRegularFuncQual(tokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isRegularFuncQual(tokenKind common.SyntaxKind) bool {
 	switch tokenKind {
 	case common.ISOLATED_KEYWORD, common.TRANSACTIONAL_KEYWORD:
 		return true
@@ -8649,57 +8649,57 @@ func (this *BallerinaParser) isRegularFuncQual(tokenKind common.SyntaxKind) bool
 	}
 }
 
-func (this *BallerinaParser) parseExplicitFunctionExpression(annots tree.STNode, qualifiers []tree.STNode, isRhsExpr bool) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_ANON_FUNC_EXPRESSION)
-	funcKeyword := this.parseFunctionKeyword()
-	nodes := this.createFuncTypeQualNodeList(qualifiers, funcKeyword, true)
+func (b *BallerinaParser) parseExplicitFunctionExpression(annots tree.STNode, qualifiers []tree.STNode, isRhsExpr bool) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_ANON_FUNC_EXPRESSION)
+	funcKeyword := b.parseFunctionKeyword()
+	nodes := b.createFuncTypeQualNodeList(qualifiers, funcKeyword, true)
 	qualifierList := nodes[0]
 	funcKeyword = nodes[1]
-	funcSignature := this.parseFuncSignature(false)
-	funcBody := this.parseAnonFuncBody(isRhsExpr)
+	funcSignature := b.parseFuncSignature(false)
+	funcBody := b.parseAnonFuncBody(isRhsExpr)
 	return tree.CreateExplicitAnonymousFunctionExpressionNode(annots, qualifierList, funcKeyword,
 		funcSignature, funcBody)
 }
 
-func (this *BallerinaParser) parseAnonFuncBody(isRhsExpr bool) tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseAnonFuncBody(isRhsExpr bool) tree.STNode {
+	switch b.peek().Kind() {
 	case common.OPEN_BRACE_TOKEN,
 		common.EOF_TOKEN:
-		body := this.parseFunctionBodyBlock(true)
-		this.endContext()
+		body := b.parseFunctionBodyBlock(true)
+		b.endContext()
 		return body
 	case common.RIGHT_DOUBLE_ARROW_TOKEN:
-		this.endContext()
-		return this.parseExpressionFuncBody(true, isRhsExpr)
+		b.endContext()
+		return b.parseExpressionFuncBody(true, isRhsExpr)
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_ANON_FUNC_BODY)
-		return this.parseAnonFuncBody(isRhsExpr)
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_ANON_FUNC_BODY)
+		return b.parseAnonFuncBody(isRhsExpr)
 	}
 }
 
-func (this *BallerinaParser) parseExpressionFuncBody(isAnon bool, isRhsExpr bool) tree.STNode {
-	rightDoubleArrow := this.parseDoubleRightArrow()
-	expression := this.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_REMOTE_CALL_ACTION, isRhsExpr, false)
+func (b *BallerinaParser) parseExpressionFuncBody(isAnon bool, isRhsExpr bool) tree.STNode {
+	rightDoubleArrow := b.parseDoubleRightArrow()
+	expression := b.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_REMOTE_CALL_ACTION, isRhsExpr, false)
 	var semiColon tree.STNode
 	if isAnon {
 		semiColon = tree.CreateEmptyNode()
 	} else {
-		semiColon = this.parseSemicolon()
+		semiColon = b.parseSemicolon()
 	}
 	return tree.CreateExpressionFunctionBodyNode(rightDoubleArrow, expression, semiColon)
 }
 
-func (this *BallerinaParser) parseDoubleRightArrow() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseDoubleRightArrow() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.RIGHT_DOUBLE_ARROW_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_EXPR_FUNC_BODY_START)
-		return this.parseDoubleRightArrow()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_EXPR_FUNC_BODY_START)
+		return b.parseDoubleRightArrow()
 	}
 }
 
-func (this *BallerinaParser) parseImplicitAnonFuncWithParams(params tree.STNode, isRhsExpr bool) tree.STNode {
+func (b *BallerinaParser) parseImplicitAnonFuncWithParams(params tree.STNode, isRhsExpr bool) tree.STNode {
 	switch params.Kind() {
 	case common.SIMPLE_NAME_REFERENCE, common.INFER_PARAM_LIST:
 		break
@@ -8708,7 +8708,7 @@ func (this *BallerinaParser) parseImplicitAnonFuncWithParams(params tree.STNode,
 		if !ok {
 			panic("parseImplicitAnonFunc: expected STBracedExpressionNode")
 		}
-		params = this.getAnonFuncParam(*bracedExpr)
+		params = b.getAnonFuncParam(*bracedExpr)
 	case common.NIL_LITERAL:
 		nilLiteralNode, ok := params.(*tree.STNilLiteralNode)
 		if !ok {
@@ -8723,12 +8723,12 @@ func (this *BallerinaParser) parseImplicitAnonFuncWithParams(params tree.STNode,
 			&common.ERROR_INVALID_PARAM_LIST_IN_INFER_ANONYMOUS_FUNCTION_EXPR)
 		params = tree.CreateSimpleNameReferenceNode(syntheticParam)
 	}
-	rightDoubleArrow := this.parseDoubleRightArrow()
-	expression := this.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_REMOTE_CALL_ACTION, isRhsExpr, false)
+	rightDoubleArrow := b.parseDoubleRightArrow()
+	expression := b.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_REMOTE_CALL_ACTION, isRhsExpr, false)
 	return tree.CreateImplicitAnonymousFunctionExpressionNode(params, rightDoubleArrow, expression)
 }
 
-func (this *BallerinaParser) getAnonFuncParam(bracedExpression tree.STBracedExpressionNode) tree.STNode {
+func (b *BallerinaParser) getAnonFuncParam(bracedExpression tree.STBracedExpressionNode) tree.STNode {
 	var paramList []tree.STNode
 	innerExpression := bracedExpression.Expression
 	openParen := bracedExpression.OpenParen
@@ -8742,43 +8742,43 @@ func (this *BallerinaParser) getAnonFuncParam(bracedExpression tree.STBracedExpr
 		tree.CreateNodeList(paramList...), bracedExpression.CloseParen)
 }
 
-func (this *BallerinaParser) parseImplicitAnonFuncWithOpenParenAndFirstParam(openParen tree.STNode, firstParam tree.STNode, isRhsExpr bool) tree.STNode {
+func (b *BallerinaParser) parseImplicitAnonFuncWithOpenParenAndFirstParam(openParen tree.STNode, firstParam tree.STNode, isRhsExpr bool) tree.STNode {
 	var paramList []tree.STNode
 	paramList = append(paramList, firstParam)
-	nextToken := this.peek()
+	nextToken := b.peek()
 	var paramEnd tree.STNode
 	var param tree.STNode
-	for !this.isEndOfAnonFuncParametersList(nextToken.Kind()) {
-		paramEnd = this.parseImplicitAnonFuncParamEnd()
+	for !b.isEndOfAnonFuncParametersList(nextToken.Kind()) {
+		paramEnd = b.parseImplicitAnonFuncParamEnd()
 		if paramEnd == nil {
 			break
 		}
 		paramList = append(paramList, paramEnd)
-		param = this.parseIdentifier(common.PARSER_RULE_CONTEXT_IMPLICIT_ANON_FUNC_PARAM)
+		param = b.parseIdentifier(common.PARSER_RULE_CONTEXT_IMPLICIT_ANON_FUNC_PARAM)
 		param = tree.CreateSimpleNameReferenceNode(param)
 		paramList = append(paramList, param)
-		nextToken = this.peek()
+		nextToken = b.peek()
 	}
 	params := tree.CreateNodeList(paramList...)
-	closeParen := this.parseCloseParenthesis()
-	this.endContext()
+	closeParen := b.parseCloseParenthesis()
+	b.endContext()
 	inferedParams := tree.CreateImplicitAnonymousFunctionParameters(openParen, params, closeParen)
-	return this.parseImplicitAnonFuncWithParams(inferedParams, isRhsExpr)
+	return b.parseImplicitAnonFuncWithParams(inferedParams, isRhsExpr)
 }
 
-func (this *BallerinaParser) parseImplicitAnonFuncParamEnd() tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseImplicitAnonFuncParamEnd() tree.STNode {
+	switch b.peek().Kind() {
 	case common.COMMA_TOKEN:
-		return this.parseComma()
+		return b.parseComma()
 	case common.CLOSE_PAREN_TOKEN:
 		return nil
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_ANON_FUNC_PARAM_RHS)
-		return this.parseImplicitAnonFuncParamEnd()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_ANON_FUNC_PARAM_RHS)
+		return b.parseImplicitAnonFuncParamEnd()
 	}
 }
 
-func (this *BallerinaParser) isEndOfAnonFuncParametersList(tokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isEndOfAnonFuncParametersList(tokenKind common.SyntaxKind) bool {
 	switch tokenKind {
 	case common.EOF_TOKEN,
 		common.CLOSE_BRACE_TOKEN,
@@ -8799,55 +8799,55 @@ func (this *BallerinaParser) isEndOfAnonFuncParametersList(tokenKind common.Synt
 	}
 }
 
-func (this *BallerinaParser) parseTupleTypeDesc() tree.STNode {
-	openBracket := this.parseOpenBracket()
-	this.startContext(common.PARSER_RULE_CONTEXT_TUPLE_MEMBERS)
-	memberTypeDesc := this.parseTupleMemberTypeDescList()
-	closeBracket := this.parseCloseBracket()
-	this.endContext()
-	openBracket = this.cloneWithDiagnosticIfListEmpty(memberTypeDesc, openBracket,
+func (b *BallerinaParser) parseTupleTypeDesc() tree.STNode {
+	openBracket := b.parseOpenBracket()
+	b.startContext(common.PARSER_RULE_CONTEXT_TUPLE_MEMBERS)
+	memberTypeDesc := b.parseTupleMemberTypeDescList()
+	closeBracket := b.parseCloseBracket()
+	b.endContext()
+	openBracket = b.cloneWithDiagnosticIfListEmpty(memberTypeDesc, openBracket,
 		&common.ERROR_MISSING_TYPE_DESC)
 	return tree.CreateTupleTypeDescriptorNode(openBracket, memberTypeDesc, closeBracket)
 }
 
-func (this *BallerinaParser) parseTupleMemberTypeDescList() tree.STNode {
+func (b *BallerinaParser) parseTupleMemberTypeDescList() tree.STNode {
 	var typeDescList []tree.STNode
-	nextToken := this.peek()
-	if this.isEndOfTypeList(nextToken.Kind()) {
+	nextToken := b.peek()
+	if b.isEndOfTypeList(nextToken.Kind()) {
 		return tree.CreateEmptyNodeList()
 	}
-	typeDesc := this.parseTupleMember()
-	res, _ := this.parseTupleTypeMembers(typeDesc, typeDescList)
+	typeDesc := b.parseTupleMember()
+	res, _ := b.parseTupleTypeMembers(typeDesc, typeDescList)
 	return res
 }
 
-func (this *BallerinaParser) parseTupleTypeMembers(firstMember tree.STNode, memberList []tree.STNode) (tree.STNode, []tree.STNode) {
+func (b *BallerinaParser) parseTupleTypeMembers(firstMember tree.STNode, memberList []tree.STNode) (tree.STNode, []tree.STNode) {
 	var tupleMemberRhs tree.STNode
-	for !this.isEndOfTypeList(this.peek().Kind()) {
+	for !b.isEndOfTypeList(b.peek().Kind()) {
 		if firstMember.Kind() == common.REST_TYPE {
-			firstMember = this.invalidateTypeDescAfterRestDesc(firstMember)
+			firstMember = b.invalidateTypeDescAfterRestDesc(firstMember)
 			break
 		}
-		tupleMemberRhs = this.parseTupleMemberRhs()
+		tupleMemberRhs = b.parseTupleMemberRhs()
 		if tupleMemberRhs == nil {
 			break
 		}
 		memberList = append(memberList, firstMember)
 		memberList = append(memberList, tupleMemberRhs)
-		firstMember = this.parseTupleMember()
+		firstMember = b.parseTupleMember()
 	}
 	memberList = append(memberList, firstMember)
 	return tree.CreateNodeList(memberList...), memberList
 }
 
-func (this *BallerinaParser) parseTupleMember() tree.STNode {
-	annot := this.parseOptionalAnnotations()
-	typeDesc := this.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE)
-	return this.createMemberOrRestNode(annot, typeDesc)
+func (b *BallerinaParser) parseTupleMember() tree.STNode {
+	annot := b.parseOptionalAnnotations()
+	typeDesc := b.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE)
+	return b.createMemberOrRestNode(annot, typeDesc)
 }
 
-func (this *BallerinaParser) createMemberOrRestNode(annot tree.STNode, typeDesc tree.STNode) tree.STNode {
-	tupleMemberRhs := this.parseTypeDescInTupleRhs()
+func (b *BallerinaParser) createMemberOrRestNode(annot tree.STNode, typeDesc tree.STNode) tree.STNode {
+	tupleMemberRhs := b.parseTypeDescInTupleRhs()
 	if tupleMemberRhs != nil {
 		annotList, ok := annot.(*tree.STNodeList)
 		if !ok {
@@ -8862,46 +8862,46 @@ func (this *BallerinaParser) createMemberOrRestNode(annot tree.STNode, typeDesc 
 	return tree.CreateMemberTypeDescriptorNode(annot, typeDesc)
 }
 
-func (this *BallerinaParser) invalidateTypeDescAfterRestDesc(restDescriptor tree.STNode) tree.STNode {
-	for !this.isEndOfTypeList(this.peek().Kind()) {
-		tupleMemberRhs := this.parseTupleMemberRhs()
+func (b *BallerinaParser) invalidateTypeDescAfterRestDesc(restDescriptor tree.STNode) tree.STNode {
+	for !b.isEndOfTypeList(b.peek().Kind()) {
+		tupleMemberRhs := b.parseTupleMemberRhs()
 		if tupleMemberRhs == nil {
 			break
 		}
 		restDescriptor = tree.CloneWithTrailingInvalidNodeMinutiae(restDescriptor, tupleMemberRhs, nil)
-		restDescriptor = tree.CloneWithTrailingInvalidNodeMinutiae(restDescriptor, this.parseTupleMember(),
+		restDescriptor = tree.CloneWithTrailingInvalidNodeMinutiae(restDescriptor, b.parseTupleMember(),
 			&common.ERROR_TYPE_DESC_AFTER_REST_DESCRIPTOR)
 	}
 	return restDescriptor
 }
 
-func (this *BallerinaParser) parseTupleMemberRhs() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseTupleMemberRhs() tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.COMMA_TOKEN:
-		return this.parseComma()
+		return b.parseComma()
 	case common.CLOSE_BRACKET_TOKEN:
 		return nil
 	default:
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_TUPLE_TYPE_MEMBER_RHS)
-		return this.parseTupleMemberRhs()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_TUPLE_TYPE_MEMBER_RHS)
+		return b.parseTupleMemberRhs()
 	}
 }
 
-func (this *BallerinaParser) parseTypeDescInTupleRhs() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseTypeDescInTupleRhs() tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.COMMA_TOKEN, common.CLOSE_BRACKET_TOKEN:
 		return nil
 	case common.ELLIPSIS_TOKEN:
-		return this.parseEllipsis()
+		return b.parseEllipsis()
 	default:
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE_RHS)
-		return this.parseTypeDescInTupleRhs()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE_RHS)
+		return b.parseTypeDescInTupleRhs()
 	}
 }
 
-func (this *BallerinaParser) isEndOfTypeList(nextTokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isEndOfTypeList(nextTokenKind common.SyntaxKind) bool {
 	switch nextTokenKind {
 	case common.CLOSE_BRACKET_TOKEN,
 		common.CLOSE_BRACE_TOKEN,
@@ -8915,81 +8915,81 @@ func (this *BallerinaParser) isEndOfTypeList(nextTokenKind common.SyntaxKind) bo
 	}
 }
 
-func (this *BallerinaParser) parseTableConstructorOrQuery(isRhsExpr bool, allowActions bool) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_TABLE_CONSTRUCTOR_OR_QUERY_EXPRESSION)
-	tableOrQueryExpr := this.parseTableConstructorOrQueryInner(isRhsExpr, allowActions)
-	this.endContext()
+func (b *BallerinaParser) parseTableConstructorOrQuery(isRhsExpr bool, allowActions bool) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_TABLE_CONSTRUCTOR_OR_QUERY_EXPRESSION)
+	tableOrQueryExpr := b.parseTableConstructorOrQueryInner(isRhsExpr, allowActions)
+	b.endContext()
 	return tableOrQueryExpr
 }
 
-func (this *BallerinaParser) parseTableConstructorOrQueryInner(isRhsExpr bool, allowActions bool) tree.STNode {
+func (b *BallerinaParser) parseTableConstructorOrQueryInner(isRhsExpr bool, allowActions bool) tree.STNode {
 	var queryConstructType tree.STNode
-	switch this.peek().Kind() {
+	switch b.peek().Kind() {
 	case common.FROM_KEYWORD:
 		queryConstructType = tree.CreateEmptyNode()
-		return this.parseQueryExprRhs(queryConstructType, isRhsExpr, allowActions)
+		return b.parseQueryExprRhs(queryConstructType, isRhsExpr, allowActions)
 	case common.TABLE_KEYWORD:
-		tableKeyword := this.parseTableKeyword()
-		return this.parseTableConstructorOrQueryWithKeyword(tableKeyword, isRhsExpr, allowActions)
+		tableKeyword := b.parseTableKeyword()
+		return b.parseTableConstructorOrQueryWithKeyword(tableKeyword, isRhsExpr, allowActions)
 	case common.STREAM_KEYWORD,
 		common.MAP_KEYWORD:
-		streamOrMapKeyword := this.consume()
+		streamOrMapKeyword := b.consume()
 		keySpecifier := tree.CreateEmptyNode()
-		queryConstructType = this.parseQueryConstructType(streamOrMapKeyword, keySpecifier)
-		return this.parseQueryExprRhs(queryConstructType, isRhsExpr, allowActions)
+		queryConstructType = b.parseQueryConstructType(streamOrMapKeyword, keySpecifier)
+		return b.parseQueryExprRhs(queryConstructType, isRhsExpr, allowActions)
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_TABLE_CONSTRUCTOR_OR_QUERY_START)
-		return this.parseTableConstructorOrQueryInner(isRhsExpr, allowActions)
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_TABLE_CONSTRUCTOR_OR_QUERY_START)
+		return b.parseTableConstructorOrQueryInner(isRhsExpr, allowActions)
 	}
 }
 
-func (this *BallerinaParser) parseTableConstructorOrQueryWithKeyword(tableKeyword tree.STNode, isRhsExpr bool, allowActions bool) tree.STNode {
+func (b *BallerinaParser) parseTableConstructorOrQueryWithKeyword(tableKeyword tree.STNode, isRhsExpr bool, allowActions bool) tree.STNode {
 	var keySpecifier tree.STNode
-	nextToken := this.peek()
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.OPEN_BRACKET_TOKEN:
 		keySpecifier = tree.CreateEmptyNode()
-		return this.parseTableConstructorExprRhs(tableKeyword, keySpecifier)
+		return b.parseTableConstructorExprRhs(tableKeyword, keySpecifier)
 	case common.KEY_KEYWORD:
-		keySpecifier = this.parseKeySpecifier()
-		return this.parseTableConstructorOrQueryRhs(tableKeyword, keySpecifier, isRhsExpr, allowActions)
+		keySpecifier = b.parseKeySpecifier()
+		return b.parseTableConstructorOrQueryRhs(tableKeyword, keySpecifier, isRhsExpr, allowActions)
 	case common.IDENTIFIER_TOKEN:
 		if isKeyKeyword(nextToken) {
-			keySpecifier = this.parseKeySpecifier()
-			return this.parseTableConstructorOrQueryRhs(tableKeyword, keySpecifier, isRhsExpr, allowActions)
+			keySpecifier = b.parseKeySpecifier()
+			return b.parseTableConstructorOrQueryRhs(tableKeyword, keySpecifier, isRhsExpr, allowActions)
 		}
 	default:
 		break
 	}
-	this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_TABLE_KEYWORD_RHS)
-	return this.parseTableConstructorOrQueryWithKeyword(tableKeyword, isRhsExpr, allowActions)
+	b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_TABLE_KEYWORD_RHS)
+	return b.parseTableConstructorOrQueryWithKeyword(tableKeyword, isRhsExpr, allowActions)
 }
 
-func (this *BallerinaParser) parseTableConstructorOrQueryRhs(tableKeyword tree.STNode, keySpecifier tree.STNode, isRhsExpr bool, allowActions bool) tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseTableConstructorOrQueryRhs(tableKeyword tree.STNode, keySpecifier tree.STNode, isRhsExpr bool, allowActions bool) tree.STNode {
+	switch b.peek().Kind() {
 	case common.FROM_KEYWORD:
-		return this.parseQueryExprRhs(this.parseQueryConstructType(tableKeyword, keySpecifier), isRhsExpr, allowActions)
+		return b.parseQueryExprRhs(b.parseQueryConstructType(tableKeyword, keySpecifier), isRhsExpr, allowActions)
 	case common.OPEN_BRACKET_TOKEN:
-		return this.parseTableConstructorExprRhs(tableKeyword, keySpecifier)
+		return b.parseTableConstructorExprRhs(tableKeyword, keySpecifier)
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_TABLE_CONSTRUCTOR_OR_QUERY_RHS)
-		return this.parseTableConstructorOrQueryRhs(tableKeyword, keySpecifier, isRhsExpr, allowActions)
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_TABLE_CONSTRUCTOR_OR_QUERY_RHS)
+		return b.parseTableConstructorOrQueryRhs(tableKeyword, keySpecifier, isRhsExpr, allowActions)
 	}
 }
 
-func (this *BallerinaParser) parseQueryConstructType(keyword tree.STNode, keySpecifier tree.STNode) tree.STNode {
+func (b *BallerinaParser) parseQueryConstructType(keyword tree.STNode, keySpecifier tree.STNode) tree.STNode {
 	return tree.CreateQueryConstructTypeNode(keyword, keySpecifier)
 }
 
-func (this *BallerinaParser) parseQueryExprRhs(queryConstructType tree.STNode, isRhsExpr bool, allowActions bool) tree.STNode {
-	this.switchContext(common.PARSER_RULE_CONTEXT_QUERY_EXPRESSION)
-	fromClause := this.parseFromClause(isRhsExpr, allowActions)
+func (b *BallerinaParser) parseQueryExprRhs(queryConstructType tree.STNode, isRhsExpr bool, allowActions bool) tree.STNode {
+	b.switchContext(common.PARSER_RULE_CONTEXT_QUERY_EXPRESSION)
+	fromClause := b.parseFromClause(isRhsExpr, allowActions)
 	var clauses []tree.STNode
 	var intermediateClause tree.STNode
 	var selectClause tree.STNode
 	var collectClause tree.STNode
-	for !this.isEndOfIntermediateClause(this.peek().Kind()) {
-		intermediateClause = this.parseIntermediateClause(isRhsExpr, allowActions)
+	for !b.isEndOfIntermediateClause(b.peek().Kind()) {
+		intermediateClause = b.parseIntermediateClause(isRhsExpr, allowActions)
 		if intermediateClause == nil {
 			break
 		}
@@ -9012,17 +9012,17 @@ func (this *BallerinaParser) parseQueryExprRhs(queryConstructType tree.STNode, i
 			clauses = append(clauses, intermediateClause)
 			continue
 		}
-		if this.isNestedQueryExpr() || (!this.isValidIntermediateQueryStart(this.peek())) {
+		if b.isNestedQueryExpr() || (!b.isValidIntermediateQueryStart(b.peek())) {
 			// Break the loop for,
 			// 1. nested query expressions as remaining clauses belong to the parent.
 			// 2. next token not being an intermediate-clause start as that token could belong to the parent node.
 			break
 		}
 	}
-	if (this.peek().Kind() == common.DO_KEYWORD) && ((!this.isNestedQueryExpr()) || ((selectClause == nil) && (collectClause == nil))) {
+	if (b.peek().Kind() == common.DO_KEYWORD) && ((!b.isNestedQueryExpr()) || ((selectClause == nil) && (collectClause == nil))) {
 		intermediateClauses := tree.CreateNodeList(clauses...)
 		queryPipeline := tree.CreateQueryPipelineNode(fromClause, intermediateClauses)
-		return this.parseQueryAction(queryConstructType, queryPipeline, selectClause, collectClause)
+		return b.parseQueryAction(queryConstructType, queryPipeline, selectClause, collectClause)
 	}
 	if (selectClause == nil) && (collectClause == nil) {
 		selectKeyword := tree.CreateMissingToken(common.SELECT_KEYWORD, nil)
@@ -9042,7 +9042,7 @@ func (this *BallerinaParser) parseQueryExprRhs(queryConstructType tree.STNode, i
 	}
 	intermediateClauses := tree.CreateNodeList(clauses...)
 	queryPipeline := tree.CreateQueryPipelineNode(fromClause, intermediateClauses)
-	onConflictClause := this.parseOnConflictClause(isRhsExpr)
+	onConflictClause := b.parseOnConflictClause(isRhsExpr)
 	var clause tree.STNode
 	if selectClause == nil {
 		clause = collectClause
@@ -9053,8 +9053,8 @@ func (this *BallerinaParser) parseQueryExprRhs(queryConstructType tree.STNode, i
 		clause, onConflictClause)
 }
 
-func (this *BallerinaParser) isNestedQueryExpr() bool {
-	contextStack := this.errorHandler.GetContextStack()
+func (b *BallerinaParser) isNestedQueryExpr() bool {
+	contextStack := b.errorHandler.GetContextStack()
 	count := 0
 	for _, ctx := range contextStack {
 		if ctx == common.PARSER_RULE_CONTEXT_QUERY_EXPRESSION {
@@ -9067,7 +9067,7 @@ func (this *BallerinaParser) isNestedQueryExpr() bool {
 	return false
 }
 
-func (this *BallerinaParser) isValidIntermediateQueryStart(token tree.STToken) bool {
+func (b *BallerinaParser) isValidIntermediateQueryStart(token tree.STToken) bool {
 	switch token.Kind() {
 	case common.FROM_KEYWORD,
 		common.WHERE_KEYWORD,
@@ -9088,25 +9088,25 @@ func (this *BallerinaParser) isValidIntermediateQueryStart(token tree.STToken) b
 	}
 }
 
-func (this *BallerinaParser) parseIntermediateClause(isRhsExpr bool, allowActions bool) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseIntermediateClause(isRhsExpr bool, allowActions bool) tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.FROM_KEYWORD:
-		return this.parseFromClause(isRhsExpr, allowActions)
+		return b.parseFromClause(isRhsExpr, allowActions)
 	case common.WHERE_KEYWORD:
-		return this.parseWhereClause(isRhsExpr)
+		return b.parseWhereClause(isRhsExpr)
 	case common.LET_KEYWORD:
-		return this.parseLetClause(isRhsExpr, allowActions)
+		return b.parseLetClause(isRhsExpr, allowActions)
 	case common.SELECT_KEYWORD:
-		return this.parseSelectClause(isRhsExpr, allowActions)
+		return b.parseSelectClause(isRhsExpr, allowActions)
 	case common.JOIN_KEYWORD, common.OUTER_KEYWORD:
-		return this.parseJoinClause(isRhsExpr)
+		return b.parseJoinClause(isRhsExpr)
 	case common.ORDER_KEYWORD,
 		common.ASCENDING_KEYWORD,
 		common.DESCENDING_KEYWORD:
-		return this.parseOrderByClause(isRhsExpr)
+		return b.parseOrderByClause(isRhsExpr)
 	case common.LIMIT_KEYWORD:
-		return this.parseLimitClause(isRhsExpr)
+		return b.parseLimitClause(isRhsExpr)
 	case common.DO_KEYWORD,
 		common.SEMICOLON_TOKEN,
 		common.ON_KEYWORD,
@@ -9114,62 +9114,62 @@ func (this *BallerinaParser) parseIntermediateClause(isRhsExpr bool, allowAction
 		return nil
 	default:
 		if isKeywordMatch(common.COLLECT_KEYWORD, nextToken) {
-			return this.parseCollectClause(isRhsExpr)
+			return b.parseCollectClause(isRhsExpr)
 		}
 		if isKeywordMatch(common.GROUP_KEYWORD, nextToken) {
-			return this.parseGroupByClause(isRhsExpr)
+			return b.parseGroupByClause(isRhsExpr)
 		}
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_QUERY_PIPELINE_RHS)
-		return this.parseIntermediateClause(isRhsExpr, allowActions)
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_QUERY_PIPELINE_RHS)
+		return b.parseIntermediateClause(isRhsExpr, allowActions)
 	}
 }
 
-func (this *BallerinaParser) parseCollectClause(isRhsExpr bool) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_COLLECT_CLAUSE)
-	collectKeyword := this.parseCollectKeyword()
-	expression := this.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_QUERY, isRhsExpr, false)
-	this.endContext()
+func (b *BallerinaParser) parseCollectClause(isRhsExpr bool) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_COLLECT_CLAUSE)
+	collectKeyword := b.parseCollectKeyword()
+	expression := b.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_QUERY, isRhsExpr, false)
+	b.endContext()
 	return tree.CreateCollectClauseNode(collectKeyword, expression)
 }
 
-func (this *BallerinaParser) parseCollectKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseCollectKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.COLLECT_KEYWORD {
-		return this.consume()
+		return b.consume()
 	}
 	if isKeywordMatch(common.COLLECT_KEYWORD, token) {
-		return this.getCollectKeyword(this.consume())
+		return b.getCollectKeyword(b.consume())
 	}
-	this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_COLLECT_KEYWORD)
-	return this.parseCollectKeyword()
+	b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_COLLECT_KEYWORD)
+	return b.parseCollectKeyword()
 }
 
-func (this *BallerinaParser) getCollectKeyword(token tree.STToken) tree.STNode {
+func (b *BallerinaParser) getCollectKeyword(token tree.STToken) tree.STNode {
 	return tree.CreateTokenWithDiagnostics(common.COLLECT_KEYWORD, token.LeadingMinutiae(), token.TrailingMinutiae(),
 		token.Diagnostics())
 }
 
-func (this *BallerinaParser) parseJoinKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseJoinKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.JOIN_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_JOIN_KEYWORD)
-		return this.parseJoinKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_JOIN_KEYWORD)
+		return b.parseJoinKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseEqualsKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseEqualsKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.EQUALS_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_EQUALS_KEYWORD)
-		return this.parseEqualsKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_EQUALS_KEYWORD)
+		return b.parseEqualsKeyword()
 	}
 }
 
-func (this *BallerinaParser) isEndOfIntermediateClause(tokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isEndOfIntermediateClause(tokenKind common.SyntaxKind) bool {
 	switch tokenKind {
 	case common.CLOSE_BRACE_TOKEN,
 		common.CLOSE_PAREN_TOKEN,
@@ -9193,180 +9193,180 @@ func (this *BallerinaParser) isEndOfIntermediateClause(tokenKind common.SyntaxKi
 		common.CONFLICT_KEYWORD:
 		return true
 	default:
-		return this.isValidExprRhsStart(tokenKind, common.NONE)
+		return b.isValidExprRhsStart(tokenKind, common.NONE)
 	}
 }
 
-func (this *BallerinaParser) parseFromClause(isRhsExpr bool, allowActions bool) tree.STNode {
-	fromKeyword := this.parseFromKeyword()
-	typedBindingPattern := this.parseTypedBindingPatternWithContext(common.PARSER_RULE_CONTEXT_FROM_CLAUSE)
-	inKeyword := this.parseInKeyword()
-	expression := this.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_QUERY, isRhsExpr, allowActions)
+func (b *BallerinaParser) parseFromClause(isRhsExpr bool, allowActions bool) tree.STNode {
+	fromKeyword := b.parseFromKeyword()
+	typedBindingPattern := b.parseTypedBindingPatternWithContext(common.PARSER_RULE_CONTEXT_FROM_CLAUSE)
+	inKeyword := b.parseInKeyword()
+	expression := b.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_QUERY, isRhsExpr, allowActions)
 	return tree.CreateFromClauseNode(fromKeyword, typedBindingPattern, inKeyword, expression)
 }
 
-func (this *BallerinaParser) parseFromKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseFromKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.FROM_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_FROM_KEYWORD)
-		return this.parseFromKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_FROM_KEYWORD)
+		return b.parseFromKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseWhereClause(isRhsExpr bool) tree.STNode {
-	whereKeyword := this.parseWhereKeyword()
-	expression := this.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_QUERY, isRhsExpr, false)
+func (b *BallerinaParser) parseWhereClause(isRhsExpr bool) tree.STNode {
+	whereKeyword := b.parseWhereKeyword()
+	expression := b.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_QUERY, isRhsExpr, false)
 	return tree.CreateWhereClauseNode(whereKeyword, expression)
 }
 
-func (this *BallerinaParser) parseWhereKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseWhereKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.WHERE_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_WHERE_KEYWORD)
-		return this.parseWhereKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_WHERE_KEYWORD)
+		return b.parseWhereKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseLimitKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseLimitKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.LIMIT_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_LIMIT_KEYWORD)
-		return this.parseLimitKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_LIMIT_KEYWORD)
+		return b.parseLimitKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseLetClause(isRhsExpr bool, allowActions bool) tree.STNode {
-	letKeyword := this.parseLetKeyword()
-	letVarDeclarations := this.parseLetVarDeclarations(common.PARSER_RULE_CONTEXT_LET_CLAUSE_LET_VAR_DECL, isRhsExpr,
+func (b *BallerinaParser) parseLetClause(isRhsExpr bool, allowActions bool) tree.STNode {
+	letKeyword := b.parseLetKeyword()
+	letVarDeclarations := b.parseLetVarDeclarations(common.PARSER_RULE_CONTEXT_LET_CLAUSE_LET_VAR_DECL, isRhsExpr,
 		allowActions)
-	letKeyword = this.cloneWithDiagnosticIfListEmpty(letVarDeclarations, letKeyword,
+	letKeyword = b.cloneWithDiagnosticIfListEmpty(letVarDeclarations, letKeyword,
 		&common.ERROR_MISSING_LET_VARIABLE_DECLARATION)
 	return tree.CreateLetClauseNode(letKeyword, letVarDeclarations)
 }
 
-func (this *BallerinaParser) parseGroupByClause(isRhsExpr bool) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_GROUP_BY_CLAUSE)
-	groupKeyword := this.parseGroupKeyword()
-	byKeyword := this.parseByKeyword()
-	groupingKeys := this.parseGroupingKeyList(isRhsExpr)
-	byKeyword = this.cloneWithDiagnosticIfListEmpty(groupingKeys, byKeyword,
+func (b *BallerinaParser) parseGroupByClause(isRhsExpr bool) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_GROUP_BY_CLAUSE)
+	groupKeyword := b.parseGroupKeyword()
+	byKeyword := b.parseByKeyword()
+	groupingKeys := b.parseGroupingKeyList(isRhsExpr)
+	byKeyword = b.cloneWithDiagnosticIfListEmpty(groupingKeys, byKeyword,
 		&common.ERROR_MISSING_GROUPING_KEY)
-	this.endContext()
+	b.endContext()
 	return tree.CreateGroupByClauseNode(groupKeyword, byKeyword, groupingKeys)
 }
 
-func (this *BallerinaParser) parseGroupKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseGroupKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.GROUP_KEYWORD {
-		return this.consume()
+		return b.consume()
 	}
 	if isKeywordMatch(common.GROUP_KEYWORD, token) {
-		return this.getGroupKeyword(this.consume())
+		return b.getGroupKeyword(b.consume())
 	}
-	this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_GROUP_KEYWORD)
-	return this.parseGroupKeyword()
+	b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_GROUP_KEYWORD)
+	return b.parseGroupKeyword()
 }
 
-func (this *BallerinaParser) getGroupKeyword(token tree.STToken) tree.STNode {
+func (b *BallerinaParser) getGroupKeyword(token tree.STToken) tree.STNode {
 	return tree.CreateTokenWithDiagnostics(common.GROUP_KEYWORD, token.LeadingMinutiae(), token.TrailingMinutiae(),
 		token.Diagnostics())
 }
 
-func (this *BallerinaParser) parseOrderKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseOrderKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.ORDER_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_ORDER_KEYWORD)
-		return this.parseOrderKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_ORDER_KEYWORD)
+		return b.parseOrderKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseByKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseByKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.BY_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_BY_KEYWORD)
-		return this.parseByKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_BY_KEYWORD)
+		return b.parseByKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseOrderByClause(isRhsExpr bool) tree.STNode {
-	orderKeyword := this.parseOrderKeyword()
-	byKeyword := this.parseByKeyword()
-	orderKeys := this.parseOrderKeyList(isRhsExpr)
-	byKeyword = this.cloneWithDiagnosticIfListEmpty(orderKeys, byKeyword, &common.ERROR_MISSING_ORDER_KEY)
+func (b *BallerinaParser) parseOrderByClause(isRhsExpr bool) tree.STNode {
+	orderKeyword := b.parseOrderKeyword()
+	byKeyword := b.parseByKeyword()
+	orderKeys := b.parseOrderKeyList(isRhsExpr)
+	byKeyword = b.cloneWithDiagnosticIfListEmpty(orderKeys, byKeyword, &common.ERROR_MISSING_ORDER_KEY)
 	return tree.CreateOrderByClauseNode(orderKeyword, byKeyword, orderKeys)
 }
 
-func (this *BallerinaParser) parseGroupingKeyList(isRhsExpr bool) tree.STNode {
+func (b *BallerinaParser) parseGroupingKeyList(isRhsExpr bool) tree.STNode {
 	var groupingKeys []tree.STNode
-	nextToken := this.peek()
-	if this.isEndOfGroupByKeyListElement(nextToken) {
+	nextToken := b.peek()
+	if b.isEndOfGroupByKeyListElement(nextToken) {
 		return tree.CreateEmptyNodeList()
 	}
-	groupingKey := this.parseGroupingKey(isRhsExpr)
+	groupingKey := b.parseGroupingKey(isRhsExpr)
 	groupingKeys = append(groupingKeys, groupingKey)
-	nextToken = this.peek()
+	nextToken = b.peek()
 	var groupingKeyListMemberEnd tree.STNode
-	for !this.isEndOfGroupByKeyListElement(nextToken) {
-		groupingKeyListMemberEnd = this.parseGroupingKeyListMemberEnd()
+	for !b.isEndOfGroupByKeyListElement(nextToken) {
+		groupingKeyListMemberEnd = b.parseGroupingKeyListMemberEnd()
 		if groupingKeyListMemberEnd == nil {
 			break
 		}
 		groupingKeys = append(groupingKeys, groupingKeyListMemberEnd)
-		groupingKey = this.parseGroupingKey(isRhsExpr)
+		groupingKey = b.parseGroupingKey(isRhsExpr)
 		groupingKeys = append(groupingKeys, groupingKey)
-		nextToken = this.peek()
+		nextToken = b.peek()
 	}
 	return tree.CreateNodeList(groupingKeys...)
 }
 
-func (this *BallerinaParser) parseOrderKeyList(isRhsExpr bool) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_ORDER_KEY_LIST)
+func (b *BallerinaParser) parseOrderKeyList(isRhsExpr bool) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_ORDER_KEY_LIST)
 	var orderKeys []tree.STNode
-	nextToken := this.peek()
-	if this.isEndOfOrderKeys(nextToken) {
-		this.endContext()
+	nextToken := b.peek()
+	if b.isEndOfOrderKeys(nextToken) {
+		b.endContext()
 		return tree.CreateEmptyNodeList()
 	}
-	orderKey := this.parseOrderKey(isRhsExpr)
+	orderKey := b.parseOrderKey(isRhsExpr)
 	orderKeys = append(orderKeys, orderKey)
-	nextToken = this.peek()
+	nextToken = b.peek()
 	var orderKeyListMemberEnd tree.STNode
-	for !this.isEndOfOrderKeys(nextToken) {
-		orderKeyListMemberEnd = this.parseOrderKeyListMemberEnd()
+	for !b.isEndOfOrderKeys(nextToken) {
+		orderKeyListMemberEnd = b.parseOrderKeyListMemberEnd()
 		if orderKeyListMemberEnd == nil {
 			break
 		}
 		orderKeys = append(orderKeys, orderKeyListMemberEnd)
-		orderKey = this.parseOrderKey(isRhsExpr)
+		orderKey = b.parseOrderKey(isRhsExpr)
 		orderKeys = append(orderKeys, orderKey)
-		nextToken = this.peek()
+		nextToken = b.peek()
 	}
-	this.endContext()
+	b.endContext()
 	return tree.CreateNodeList(orderKeys...)
 }
 
-func (this *BallerinaParser) isEndOfGroupByKeyListElement(nextToken tree.STToken) bool {
+func (b *BallerinaParser) isEndOfGroupByKeyListElement(nextToken tree.STToken) bool {
 	switch nextToken.Kind() {
 	case common.COMMA_TOKEN:
 		return false
 	case common.EOF_TOKEN:
 		return true
 	default:
-		return this.isQueryClauseStartToken(nextToken)
+		return b.isQueryClauseStartToken(nextToken)
 	}
 }
 
-func (this *BallerinaParser) isEndOfOrderKeys(nextToken tree.STToken) bool {
+func (b *BallerinaParser) isEndOfOrderKeys(nextToken tree.STToken) bool {
 	switch nextToken.Kind() {
 	case common.COMMA_TOKEN,
 		common.ASCENDING_KEYWORD,
@@ -9375,11 +9375,11 @@ func (this *BallerinaParser) isEndOfOrderKeys(nextToken tree.STToken) bool {
 	case common.SEMICOLON_TOKEN, common.EOF_TOKEN:
 		return true
 	default:
-		return this.isQueryClauseStartToken(nextToken)
+		return b.isQueryClauseStartToken(nextToken)
 	}
 }
 
-func (this *BallerinaParser) isQueryClauseStartToken(nextToken tree.STToken) bool {
+func (b *BallerinaParser) isQueryClauseStartToken(nextToken tree.STToken) bool {
 	switch nextToken.Kind() {
 	case common.SELECT_KEYWORD,
 		common.LET_KEYWORD,
@@ -9398,160 +9398,160 @@ func (this *BallerinaParser) isQueryClauseStartToken(nextToken tree.STToken) boo
 	}
 }
 
-func (this *BallerinaParser) parseGroupingKeyListMemberEnd() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseGroupingKeyListMemberEnd() tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.COMMA_TOKEN:
-		return this.consume()
+		return b.consume()
 	case common.EOF_TOKEN:
 		return nil
 	default:
-		if this.isQueryClauseStartToken(nextToken) {
+		if b.isQueryClauseStartToken(nextToken) {
 			return nil
 		}
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_GROUPING_KEY_LIST_ELEMENT_END)
-		return this.parseGroupingKeyListMemberEnd()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_GROUPING_KEY_LIST_ELEMENT_END)
+		return b.parseGroupingKeyListMemberEnd()
 	}
 }
 
-func (this *BallerinaParser) parseOrderKeyListMemberEnd() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseOrderKeyListMemberEnd() tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.COMMA_TOKEN:
-		return this.parseComma()
+		return b.parseComma()
 	case common.EOF_TOKEN:
 		return nil
 	default:
-		if this.isQueryClauseStartToken(nextToken) {
+		if b.isQueryClauseStartToken(nextToken) {
 			return nil
 		}
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_ORDER_KEY_LIST_END)
-		return this.parseOrderKeyListMemberEnd()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_ORDER_KEY_LIST_END)
+		return b.parseOrderKeyListMemberEnd()
 	}
 }
 
-func (this *BallerinaParser) parseGroupingKeyVariableDeclaration(isRhsExpr bool) tree.STNode {
-	groupingKeyElementTypeDesc := this.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_BEFORE_IDENTIFIER_IN_GROUPING_KEY)
-	this.startContext(common.PARSER_RULE_CONTEXT_BINDING_PATTERN_STARTING_IDENTIFIER)
-	groupingKeySimpleBP := this.createCaptureOrWildcardBP(this.parseVariableName())
-	this.endContext()
-	equalsToken := this.parseAssignOp()
-	groupingKeyExpression := this.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_QUERY, isRhsExpr, false)
+func (b *BallerinaParser) parseGroupingKeyVariableDeclaration(isRhsExpr bool) tree.STNode {
+	groupingKeyElementTypeDesc := b.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_BEFORE_IDENTIFIER_IN_GROUPING_KEY)
+	b.startContext(common.PARSER_RULE_CONTEXT_BINDING_PATTERN_STARTING_IDENTIFIER)
+	groupingKeySimpleBP := b.createCaptureOrWildcardBP(b.parseVariableName())
+	b.endContext()
+	equalsToken := b.parseAssignOp()
+	groupingKeyExpression := b.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_QUERY, isRhsExpr, false)
 	return tree.CreateGroupingKeyVarDeclarationNode(groupingKeyElementTypeDesc, groupingKeySimpleBP,
 		equalsToken, groupingKeyExpression)
 }
 
-func (this *BallerinaParser) parseGroupingKey(isRhsExpr bool) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseGroupingKey(isRhsExpr bool) tree.STNode {
+	nextToken := b.peek()
 	nextTokenKind := nextToken.Kind()
-	if (nextTokenKind == common.IDENTIFIER_TOKEN) && (!this.isPossibleGroupingKeyVarDeclaration()) {
-		return tree.CreateSimpleNameReferenceNode(this.parseVariableName())
+	if (nextTokenKind == common.IDENTIFIER_TOKEN) && (!b.isPossibleGroupingKeyVarDeclaration()) {
+		return tree.CreateSimpleNameReferenceNode(b.parseVariableName())
 	} else if isTypeStartingToken(nextTokenKind, nextToken) {
-		return this.parseGroupingKeyVariableDeclaration(isRhsExpr)
+		return b.parseGroupingKeyVariableDeclaration(isRhsExpr)
 	}
-	this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_GROUPING_KEY_LIST_ELEMENT)
-	return this.parseGroupingKey(isRhsExpr)
+	b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_GROUPING_KEY_LIST_ELEMENT)
+	return b.parseGroupingKey(isRhsExpr)
 }
 
-func (this *BallerinaParser) isPossibleGroupingKeyVarDeclaration() bool {
-	nextNextTokenKind := this.getNextNextToken().Kind()
-	return ((nextNextTokenKind == common.EQUAL_TOKEN) || ((nextNextTokenKind == common.IDENTIFIER_TOKEN) && (this.peekN(3).Kind() == common.EQUAL_TOKEN)))
+func (b *BallerinaParser) isPossibleGroupingKeyVarDeclaration() bool {
+	nextNextTokenKind := b.getNextNextToken().Kind()
+	return ((nextNextTokenKind == common.EQUAL_TOKEN) || ((nextNextTokenKind == common.IDENTIFIER_TOKEN) && (b.peekN(3).Kind() == common.EQUAL_TOKEN)))
 }
 
-func (this *BallerinaParser) parseOrderKey(isRhsExpr bool) tree.STNode {
-	expression := this.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_QUERY, isRhsExpr, false)
+func (b *BallerinaParser) parseOrderKey(isRhsExpr bool) tree.STNode {
+	expression := b.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_QUERY, isRhsExpr, false)
 	var orderDirection tree.STNode
-	nextToken := this.peek()
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.ASCENDING_KEYWORD, common.DESCENDING_KEYWORD:
-		orderDirection = this.consume()
+		orderDirection = b.consume()
 	default:
 		orderDirection = tree.CreateEmptyNode()
 	}
 	return tree.CreateOrderKeyNode(expression, orderDirection)
 }
 
-func (this *BallerinaParser) parseSelectClause(isRhsExpr bool, allowActions bool) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_SELECT_CLAUSE)
-	selectKeyword := this.parseSelectKeyword()
-	expression := this.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_QUERY, isRhsExpr, allowActions)
-	this.endContext()
+func (b *BallerinaParser) parseSelectClause(isRhsExpr bool, allowActions bool) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_SELECT_CLAUSE)
+	selectKeyword := b.parseSelectKeyword()
+	expression := b.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_QUERY, isRhsExpr, allowActions)
+	b.endContext()
 	return tree.CreateSelectClauseNode(selectKeyword, expression)
 }
 
-func (this *BallerinaParser) parseSelectKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseSelectKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.SELECT_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_SELECT_KEYWORD)
-		return this.parseSelectKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_SELECT_KEYWORD)
+		return b.parseSelectKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseOnConflictClause(isRhsExpr bool) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseOnConflictClause(isRhsExpr bool) tree.STNode {
+	nextToken := b.peek()
 	if (nextToken.Kind() != common.ON_KEYWORD) && (nextToken.Kind() != common.CONFLICT_KEYWORD) {
 		return tree.CreateEmptyNode()
 	}
-	this.startContext(common.PARSER_RULE_CONTEXT_ON_CONFLICT_CLAUSE)
-	onKeyword := this.parseOnKeyword()
-	conflictKeyword := this.parseConflictKeyword()
-	this.endContext()
-	expr := this.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_QUERY, isRhsExpr, false)
+	b.startContext(common.PARSER_RULE_CONTEXT_ON_CONFLICT_CLAUSE)
+	onKeyword := b.parseOnKeyword()
+	conflictKeyword := b.parseConflictKeyword()
+	b.endContext()
+	expr := b.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_QUERY, isRhsExpr, false)
 	return tree.CreateOnConflictClauseNode(onKeyword, conflictKeyword, expr)
 }
 
-func (this *BallerinaParser) parseConflictKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseConflictKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.CONFLICT_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_CONFLICT_KEYWORD)
-		return this.parseConflictKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_CONFLICT_KEYWORD)
+		return b.parseConflictKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseLimitClause(isRhsExpr bool) tree.STNode {
-	limitKeyword := this.parseLimitKeyword()
-	expr := this.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_QUERY, isRhsExpr, false)
+func (b *BallerinaParser) parseLimitClause(isRhsExpr bool) tree.STNode {
+	limitKeyword := b.parseLimitKeyword()
+	expr := b.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_QUERY, isRhsExpr, false)
 	return tree.CreateLimitClauseNode(limitKeyword, expr)
 }
 
-func (this *BallerinaParser) parseJoinClause(isRhsExpr bool) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_JOIN_CLAUSE)
+func (b *BallerinaParser) parseJoinClause(isRhsExpr bool) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_JOIN_CLAUSE)
 	var outerKeyword tree.STNode
-	nextToken := this.peek()
+	nextToken := b.peek()
 	if nextToken.Kind() == common.OUTER_KEYWORD {
-		outerKeyword = this.consume()
+		outerKeyword = b.consume()
 	} else {
 		outerKeyword = tree.CreateEmptyNode()
 	}
-	joinKeyword := this.parseJoinKeyword()
-	typedBindingPattern := this.parseTypedBindingPatternWithContext(common.PARSER_RULE_CONTEXT_JOIN_CLAUSE)
-	inKeyword := this.parseInKeyword()
-	expression := this.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_QUERY, isRhsExpr, false)
-	this.endContext()
-	onCondition := this.parseOnClause(isRhsExpr)
+	joinKeyword := b.parseJoinKeyword()
+	typedBindingPattern := b.parseTypedBindingPatternWithContext(common.PARSER_RULE_CONTEXT_JOIN_CLAUSE)
+	inKeyword := b.parseInKeyword()
+	expression := b.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_QUERY, isRhsExpr, false)
+	b.endContext()
+	onCondition := b.parseOnClause(isRhsExpr)
 	return tree.CreateJoinClauseNode(outerKeyword, joinKeyword, typedBindingPattern, inKeyword, expression,
 		onCondition)
 }
 
-func (this *BallerinaParser) parseOnClause(isRhsExpr bool) tree.STNode {
-	nextToken := this.peek()
-	if this.isQueryClauseStartToken(nextToken) {
-		return this.createMissingOnClauseNode()
+func (b *BallerinaParser) parseOnClause(isRhsExpr bool) tree.STNode {
+	nextToken := b.peek()
+	if b.isQueryClauseStartToken(nextToken) {
+		return b.createMissingOnClauseNode()
 	}
-	this.startContext(common.PARSER_RULE_CONTEXT_ON_CLAUSE)
-	onKeyword := this.parseOnKeyword()
-	lhsExpression := this.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_QUERY, isRhsExpr, false)
-	equalsKeyword := this.parseEqualsKeyword()
-	this.endContext()
-	rhsExpression := this.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_QUERY, isRhsExpr, false)
+	b.startContext(common.PARSER_RULE_CONTEXT_ON_CLAUSE)
+	onKeyword := b.parseOnKeyword()
+	lhsExpression := b.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_QUERY, isRhsExpr, false)
+	equalsKeyword := b.parseEqualsKeyword()
+	b.endContext()
+	rhsExpression := b.parseExpressionWithPrecedence(OPERATOR_PRECEDENCE_QUERY, isRhsExpr, false)
 	return tree.CreateOnClauseNode(onKeyword, lhsExpression, equalsKeyword, rhsExpression)
 }
 
-func (this *BallerinaParser) createMissingOnClauseNode() tree.STNode {
+func (b *BallerinaParser) createMissingOnClauseNode() tree.STNode {
 	onKeyword := tree.CreateMissingTokenWithDiagnostics(common.ON_KEYWORD,
 		&common.ERROR_MISSING_ON_KEYWORD)
 	identifier := tree.CreateMissingTokenWithDiagnostics(common.IDENTIFIER_TOKEN,
@@ -9563,9 +9563,9 @@ func (this *BallerinaParser) createMissingOnClauseNode() tree.STNode {
 	return tree.CreateOnClauseNode(onKeyword, lhsExpression, equalsKeyword, rhsExpression)
 }
 
-func (this *BallerinaParser) parseStartAction(annots tree.STNode) tree.STNode {
-	startKeyword := this.parseStartKeyword()
-	expr := this.parseActionOrExpression()
+func (b *BallerinaParser) parseStartAction(annots tree.STNode) tree.STNode {
+	startKeyword := b.parseStartKeyword()
+	expr := b.parseActionOrExpression()
 	switch expr.Kind() {
 	case common.FUNCTION_CALL,
 		common.METHOD_CALL,
@@ -9575,7 +9575,7 @@ func (this *BallerinaParser) parseStartAction(annots tree.STNode) tree.STNode {
 		common.QUALIFIED_NAME_REFERENCE,
 		common.FIELD_ACCESS,
 		common.ASYNC_SEND_ACTION:
-		expr = this.generateValidExprForStartAction(expr)
+		expr = b.generateValidExprForStartAction(expr)
 	default:
 		startKeyword = tree.CloneWithTrailingInvalidNodeMinutiae(startKeyword, expr,
 			&common.ERROR_INVALID_EXPRESSION_IN_START_ACTION)
@@ -9587,10 +9587,10 @@ func (this *BallerinaParser) parseStartAction(annots tree.STNode) tree.STNode {
 		expr = tree.CreateFunctionCallExpressionNode(funcName, openParenToken,
 			tree.CreateEmptyNodeList(), closeParenToken)
 	}
-	return tree.CreateStartActionNode(this.getAnnotations(annots), startKeyword, expr)
+	return tree.CreateStartActionNode(b.getAnnotations(annots), startKeyword, expr)
 }
 
-func (this *BallerinaParser) generateValidExprForStartAction(expr tree.STNode) tree.STNode {
+func (b *BallerinaParser) generateValidExprForStartAction(expr tree.STNode) tree.STNode {
 	openParenToken := tree.CreateMissingTokenWithDiagnostics(common.OPEN_PAREN_TOKEN,
 		&common.ERROR_MISSING_OPEN_PAREN_TOKEN)
 	arguments := tree.CreateEmptyNodeList()
@@ -9618,79 +9618,79 @@ func (this *BallerinaParser) generateValidExprForStartAction(expr tree.STNode) t
 	}
 }
 
-func (this *BallerinaParser) parseStartKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseStartKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.START_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_START_KEYWORD)
-		return this.parseStartKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_START_KEYWORD)
+		return b.parseStartKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseFlushAction() tree.STNode {
-	flushKeyword := this.parseFlushKeyword()
-	peerWorker := this.parseOptionalPeerWorkerName()
+func (b *BallerinaParser) parseFlushAction() tree.STNode {
+	flushKeyword := b.parseFlushKeyword()
+	peerWorker := b.parseOptionalPeerWorkerName()
 	return tree.CreateFlushActionNode(flushKeyword, peerWorker)
 }
 
-func (this *BallerinaParser) parseFlushKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseFlushKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.FLUSH_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_FLUSH_KEYWORD)
-		return this.parseFlushKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_FLUSH_KEYWORD)
+		return b.parseFlushKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseOptionalPeerWorkerName() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseOptionalPeerWorkerName() tree.STNode {
+	token := b.peek()
 	switch token.Kind() {
 	case common.IDENTIFIER_TOKEN, common.FUNCTION_KEYWORD:
-		return tree.CreateSimpleNameReferenceNode(this.consume())
+		return tree.CreateSimpleNameReferenceNode(b.consume())
 	default:
 		return tree.CreateEmptyNode()
 	}
 }
 
-func (this *BallerinaParser) parseIntersectionTypeDescriptor(leftTypeDesc tree.STNode, context common.ParserRuleContext, isTypedBindingPattern bool) tree.STNode {
-	bitwiseAndToken := this.consume()
-	rightTypeDesc := this.parseTypeDescriptorInternalWithPrecedence(nil, context, isTypedBindingPattern, false,
+func (b *BallerinaParser) parseIntersectionTypeDescriptor(leftTypeDesc tree.STNode, context common.ParserRuleContext, isTypedBindingPattern bool) tree.STNode {
+	bitwiseAndToken := b.consume()
+	rightTypeDesc := b.parseTypeDescriptorInternalWithPrecedence(nil, context, isTypedBindingPattern, false,
 		TYPE_PRECEDENCE_INTERSECTION)
-	return this.mergeTypesWithIntersection(leftTypeDesc, bitwiseAndToken, rightTypeDesc)
+	return b.mergeTypesWithIntersection(leftTypeDesc, bitwiseAndToken, rightTypeDesc)
 }
 
-func (this *BallerinaParser) createIntersectionTypeDesc(leftTypeDesc tree.STNode, bitwiseAndToken tree.STNode, rightTypeDesc tree.STNode) tree.STNode {
-	leftTypeDesc = this.validateForUsageOfVar(leftTypeDesc)
-	rightTypeDesc = this.validateForUsageOfVar(rightTypeDesc)
+func (b *BallerinaParser) createIntersectionTypeDesc(leftTypeDesc tree.STNode, bitwiseAndToken tree.STNode, rightTypeDesc tree.STNode) tree.STNode {
+	leftTypeDesc = b.validateForUsageOfVar(leftTypeDesc)
+	rightTypeDesc = b.validateForUsageOfVar(rightTypeDesc)
 	return tree.CreateIntersectionTypeDescriptorNode(leftTypeDesc, bitwiseAndToken, rightTypeDesc)
 }
 
-func (this *BallerinaParser) parseSingletonTypeDesc() tree.STNode {
-	simpleContExpr := this.parseSimpleConstExpr()
+func (b *BallerinaParser) parseSingletonTypeDesc() tree.STNode {
+	simpleContExpr := b.parseSimpleConstExpr()
 	return tree.CreateSingletonTypeDescriptorNode(simpleContExpr)
 }
 
-func (this *BallerinaParser) parseSignedIntOrFloat() tree.STNode {
-	operator := this.parseUnaryOperator()
+func (b *BallerinaParser) parseSignedIntOrFloat() tree.STNode {
+	operator := b.parseUnaryOperator()
 	var literal tree.STNode
-	nextToken := this.peek()
+	nextToken := b.peek()
 
 	switch nextToken.Kind() {
 
 	case common.HEX_INTEGER_LITERAL_TOKEN,
 		common.DECIMAL_FLOATING_POINT_LITERAL_TOKEN,
 		common.HEX_FLOATING_POINT_LITERAL_TOKEN:
-		literal = this.parseBasicLiteral()
+		literal = b.parseBasicLiteral()
 	default:
 		literal = tree.CreateBasicLiteralNode(common.NUMERIC_LITERAL,
-			this.parseDecimalIntLiteral(common.PARSER_RULE_CONTEXT_DECIMAL_INTEGER_LITERAL_TOKEN))
+			b.parseDecimalIntLiteral(common.PARSER_RULE_CONTEXT_DECIMAL_INTEGER_LITERAL_TOKEN))
 	}
 	return tree.CreateUnaryExpressionNode(operator, literal)
 }
 
-func (this *BallerinaParser) isValidExpressionStart(nextTokenKind common.SyntaxKind, nextTokenIndex int) bool {
+func (b *BallerinaParser) isValidExpressionStart(nextTokenKind common.SyntaxKind, nextTokenIndex int) bool {
 	nextTokenIndex++
 	switch nextTokenKind {
 	case common.DECIMAL_INTEGER_LITERAL_TOKEN,
@@ -9701,14 +9701,14 @@ func (this *BallerinaParser) isValidExpressionStart(nextTokenKind common.SyntaxK
 		common.FALSE_KEYWORD,
 		common.DECIMAL_FLOATING_POINT_LITERAL_TOKEN,
 		common.HEX_FLOATING_POINT_LITERAL_TOKEN:
-		nextNextTokenKind := this.peekN(nextTokenIndex).Kind()
+		nextNextTokenKind := b.peekN(nextTokenIndex).Kind()
 		if (nextNextTokenKind == common.PIPE_TOKEN) || (nextNextTokenKind == common.BITWISE_AND_TOKEN) {
 			nextTokenIndex++
-			return this.isValidExpressionStart(this.peekN(nextTokenIndex).Kind(), nextTokenIndex)
+			return b.isValidExpressionStart(b.peekN(nextTokenIndex).Kind(), nextTokenIndex)
 		}
-		return ((((nextNextTokenKind == common.SEMICOLON_TOKEN) || (nextNextTokenKind == common.COMMA_TOKEN)) || (nextNextTokenKind == common.CLOSE_BRACKET_TOKEN)) || this.isValidExprRhsStart(nextNextTokenKind, common.SIMPLE_NAME_REFERENCE))
+		return ((((nextNextTokenKind == common.SEMICOLON_TOKEN) || (nextNextTokenKind == common.COMMA_TOKEN)) || (nextNextTokenKind == common.CLOSE_BRACKET_TOKEN)) || b.isValidExprRhsStart(nextNextTokenKind, common.SIMPLE_NAME_REFERENCE))
 	case common.IDENTIFIER_TOKEN:
-		return this.isValidExprRhsStart(this.peekN(nextTokenIndex).Kind(), common.SIMPLE_NAME_REFERENCE)
+		return b.isValidExprRhsStart(b.peekN(nextTokenIndex).Kind(), common.SIMPLE_NAME_REFERENCE)
 	case common.OPEN_PAREN_TOKEN, common.CHECK_KEYWORD, common.CHECKPANIC_KEYWORD, common.OPEN_BRACE_TOKEN,
 		common.TYPEOF_KEYWORD, common.NEGATION_TOKEN, common.EXCLAMATION_MARK_TOKEN, common.TRAP_KEYWORD,
 		common.OPEN_BRACKET_TOKEN, common.LT_TOKEN, common.FROM_KEYWORD, common.LET_KEYWORD,
@@ -9717,16 +9717,16 @@ func (this *BallerinaParser) isValidExpressionStart(nextTokenKind common.SyntaxK
 		common.NATURAL_KEYWORD:
 		return true
 	case common.PLUS_TOKEN, common.MINUS_TOKEN:
-		return this.isValidExpressionStart(this.peekN(nextTokenIndex).Kind(), nextTokenIndex)
+		return b.isValidExpressionStart(b.peekN(nextTokenIndex).Kind(), nextTokenIndex)
 	case common.TABLE_KEYWORD, common.MAP_KEYWORD:
-		return (this.peekN(nextTokenIndex).Kind() == common.FROM_KEYWORD)
+		return (b.peekN(nextTokenIndex).Kind() == common.FROM_KEYWORD)
 	case common.STREAM_KEYWORD:
-		nextNextToken := this.peekN(nextTokenIndex)
+		nextNextToken := b.peekN(nextTokenIndex)
 		return (((nextNextToken.Kind() == common.KEY_KEYWORD) || (nextNextToken.Kind() == common.OPEN_BRACKET_TOKEN)) || (nextNextToken.Kind() == common.FROM_KEYWORD))
 	case common.ERROR_KEYWORD:
-		return (this.peekN(nextTokenIndex).Kind() == common.OPEN_PAREN_TOKEN)
+		return (b.peekN(nextTokenIndex).Kind() == common.OPEN_PAREN_TOKEN)
 	case common.XML_KEYWORD, common.STRING_KEYWORD, common.RE_KEYWORD:
-		return (this.peekN(nextTokenIndex).Kind() == common.BACKTICK_TOKEN)
+		return (b.peekN(nextTokenIndex).Kind() == common.BACKTICK_TOKEN)
 	case common.START_KEYWORD,
 		common.FLUSH_KEYWORD,
 		common.WAIT_KEYWORD:
@@ -9736,107 +9736,107 @@ func (this *BallerinaParser) isValidExpressionStart(nextTokenKind common.SyntaxK
 	}
 }
 
-func (this *BallerinaParser) parseSyncSendAction(expression tree.STNode) tree.STNode {
-	syncSendToken := this.parseSyncSendToken()
-	peerWorker := this.parsePeerWorkerName()
+func (b *BallerinaParser) parseSyncSendAction(expression tree.STNode) tree.STNode {
+	syncSendToken := b.parseSyncSendToken()
+	peerWorker := b.parsePeerWorkerName()
 	return tree.CreateSyncSendActionNode(expression, syncSendToken, peerWorker)
 }
 
-func (this *BallerinaParser) parsePeerWorkerName() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parsePeerWorkerName() tree.STNode {
+	token := b.peek()
 	switch token.Kind() {
 	case common.IDENTIFIER_TOKEN, common.FUNCTION_KEYWORD:
-		return tree.CreateSimpleNameReferenceNode(this.consume())
+		return tree.CreateSimpleNameReferenceNode(b.consume())
 	default:
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_PEER_WORKER_NAME)
-		return this.parsePeerWorkerName()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_PEER_WORKER_NAME)
+		return b.parsePeerWorkerName()
 	}
 }
 
-func (this *BallerinaParser) parseSyncSendToken() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseSyncSendToken() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.SYNC_SEND_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_SYNC_SEND_TOKEN)
-		return this.parseSyncSendToken()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_SYNC_SEND_TOKEN)
+		return b.parseSyncSendToken()
 	}
 }
 
-func (this *BallerinaParser) parseReceiveAction() tree.STNode {
-	leftArrow := this.parseLeftArrowToken()
-	receiveWorkers := this.parseReceiveWorkers()
+func (b *BallerinaParser) parseReceiveAction() tree.STNode {
+	leftArrow := b.parseLeftArrowToken()
+	receiveWorkers := b.parseReceiveWorkers()
 	return tree.CreateReceiveActionNode(leftArrow, receiveWorkers)
 }
 
-func (this *BallerinaParser) parseReceiveWorkers() tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseReceiveWorkers() tree.STNode {
+	switch b.peek().Kind() {
 	case common.FUNCTION_KEYWORD, common.IDENTIFIER_TOKEN:
-		return this.parseSingleOrAlternateReceiveWorkers()
+		return b.parseSingleOrAlternateReceiveWorkers()
 	case common.OPEN_BRACE_TOKEN:
-		return this.parseMultipleReceiveWorkers()
+		return b.parseMultipleReceiveWorkers()
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_RECEIVE_WORKERS)
-		return this.parseReceiveWorkers()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_RECEIVE_WORKERS)
+		return b.parseReceiveWorkers()
 	}
 }
 
-func (this *BallerinaParser) parseSingleOrAlternateReceiveWorkers() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_SINGLE_OR_ALTERNATE_WORKER)
+func (b *BallerinaParser) parseSingleOrAlternateReceiveWorkers() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_SINGLE_OR_ALTERNATE_WORKER)
 	var workers []tree.STNode
-	peerWorker := this.parsePeerWorkerName()
+	peerWorker := b.parsePeerWorkerName()
 	workers = append(workers, peerWorker)
-	nextToken := this.peek()
+	nextToken := b.peek()
 	if nextToken.Kind() != common.PIPE_TOKEN {
-		this.endContext()
+		b.endContext()
 		return peerWorker
 	}
 	for nextToken.Kind() == common.PIPE_TOKEN {
-		pipeToken := this.consume()
+		pipeToken := b.consume()
 		workers = append(workers, pipeToken)
-		peerWorker = this.parsePeerWorkerName()
+		peerWorker = b.parsePeerWorkerName()
 		workers = append(workers, peerWorker)
-		nextToken = this.peek()
+		nextToken = b.peek()
 	}
-	this.endContext()
+	b.endContext()
 	return tree.CreateAlternateReceiveNode(tree.CreateNodeList(workers...))
 }
 
-func (this *BallerinaParser) parseMultipleReceiveWorkers() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_MULTI_RECEIVE_WORKERS)
-	openBrace := this.parseOpenBrace()
-	receiveFields := this.parseReceiveFields()
-	closeBrace := this.parseCloseBrace()
-	this.endContext()
-	openBrace = this.cloneWithDiagnosticIfListEmpty(receiveFields, openBrace,
+func (b *BallerinaParser) parseMultipleReceiveWorkers() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_MULTI_RECEIVE_WORKERS)
+	openBrace := b.parseOpenBrace()
+	receiveFields := b.parseReceiveFields()
+	closeBrace := b.parseCloseBrace()
+	b.endContext()
+	openBrace = b.cloneWithDiagnosticIfListEmpty(receiveFields, openBrace,
 		&common.ERROR_MISSING_RECEIVE_FIELD_IN_RECEIVE_ACTION)
 	return tree.CreateReceiveFieldsNode(openBrace, receiveFields, closeBrace)
 }
 
-func (this *BallerinaParser) parseReceiveFields() tree.STNode {
+func (b *BallerinaParser) parseReceiveFields() tree.STNode {
 	var receiveFields []tree.STNode
-	nextToken := this.peek()
-	if this.isEndOfReceiveFields(nextToken.Kind()) {
+	nextToken := b.peek()
+	if b.isEndOfReceiveFields(nextToken.Kind()) {
 		return tree.CreateEmptyNodeList()
 	}
-	receiveField := this.parseReceiveField()
+	receiveField := b.parseReceiveField()
 	receiveFields = append(receiveFields, receiveField)
-	nextToken = this.peek()
+	nextToken = b.peek()
 	var recieveFieldEnd tree.STNode
-	for !this.isEndOfReceiveFields(nextToken.Kind()) {
-		recieveFieldEnd = this.parseReceiveFieldEnd()
+	for !b.isEndOfReceiveFields(nextToken.Kind()) {
+		recieveFieldEnd = b.parseReceiveFieldEnd()
 		if recieveFieldEnd == nil {
 			break
 		}
 		receiveFields = append(receiveFields, recieveFieldEnd)
-		receiveField = this.parseReceiveField()
+		receiveField = b.parseReceiveField()
 		receiveFields = append(receiveFields, receiveField)
-		nextToken = this.peek()
+		nextToken = b.peek()
 	}
 	return tree.CreateNodeList(receiveFields...)
 }
 
-func (this *BallerinaParser) isEndOfReceiveFields(nextTokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isEndOfReceiveFields(nextTokenKind common.SyntaxKind) bool {
 	switch nextTokenKind {
 	case common.EOF_TOKEN, common.CLOSE_BRACE_TOKEN:
 		return true
@@ -9845,80 +9845,80 @@ func (this *BallerinaParser) isEndOfReceiveFields(nextTokenKind common.SyntaxKin
 	}
 }
 
-func (this *BallerinaParser) parseReceiveFieldEnd() tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseReceiveFieldEnd() tree.STNode {
+	switch b.peek().Kind() {
 	case common.COMMA_TOKEN:
-		return this.parseComma()
+		return b.parseComma()
 	case common.CLOSE_BRACE_TOKEN:
 		return nil
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_RECEIVE_FIELD_END)
-		return this.parseReceiveFieldEnd()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_RECEIVE_FIELD_END)
+		return b.parseReceiveFieldEnd()
 	}
 }
 
-func (this *BallerinaParser) parseReceiveField() tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseReceiveField() tree.STNode {
+	switch b.peek().Kind() {
 	case common.FUNCTION_KEYWORD:
-		functionKeyword := this.consume()
+		functionKeyword := b.consume()
 		return tree.CreateSimpleNameReferenceNode(functionKeyword)
 	case common.IDENTIFIER_TOKEN:
-		identifier := this.parseIdentifier(common.PARSER_RULE_CONTEXT_RECEIVE_FIELD_NAME)
-		return this.createReceiveField(identifier)
+		identifier := b.parseIdentifier(common.PARSER_RULE_CONTEXT_RECEIVE_FIELD_NAME)
+		return b.createReceiveField(identifier)
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_RECEIVE_FIELD)
-		return this.parseReceiveField()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_RECEIVE_FIELD)
+		return b.parseReceiveField()
 	}
 }
 
-func (this *BallerinaParser) createReceiveField(identifier tree.STNode) tree.STNode {
-	if this.peek().Kind() != common.COLON_TOKEN {
+func (b *BallerinaParser) createReceiveField(identifier tree.STNode) tree.STNode {
+	if b.peek().Kind() != common.COLON_TOKEN {
 		return tree.CreateSimpleNameReferenceNode(identifier)
 	}
 	identifier = tree.CreateSimpleNameReferenceNode(identifier)
-	colon := this.parseColon()
-	peerWorker := this.parsePeerWorkerName()
+	colon := b.parseColon()
+	peerWorker := b.parsePeerWorkerName()
 	return tree.CreateReceiveFieldNode(identifier, colon, peerWorker)
 }
 
-func (this *BallerinaParser) parseLeftArrowToken() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseLeftArrowToken() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.LEFT_ARROW_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_LEFT_ARROW_TOKEN)
-		return this.parseLeftArrowToken()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_LEFT_ARROW_TOKEN)
+		return b.parseLeftArrowToken()
 	}
 }
 
-func (this *BallerinaParser) parseSignedRightShiftToken() tree.STNode {
-	firstToken := this.consume()
+func (b *BallerinaParser) parseSignedRightShiftToken() tree.STNode {
+	firstToken := b.consume()
 	if firstToken.Kind() == common.DOUBLE_GT_TOKEN {
 		return firstToken
 	}
-	endLGToken := this.consume()
+	endLGToken := b.consume()
 	var doubleGTToken tree.STNode
 	doubleGTToken = tree.CreateToken(common.DOUBLE_GT_TOKEN, firstToken.LeadingMinutiae(),
 		endLGToken.TrailingMinutiae())
-	if this.hasTrailingMinutiae(firstToken) {
+	if b.hasTrailingMinutiae(firstToken) {
 		doubleGTToken = tree.AddDiagnostic(doubleGTToken,
 			&common.ERROR_NO_WHITESPACES_ALLOWED_IN_RIGHT_SHIFT_OP)
 	}
 	return doubleGTToken
 }
 
-func (this *BallerinaParser) parseUnsignedRightShiftToken() tree.STNode {
-	firstToken := this.consume()
+func (b *BallerinaParser) parseUnsignedRightShiftToken() tree.STNode {
+	firstToken := b.consume()
 	if firstToken.Kind() == common.TRIPPLE_GT_TOKEN {
 		return firstToken
 	}
-	middleGTToken := this.consume()
-	endLGToken := this.consume()
+	middleGTToken := b.consume()
+	endLGToken := b.consume()
 	var unsignedRightShiftToken tree.STNode
 	unsignedRightShiftToken = tree.CreateToken(common.TRIPPLE_GT_TOKEN,
 		firstToken.LeadingMinutiae(), endLGToken.TrailingMinutiae())
-	validOpenGTToken := (!this.hasTrailingMinutiae(firstToken))
-	validMiddleGTToken := (!this.hasTrailingMinutiae(middleGTToken))
+	validOpenGTToken := (!b.hasTrailingMinutiae(firstToken))
+	validMiddleGTToken := (!b.hasTrailingMinutiae(middleGTToken))
 	if validOpenGTToken && validMiddleGTToken {
 		return unsignedRightShiftToken
 	}
@@ -9927,54 +9927,54 @@ func (this *BallerinaParser) parseUnsignedRightShiftToken() tree.STNode {
 	return unsignedRightShiftToken
 }
 
-func (this *BallerinaParser) parseWaitAction() tree.STNode {
-	waitKeyword := this.parseWaitKeyword()
-	if this.peek().Kind() == common.OPEN_BRACE_TOKEN {
-		return this.parseMultiWaitAction(waitKeyword)
+func (b *BallerinaParser) parseWaitAction() tree.STNode {
+	waitKeyword := b.parseWaitKeyword()
+	if b.peek().Kind() == common.OPEN_BRACE_TOKEN {
+		return b.parseMultiWaitAction(waitKeyword)
 	}
-	return this.parseSingleOrAlternateWaitAction(waitKeyword)
+	return b.parseSingleOrAlternateWaitAction(waitKeyword)
 }
 
-func (this *BallerinaParser) parseWaitKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseWaitKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.WAIT_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_WAIT_KEYWORD)
-		return this.parseWaitKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_WAIT_KEYWORD)
+		return b.parseWaitKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseSingleOrAlternateWaitAction(waitKeyword tree.STNode) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_ALTERNATE_WAIT_EXPRS)
-	nextToken := this.peek()
-	if this.isEndOfWaitFutureExprList(nextToken.Kind()) {
-		this.endContext()
+func (b *BallerinaParser) parseSingleOrAlternateWaitAction(waitKeyword tree.STNode) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_ALTERNATE_WAIT_EXPRS)
+	nextToken := b.peek()
+	if b.isEndOfWaitFutureExprList(nextToken.Kind()) {
+		b.endContext()
 		waitFutureExprs := tree.CreateSimpleNameReferenceNode(tree.CreateMissingToken(common.IDENTIFIER_TOKEN, nil))
 		waitFutureExprs = tree.AddDiagnostic(waitFutureExprs,
 			&common.ERROR_MISSING_WAIT_FUTURE_EXPRESSION)
 		return tree.CreateWaitActionNode(waitKeyword, waitFutureExprs)
 	}
 	var waitFutureExprList []tree.STNode
-	waitField := this.parseWaitFutureExpr()
+	waitField := b.parseWaitFutureExpr()
 	waitFutureExprList = append(waitFutureExprList, waitField)
-	nextToken = this.peek()
+	nextToken = b.peek()
 	var waitFutureExprEnd tree.STNode
-	for !this.isEndOfWaitFutureExprList(nextToken.Kind()) {
-		waitFutureExprEnd = this.parseWaitFutureExprEnd()
+	for !b.isEndOfWaitFutureExprList(nextToken.Kind()) {
+		waitFutureExprEnd = b.parseWaitFutureExprEnd()
 		if waitFutureExprEnd == nil {
 			break
 		}
 		waitFutureExprList = append(waitFutureExprList, waitFutureExprEnd)
-		waitField = this.parseWaitFutureExpr()
+		waitField = b.parseWaitFutureExpr()
 		waitFutureExprList = append(waitFutureExprList, waitField)
-		nextToken = this.peek()
+		nextToken = b.peek()
 	}
-	this.endContext()
+	b.endContext()
 	return tree.CreateWaitActionNode(waitKeyword, waitFutureExprList[0])
 }
 
-func (this *BallerinaParser) isEndOfWaitFutureExprList(nextTokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isEndOfWaitFutureExprList(nextTokenKind common.SyntaxKind) bool {
 	switch nextTokenKind {
 	case common.EOF_TOKEN, common.CLOSE_BRACE_TOKEN, common.SEMICOLON_TOKEN, common.OPEN_BRACE_TOKEN:
 		return true
@@ -9983,67 +9983,67 @@ func (this *BallerinaParser) isEndOfWaitFutureExprList(nextTokenKind common.Synt
 	}
 }
 
-func (this *BallerinaParser) parseWaitFutureExpr() tree.STNode {
-	waitFutureExpr := this.parseActionOrExpression()
+func (b *BallerinaParser) parseWaitFutureExpr() tree.STNode {
+	waitFutureExpr := b.parseActionOrExpression()
 	if waitFutureExpr.Kind() == common.MAPPING_CONSTRUCTOR {
 		waitFutureExpr = tree.AddDiagnostic(waitFutureExpr,
 			&common.ERROR_MAPPING_CONSTRUCTOR_EXPR_AS_A_WAIT_EXPR)
-	} else if this.isAction(waitFutureExpr) {
+	} else if b.isAction(waitFutureExpr) {
 		waitFutureExpr = tree.AddDiagnostic(waitFutureExpr, &common.ERROR_ACTION_AS_A_WAIT_EXPR)
 	}
 	return waitFutureExpr
 }
 
-func (this *BallerinaParser) parseWaitFutureExprEnd() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseWaitFutureExprEnd() tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.PIPE_TOKEN:
-		return this.parsePipeToken()
+		return b.parsePipeToken()
 	default:
-		if this.isEndOfWaitFutureExprList(nextToken.Kind()) || (!this.isValidExpressionStart(nextToken.Kind(), 1)) {
+		if b.isEndOfWaitFutureExprList(nextToken.Kind()) || (!b.isValidExpressionStart(nextToken.Kind(), 1)) {
 			return nil
 		}
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_WAIT_FUTURE_EXPR_END)
-		return this.parseWaitFutureExprEnd()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_WAIT_FUTURE_EXPR_END)
+		return b.parseWaitFutureExprEnd()
 	}
 }
 
-func (this *BallerinaParser) parseMultiWaitAction(waitKeyword tree.STNode) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_MULTI_WAIT_FIELDS)
-	openBrace := this.parseOpenBrace()
-	waitFields := this.parseWaitFields()
-	closeBrace := this.parseCloseBrace()
-	this.endContext()
-	openBrace = this.cloneWithDiagnosticIfListEmpty(waitFields, openBrace,
+func (b *BallerinaParser) parseMultiWaitAction(waitKeyword tree.STNode) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_MULTI_WAIT_FIELDS)
+	openBrace := b.parseOpenBrace()
+	waitFields := b.parseWaitFields()
+	closeBrace := b.parseCloseBrace()
+	b.endContext()
+	openBrace = b.cloneWithDiagnosticIfListEmpty(waitFields, openBrace,
 		&common.ERROR_MISSING_WAIT_FIELD_IN_WAIT_ACTION)
 	waitFieldsNode := tree.CreateWaitFieldsListNode(openBrace, waitFields, closeBrace)
 	return tree.CreateWaitActionNode(waitKeyword, waitFieldsNode)
 }
 
-func (this *BallerinaParser) parseWaitFields() tree.STNode {
+func (b *BallerinaParser) parseWaitFields() tree.STNode {
 	var waitFields []tree.STNode
-	nextToken := this.peek()
-	if this.isEndOfWaitFields(nextToken.Kind()) {
+	nextToken := b.peek()
+	if b.isEndOfWaitFields(nextToken.Kind()) {
 		return tree.CreateEmptyNodeList()
 	}
-	waitField := this.parseWaitField()
+	waitField := b.parseWaitField()
 	waitFields = append(waitFields, waitField)
-	nextToken = this.peek()
+	nextToken = b.peek()
 	var waitFieldEnd tree.STNode
-	for !this.isEndOfWaitFields(nextToken.Kind()) {
-		waitFieldEnd = this.parseWaitFieldEnd()
+	for !b.isEndOfWaitFields(nextToken.Kind()) {
+		waitFieldEnd = b.parseWaitFieldEnd()
 		if waitFieldEnd == nil {
 			break
 		}
 		waitFields = append(waitFields, waitFieldEnd)
-		waitField = this.parseWaitField()
+		waitField = b.parseWaitField()
 		waitFields = append(waitFields, waitField)
-		nextToken = this.peek()
+		nextToken = b.peek()
 	}
 	return tree.CreateNodeList(waitFields...)
 }
 
-func (this *BallerinaParser) isEndOfWaitFields(nextTokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isEndOfWaitFields(nextTokenKind common.SyntaxKind) bool {
 	switch nextTokenKind {
 	case common.EOF_TOKEN, common.CLOSE_BRACE_TOKEN:
 		return true
@@ -10052,66 +10052,66 @@ func (this *BallerinaParser) isEndOfWaitFields(nextTokenKind common.SyntaxKind) 
 	}
 }
 
-func (this *BallerinaParser) parseWaitFieldEnd() tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseWaitFieldEnd() tree.STNode {
+	switch b.peek().Kind() {
 	case common.COMMA_TOKEN:
-		return this.parseComma()
+		return b.parseComma()
 	case common.CLOSE_BRACE_TOKEN:
 		return nil
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_WAIT_FIELD_END)
-		return this.parseWaitFieldEnd()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_WAIT_FIELD_END)
+		return b.parseWaitFieldEnd()
 	}
 }
 
-func (this *BallerinaParser) parseWaitField() tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseWaitField() tree.STNode {
+	switch b.peek().Kind() {
 	case common.IDENTIFIER_TOKEN:
-		identifier := this.parseIdentifier(common.PARSER_RULE_CONTEXT_WAIT_FIELD_NAME)
+		identifier := b.parseIdentifier(common.PARSER_RULE_CONTEXT_WAIT_FIELD_NAME)
 		identifier = tree.CreateSimpleNameReferenceNode(identifier)
-		return this.createQualifiedWaitField(identifier)
+		return b.createQualifiedWaitField(identifier)
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_WAIT_FIELD_NAME)
-		return this.parseWaitField()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_WAIT_FIELD_NAME)
+		return b.parseWaitField()
 	}
 }
 
-func (this *BallerinaParser) createQualifiedWaitField(identifier tree.STNode) tree.STNode {
-	if this.peek().Kind() != common.COLON_TOKEN {
+func (b *BallerinaParser) createQualifiedWaitField(identifier tree.STNode) tree.STNode {
+	if b.peek().Kind() != common.COLON_TOKEN {
 		return identifier
 	}
-	colon := this.parseColon()
-	waitFutureExpr := this.parseWaitFutureExpr()
+	colon := b.parseColon()
+	waitFutureExpr := b.parseWaitFutureExpr()
 	return tree.CreateWaitFieldNode(identifier, colon, waitFutureExpr)
 }
 
-func (this *BallerinaParser) parseAnnotAccessExpression(lhsExpr tree.STNode, isInConditionalExpr bool) tree.STNode {
-	annotAccessToken := this.parseAnnotChainingToken()
-	annotTagReference := this.parseFieldAccessIdentifier(isInConditionalExpr)
+func (b *BallerinaParser) parseAnnotAccessExpression(lhsExpr tree.STNode, isInConditionalExpr bool) tree.STNode {
+	annotAccessToken := b.parseAnnotChainingToken()
+	annotTagReference := b.parseFieldAccessIdentifier(isInConditionalExpr)
 	return tree.CreateAnnotAccessExpressionNode(lhsExpr, annotAccessToken, annotTagReference)
 }
 
-func (this *BallerinaParser) parseAnnotChainingToken() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseAnnotChainingToken() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.ANNOT_CHAINING_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_ANNOT_CHAINING_TOKEN)
-		return this.parseAnnotChainingToken()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_ANNOT_CHAINING_TOKEN)
+		return b.parseAnnotChainingToken()
 	}
 }
 
-func (this *BallerinaParser) parseFieldAccessIdentifier(isInConditionalExpr bool) tree.STNode {
-	nextToken := this.peek()
-	if !this.isPredeclaredIdentifier(nextToken.Kind()) {
+func (b *BallerinaParser) parseFieldAccessIdentifier(isInConditionalExpr bool) tree.STNode {
+	nextToken := b.peek()
+	if !b.isPredeclaredIdentifier(nextToken.Kind()) {
 		var identifier tree.STNode = tree.CreateMissingTokenWithDiagnostics(common.IDENTIFIER_TOKEN,
 			&common.ERROR_MISSING_IDENTIFIER)
-		return this.parseQualifiedIdentifierNode(identifier, isInConditionalExpr)
+		return b.parseQualifiedIdentifierNode(identifier, isInConditionalExpr)
 	}
-	return this.parseQualifiedIdentifierInner(common.PARSER_RULE_CONTEXT_FIELD_ACCESS_IDENTIFIER, isInConditionalExpr)
+	return b.parseQualifiedIdentifierInner(common.PARSER_RULE_CONTEXT_FIELD_ACCESS_IDENTIFIER, isInConditionalExpr)
 }
 
-func (this *BallerinaParser) parseQueryAction(queryConstructType tree.STNode, queryPipeline tree.STNode, selectClause tree.STNode, collectClause tree.STNode) tree.STNode {
+func (b *BallerinaParser) parseQueryAction(queryConstructType tree.STNode, queryPipeline tree.STNode, selectClause tree.STNode, collectClause tree.STNode) tree.STNode {
 	if queryConstructType != nil {
 		queryPipeline = tree.CloneWithLeadingInvalidNodeMinutiae(queryPipeline, queryConstructType,
 			&common.ERROR_QUERY_CONSTRUCT_TYPE_IN_QUERY_ACTION)
@@ -10124,44 +10124,44 @@ func (this *BallerinaParser) parseQueryAction(queryConstructType tree.STNode, qu
 		queryPipeline = tree.CloneWithTrailingInvalidNodeMinutiae(queryPipeline, collectClause,
 			&common.ERROR_COLLECT_CLAUSE_IN_QUERY_ACTION)
 	}
-	this.startContext(common.PARSER_RULE_CONTEXT_DO_CLAUSE)
-	doKeyword := this.parseDoKeyword()
-	blockStmt := this.parseBlockNode()
-	this.endContext()
+	b.startContext(common.PARSER_RULE_CONTEXT_DO_CLAUSE)
+	doKeyword := b.parseDoKeyword()
+	blockStmt := b.parseBlockNode()
+	b.endContext()
 	return tree.CreateQueryActionNode(queryPipeline, doKeyword, blockStmt)
 }
 
-func (this *BallerinaParser) parseDoKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseDoKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.DO_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_DO_KEYWORD)
-		return this.parseDoKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_DO_KEYWORD)
+		return b.parseDoKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseOptionalFieldAccessExpression(lhsExpr tree.STNode, isInConditionalExpr bool) tree.STNode {
-	optionalFieldAccessToken := this.parseOptionalChainingToken()
-	fieldName := this.parseFieldAccessIdentifier(isInConditionalExpr)
+func (b *BallerinaParser) parseOptionalFieldAccessExpression(lhsExpr tree.STNode, isInConditionalExpr bool) tree.STNode {
+	optionalFieldAccessToken := b.parseOptionalChainingToken()
+	fieldName := b.parseFieldAccessIdentifier(isInConditionalExpr)
 	return tree.CreateOptionalFieldAccessExpressionNode(lhsExpr, optionalFieldAccessToken, fieldName)
 }
 
-func (this *BallerinaParser) parseOptionalChainingToken() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseOptionalChainingToken() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.OPTIONAL_CHAINING_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_OPTIONAL_CHAINING_TOKEN)
-		return this.parseOptionalChainingToken()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_OPTIONAL_CHAINING_TOKEN)
+		return b.parseOptionalChainingToken()
 	}
 }
 
-func (this *BallerinaParser) parseConditionalExpression(lhsExpr tree.STNode, isInConditionalExpr bool) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_CONDITIONAL_EXPRESSION)
-	questionMark := this.parseQuestionMark()
-	middleExpr := this.parseExpressionWithConditional(OPERATOR_PRECEDENCE_ANON_FUNC_OR_LET, true, false, true)
-	if this.peek().Kind() != common.COLON_TOKEN {
+func (b *BallerinaParser) parseConditionalExpression(lhsExpr tree.STNode, isInConditionalExpr bool) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_CONDITIONAL_EXPRESSION)
+	questionMark := b.parseQuestionMark()
+	middleExpr := b.parseExpressionWithConditional(OPERATOR_PRECEDENCE_ANON_FUNC_OR_LET, true, false, true)
+	if b.peek().Kind() != common.COLON_TOKEN {
 		if middleExpr.Kind() == common.CONDITIONAL_EXPRESSION {
 			innerConditionalExpr, ok := middleExpr.(*tree.STConditionalExpressionNode)
 			if !ok {
@@ -10170,36 +10170,36 @@ func (this *BallerinaParser) parseConditionalExpression(lhsExpr tree.STNode, isI
 			innerMiddleExpr := innerConditionalExpr.MiddleExpression
 			rightMostQNameRef := tree.GetQualifiedNameRefNode(innerMiddleExpr, false)
 			if rightMostQNameRef != nil {
-				middleExpr = this.generateConditionalExprForRightMost(innerConditionalExpr.LhsExpression,
+				middleExpr = b.generateConditionalExprForRightMost(innerConditionalExpr.LhsExpression,
 					innerConditionalExpr.QuestionMarkToken, innerMiddleExpr, rightMostQNameRef)
-				this.endContext()
+				b.endContext()
 				return tree.CreateConditionalExpressionNode(lhsExpr, questionMark, middleExpr,
 					innerConditionalExpr.ColonToken, innerConditionalExpr.EndExpression)
 			}
 			leftMostQNameRef := tree.GetQualifiedNameRefNode(innerMiddleExpr, true)
 			if leftMostQNameRef != nil {
-				middleExpr = this.generateConditionalExprForLeftMost(innerConditionalExpr.LhsExpression,
+				middleExpr = b.generateConditionalExprForLeftMost(innerConditionalExpr.LhsExpression,
 					innerConditionalExpr.QuestionMarkToken, innerMiddleExpr, leftMostQNameRef)
-				this.endContext()
+				b.endContext()
 				return tree.CreateConditionalExpressionNode(lhsExpr, questionMark, middleExpr,
 					innerConditionalExpr.ColonToken, innerConditionalExpr.EndExpression)
 			}
 		}
 		rightMostQNameRef := tree.GetQualifiedNameRefNode(middleExpr, false)
 		if rightMostQNameRef != nil {
-			this.endContext()
-			return this.generateConditionalExprForRightMost(lhsExpr, questionMark, middleExpr, rightMostQNameRef)
+			b.endContext()
+			return b.generateConditionalExprForRightMost(lhsExpr, questionMark, middleExpr, rightMostQNameRef)
 		}
 		leftMostQNameRef := tree.GetQualifiedNameRefNode(middleExpr, true)
 		if leftMostQNameRef != nil {
-			this.endContext()
-			return this.generateConditionalExprForLeftMost(lhsExpr, questionMark, middleExpr, leftMostQNameRef)
+			b.endContext()
+			return b.generateConditionalExprForLeftMost(lhsExpr, questionMark, middleExpr, leftMostQNameRef)
 		}
 	}
-	return this.parseConditionalExprRhs(lhsExpr, questionMark, middleExpr, isInConditionalExpr)
+	return b.parseConditionalExprRhs(lhsExpr, questionMark, middleExpr, isInConditionalExpr)
 }
 
-func (this *BallerinaParser) generateConditionalExprForRightMost(lhsExpr tree.STNode, questionMark tree.STNode, middleExpr tree.STNode, rightMostQualifiedNameRef tree.STNode) tree.STNode {
+func (b *BallerinaParser) generateConditionalExprForRightMost(lhsExpr tree.STNode, questionMark tree.STNode, middleExpr tree.STNode, rightMostQualifiedNameRef tree.STNode) tree.STNode {
 	qualifiedNameRef, ok := rightMostQualifiedNameRef.(*tree.STQualifiedNameReferenceNode)
 	if !ok {
 		panic("expected STQualifiedNameReferenceNode")
@@ -10211,7 +10211,7 @@ func (this *BallerinaParser) generateConditionalExprForRightMost(lhsExpr tree.ST
 		endExpr)
 }
 
-func (this *BallerinaParser) generateConditionalExprForLeftMost(lhsExpr tree.STNode, questionMark tree.STNode, middleExpr tree.STNode, leftMostQualifiedNameRef tree.STNode) tree.STNode {
+func (b *BallerinaParser) generateConditionalExprForLeftMost(lhsExpr tree.STNode, questionMark tree.STNode, middleExpr tree.STNode, leftMostQualifiedNameRef tree.STNode) tree.STNode {
 	qualifiedNameRef, ok := leftMostQualifiedNameRef.(*tree.STQualifiedNameReferenceNode)
 	if !ok {
 		panic("expected STQualifiedNameReferenceNode")
@@ -10223,221 +10223,221 @@ func (this *BallerinaParser) generateConditionalExprForLeftMost(lhsExpr tree.STN
 		endExpr)
 }
 
-func (this *BallerinaParser) parseConditionalExprRhs(lhsExpr tree.STNode, questionMark tree.STNode, middleExpr tree.STNode, isInConditionalExpr bool) tree.STNode {
-	colon := this.parseColon()
-	this.endContext()
-	endExpr := this.parseExpressionWithConditional(OPERATOR_PRECEDENCE_ANON_FUNC_OR_LET, true, false,
+func (b *BallerinaParser) parseConditionalExprRhs(lhsExpr tree.STNode, questionMark tree.STNode, middleExpr tree.STNode, isInConditionalExpr bool) tree.STNode {
+	colon := b.parseColon()
+	b.endContext()
+	endExpr := b.parseExpressionWithConditional(OPERATOR_PRECEDENCE_ANON_FUNC_OR_LET, true, false,
 		isInConditionalExpr)
 	return tree.CreateConditionalExpressionNode(lhsExpr, questionMark, middleExpr, colon, endExpr)
 }
 
-func (this *BallerinaParser) parseEnumDeclaration(metadata tree.STNode, qualifier tree.STNode) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_MODULE_ENUM_DECLARATION)
-	enumKeywordToken := this.parseEnumKeyword()
-	identifier := this.parseIdentifier(common.PARSER_RULE_CONTEXT_MODULE_ENUM_NAME)
-	openBraceToken := this.parseOpenBrace()
-	enumMemberList := this.parseEnumMemberList()
-	closeBraceToken := this.parseCloseBrace()
-	semicolon := this.parseOptionalSemicolon()
-	this.endContext()
-	openBraceToken = this.cloneWithDiagnosticIfListEmpty(enumMemberList, openBraceToken,
+func (b *BallerinaParser) parseEnumDeclaration(metadata tree.STNode, qualifier tree.STNode) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_MODULE_ENUM_DECLARATION)
+	enumKeywordToken := b.parseEnumKeyword()
+	identifier := b.parseIdentifier(common.PARSER_RULE_CONTEXT_MODULE_ENUM_NAME)
+	openBraceToken := b.parseOpenBrace()
+	enumMemberList := b.parseEnumMemberList()
+	closeBraceToken := b.parseCloseBrace()
+	semicolon := b.parseOptionalSemicolon()
+	b.endContext()
+	openBraceToken = b.cloneWithDiagnosticIfListEmpty(enumMemberList, openBraceToken,
 		&common.ERROR_MISSING_ENUM_MEMBER)
 	return tree.CreateEnumDeclarationNode(metadata, qualifier, enumKeywordToken, identifier,
 		openBraceToken, enumMemberList, closeBraceToken, semicolon)
 }
 
-func (this *BallerinaParser) parseEnumKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseEnumKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.ENUM_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_ENUM_KEYWORD)
-		return this.parseEnumKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_ENUM_KEYWORD)
+		return b.parseEnumKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseEnumMemberList() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_ENUM_MEMBER_LIST)
-	if this.peek().Kind() == common.CLOSE_BRACE_TOKEN {
+func (b *BallerinaParser) parseEnumMemberList() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_ENUM_MEMBER_LIST)
+	if b.peek().Kind() == common.CLOSE_BRACE_TOKEN {
 		return tree.CreateEmptyNodeList()
 	}
 	var enumMemberList []tree.STNode
-	enumMember := this.parseEnumMember()
+	enumMember := b.parseEnumMember()
 	var enumMemberRhs tree.STNode
-	for this.peek().Kind() != common.CLOSE_BRACE_TOKEN {
-		enumMemberRhs = this.parseEnumMemberEnd()
+	for b.peek().Kind() != common.CLOSE_BRACE_TOKEN {
+		enumMemberRhs = b.parseEnumMemberEnd()
 		if enumMemberRhs == nil {
 			break
 		}
 		enumMemberList = append(enumMemberList, enumMember)
 		enumMemberList = append(enumMemberList, enumMemberRhs)
-		enumMember = this.parseEnumMember()
+		enumMember = b.parseEnumMember()
 	}
 	enumMemberList = append(enumMemberList, enumMember)
-	this.endContext()
+	b.endContext()
 	return tree.CreateNodeList(enumMemberList...)
 }
 
-func (this *BallerinaParser) parseEnumMember() tree.STNode {
+func (b *BallerinaParser) parseEnumMember() tree.STNode {
 	var metadata tree.STNode
-	switch this.peek().Kind() {
+	switch b.peek().Kind() {
 	case common.DOCUMENTATION_STRING, common.AT_TOKEN:
-		metadata = this.parseMetaData()
+		metadata = b.parseMetaData()
 	default:
 		metadata = tree.CreateEmptyNode()
 	}
-	identifierNode := this.parseIdentifier(common.PARSER_RULE_CONTEXT_ENUM_MEMBER_NAME)
-	return this.parseEnumMemberRhs(metadata, identifierNode)
+	identifierNode := b.parseIdentifier(common.PARSER_RULE_CONTEXT_ENUM_MEMBER_NAME)
+	return b.parseEnumMemberRhs(metadata, identifierNode)
 }
 
-func (this *BallerinaParser) parseEnumMemberRhs(metadata tree.STNode, identifierNode tree.STNode) tree.STNode {
+func (b *BallerinaParser) parseEnumMemberRhs(metadata tree.STNode, identifierNode tree.STNode) tree.STNode {
 	var equalToken tree.STNode
 	var constExprNode tree.STNode
-	switch this.peek().Kind() {
+	switch b.peek().Kind() {
 	case common.EQUAL_TOKEN:
-		equalToken = this.parseAssignOp()
-		constExprNode = this.parseExpression()
+		equalToken = b.parseAssignOp()
+		constExprNode = b.parseExpression()
 	case common.COMMA_TOKEN, common.CLOSE_BRACE_TOKEN:
 		equalToken = tree.CreateEmptyNode()
 		constExprNode = tree.CreateEmptyNode()
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_ENUM_MEMBER_RHS)
-		return this.parseEnumMemberRhs(metadata, identifierNode)
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_ENUM_MEMBER_RHS)
+		return b.parseEnumMemberRhs(metadata, identifierNode)
 	}
 	return tree.CreateEnumMemberNode(metadata, identifierNode, equalToken, constExprNode)
 }
 
-func (this *BallerinaParser) parseEnumMemberEnd() tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseEnumMemberEnd() tree.STNode {
+	switch b.peek().Kind() {
 	case common.COMMA_TOKEN:
-		return this.parseComma()
+		return b.parseComma()
 	case common.CLOSE_BRACE_TOKEN:
 		return nil
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_ENUM_MEMBER_END)
-		return this.parseEnumMemberEnd()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_ENUM_MEMBER_END)
+		return b.parseEnumMemberEnd()
 	}
 }
 
-func (this *BallerinaParser) parseTransactionStmtOrVarDecl(annots tree.STNode, qualifiers []tree.STNode, transactionKeyword tree.STToken) (tree.STNode, []tree.STNode) {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseTransactionStmtOrVarDecl(annots tree.STNode, qualifiers []tree.STNode, transactionKeyword tree.STToken) (tree.STNode, []tree.STNode) {
+	switch b.peek().Kind() {
 	case common.OPEN_BRACE_TOKEN:
-		this.reportInvalidStatementAnnots(annots, qualifiers)
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseTransactionStatement(transactionKeyword), qualifiers
+		b.reportInvalidStatementAnnots(annots, qualifiers)
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseTransactionStatement(transactionKeyword), qualifiers
 	case common.COLON_TOKEN:
-		if this.getNextNextToken().Kind() == common.IDENTIFIER_TOKEN {
-			typeDesc := this.parseQualifiedIdentifierWithPredeclPrefix(transactionKeyword, false)
-			return this.parseVarDeclTypeDescRhs(typeDesc, annots, qualifiers, true, false)
+		if b.getNextNextToken().Kind() == common.IDENTIFIER_TOKEN {
+			typeDesc := b.parseQualifiedIdentifierWithPredeclPrefix(transactionKeyword, false)
+			return b.parseVarDeclTypeDescRhs(typeDesc, annots, qualifiers, true, false)
 		}
 		fallthrough
 	default:
-		solution := this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_TRANSACTION_STMT_RHS_OR_TYPE_REF)
+		solution := b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_TRANSACTION_STMT_RHS_OR_TYPE_REF)
 		if (solution.Action == ACTION_KEEP) || ((solution.Action == ACTION_INSERT) && (solution.TokenKind == common.COLON_TOKEN)) {
-			typeDesc := this.parseQualifiedIdentifierWithPredeclPrefix(transactionKeyword, false)
-			return this.parseVarDeclTypeDescRhs(typeDesc, annots, qualifiers, true, false)
+			typeDesc := b.parseQualifiedIdentifierWithPredeclPrefix(transactionKeyword, false)
+			return b.parseVarDeclTypeDescRhs(typeDesc, annots, qualifiers, true, false)
 		}
-		return this.parseTransactionStmtOrVarDecl(annots, qualifiers, transactionKeyword)
+		return b.parseTransactionStmtOrVarDecl(annots, qualifiers, transactionKeyword)
 	}
 }
 
-func (this *BallerinaParser) parseTransactionStatement(transactionKeyword tree.STNode) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_TRANSACTION_STMT)
-	blockStmt := this.parseBlockNode()
-	this.endContext()
-	onFailClause := this.parseOptionalOnFailClause()
+func (b *BallerinaParser) parseTransactionStatement(transactionKeyword tree.STNode) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_TRANSACTION_STMT)
+	blockStmt := b.parseBlockNode()
+	b.endContext()
+	onFailClause := b.parseOptionalOnFailClause()
 	return tree.CreateTransactionStatementNode(transactionKeyword, blockStmt, onFailClause)
 }
 
-func (this *BallerinaParser) parseCommitAction() tree.STNode {
-	commitKeyword := this.parseCommitKeyword()
+func (b *BallerinaParser) parseCommitAction() tree.STNode {
+	commitKeyword := b.parseCommitKeyword()
 	return tree.CreateCommitActionNode(commitKeyword)
 }
 
-func (this *BallerinaParser) parseCommitKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseCommitKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.COMMIT_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_COMMIT_KEYWORD)
-		return this.parseCommitKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_COMMIT_KEYWORD)
+		return b.parseCommitKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseRetryStatement() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_RETRY_STMT)
-	retryKeyword := this.parseRetryKeyword()
-	retryStmt := this.parseRetryKeywordRhs(retryKeyword)
+func (b *BallerinaParser) parseRetryStatement() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_RETRY_STMT)
+	retryKeyword := b.parseRetryKeyword()
+	retryStmt := b.parseRetryKeywordRhs(retryKeyword)
 	return retryStmt
 }
 
-func (this *BallerinaParser) parseRetryKeywordRhs(retryKeyword tree.STNode) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseRetryKeywordRhs(retryKeyword tree.STNode) tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.LT_TOKEN:
-		return this.parseRetryTypeParamRhs(retryKeyword, this.parseTypeParameter())
+		return b.parseRetryTypeParamRhs(retryKeyword, b.parseTypeParameter())
 	case common.OPEN_PAREN_TOKEN,
 		common.OPEN_BRACE_TOKEN,
 		common.TRANSACTION_KEYWORD:
-		return this.parseRetryTypeParamRhs(retryKeyword, tree.CreateEmptyNode())
+		return b.parseRetryTypeParamRhs(retryKeyword, tree.CreateEmptyNode())
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_RETRY_KEYWORD_RHS)
-		return this.parseRetryKeywordRhs(retryKeyword)
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_RETRY_KEYWORD_RHS)
+		return b.parseRetryKeywordRhs(retryKeyword)
 	}
 }
 
-func (this *BallerinaParser) parseRetryTypeParamRhs(retryKeyword tree.STNode, typeParam tree.STNode) tree.STNode {
+func (b *BallerinaParser) parseRetryTypeParamRhs(retryKeyword tree.STNode, typeParam tree.STNode) tree.STNode {
 	var args tree.STNode
-	switch this.peek().Kind() {
+	switch b.peek().Kind() {
 	case common.OPEN_PAREN_TOKEN:
-		args = this.parseParenthesizedArgList()
+		args = b.parseParenthesizedArgList()
 	case common.OPEN_BRACE_TOKEN,
 		common.TRANSACTION_KEYWORD:
 		args = tree.CreateEmptyNode()
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_RETRY_TYPE_PARAM_RHS)
-		return this.parseRetryTypeParamRhs(retryKeyword, typeParam)
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_RETRY_TYPE_PARAM_RHS)
+		return b.parseRetryTypeParamRhs(retryKeyword, typeParam)
 	}
-	blockStmt := this.parseRetryBody()
-	this.endContext()
-	onFailClause := this.parseOptionalOnFailClause()
+	blockStmt := b.parseRetryBody()
+	b.endContext()
+	onFailClause := b.parseOptionalOnFailClause()
 	return tree.CreateRetryStatementNode(retryKeyword, typeParam, args, blockStmt, onFailClause)
 }
 
-func (this *BallerinaParser) parseRetryBody() tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseRetryBody() tree.STNode {
+	switch b.peek().Kind() {
 	case common.OPEN_BRACE_TOKEN:
-		return this.parseBlockNode()
+		return b.parseBlockNode()
 	case common.TRANSACTION_KEYWORD:
-		return this.parseTransactionStatement(this.consume())
+		return b.parseTransactionStatement(b.consume())
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_RETRY_BODY)
-		return this.parseRetryBody()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_RETRY_BODY)
+		return b.parseRetryBody()
 	}
 }
 
-func (this *BallerinaParser) parseOptionalOnFailClause() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseOptionalOnFailClause() tree.STNode {
+	nextToken := b.peek()
 	if nextToken.Kind() == common.ON_KEYWORD {
-		return this.parseOnFailClause()
+		return b.parseOnFailClause()
 	}
-	if this.isEndOfRegularCompoundStmt(nextToken.Kind()) {
+	if b.isEndOfRegularCompoundStmt(nextToken.Kind()) {
 		return tree.CreateEmptyNode()
 	}
-	this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_REGULAR_COMPOUND_STMT_RHS)
-	return this.parseOptionalOnFailClause()
+	b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_REGULAR_COMPOUND_STMT_RHS)
+	return b.parseOptionalOnFailClause()
 }
 
-func (this *BallerinaParser) isEndOfRegularCompoundStmt(nodeKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isEndOfRegularCompoundStmt(nodeKind common.SyntaxKind) bool {
 	switch nodeKind {
 	case common.CLOSE_BRACE_TOKEN, common.SEMICOLON_TOKEN, common.AT_TOKEN, common.EOF_TOKEN:
 		return true
 	default:
-		return this.isStatementStartingToken(nodeKind)
+		return b.isStatementStartingToken(nodeKind)
 	}
 }
 
-func (this *BallerinaParser) isStatementStartingToken(nodeKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isStatementStartingToken(nodeKind common.SyntaxKind) bool {
 	switch nodeKind {
 	case common.FINAL_KEYWORD, common.IF_KEYWORD, common.WHILE_KEYWORD, common.DO_KEYWORD,
 		common.PANIC_KEYWORD, common.CONTINUE_KEYWORD, common.BREAK_KEYWORD, common.RETURN_KEYWORD,
@@ -10449,102 +10449,102 @@ func (this *BallerinaParser) isStatementStartingToken(nodeKind common.SyntaxKind
 		common.CONST_KEYWORD:
 		return true
 	default:
-		if this.isTypeStartingToken(nodeKind) {
+		if b.isTypeStartingToken(nodeKind) {
 			return true
 		}
-		if this.isValidExpressionStart(nodeKind, 1) {
+		if b.isValidExpressionStart(nodeKind, 1) {
 			return true
 		}
 		return false
 	}
 }
 
-func (this *BallerinaParser) parseOnFailClause() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_ON_FAIL_CLAUSE)
-	onKeyword := this.parseOnKeyword()
-	failKeyword := this.parseFailKeyword()
-	typedBindingPattern := this.parseOnfailOptionalBP()
-	blockStatement := this.parseBlockNode()
-	this.endContext()
+func (b *BallerinaParser) parseOnFailClause() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_ON_FAIL_CLAUSE)
+	onKeyword := b.parseOnKeyword()
+	failKeyword := b.parseFailKeyword()
+	typedBindingPattern := b.parseOnfailOptionalBP()
+	blockStatement := b.parseBlockNode()
+	b.endContext()
 	return tree.CreateOnFailClauseNode(onKeyword, failKeyword, typedBindingPattern,
 		blockStatement)
 }
 
-func (this *BallerinaParser) parseOnfailOptionalBP() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseOnfailOptionalBP() tree.STNode {
+	nextToken := b.peek()
 	if nextToken.Kind() == common.OPEN_BRACE_TOKEN {
 		return tree.CreateEmptyNode()
-	} else if this.isTypeStartingToken(nextToken.Kind()) {
-		return this.parseTypedBindingPattern()
+	} else if b.isTypeStartingToken(nextToken.Kind()) {
+		return b.parseTypedBindingPattern()
 	} else {
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_ON_FAIL_OPTIONAL_BINDING_PATTERN)
-		return this.parseOnfailOptionalBP()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_ON_FAIL_OPTIONAL_BINDING_PATTERN)
+		return b.parseOnfailOptionalBP()
 	}
 }
 
-func (this *BallerinaParser) parseTypedBindingPattern() tree.STNode {
-	typeDescriptor := this.parseTypeDescriptorWithoutQualifiers(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN, true, false, TYPE_PRECEDENCE_DEFAULT)
-	bindingPattern := this.parseBindingPattern()
+func (b *BallerinaParser) parseTypedBindingPattern() tree.STNode {
+	typeDescriptor := b.parseTypeDescriptorWithoutQualifiers(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN, true, false, TYPE_PRECEDENCE_DEFAULT)
+	bindingPattern := b.parseBindingPattern()
 	return tree.CreateTypedBindingPatternNode(typeDescriptor, bindingPattern)
 }
 
-func (this *BallerinaParser) parseRetryKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseRetryKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.RETRY_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_RETRY_KEYWORD)
-		return this.parseRetryKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_RETRY_KEYWORD)
+		return b.parseRetryKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseRollbackStatement() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_ROLLBACK_STMT)
-	rollbackKeyword := this.parseRollbackKeyword()
+func (b *BallerinaParser) parseRollbackStatement() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_ROLLBACK_STMT)
+	rollbackKeyword := b.parseRollbackKeyword()
 	var expression tree.STNode
-	if this.peek().Kind() == common.SEMICOLON_TOKEN {
+	if b.peek().Kind() == common.SEMICOLON_TOKEN {
 		expression = tree.CreateEmptyNode()
 	} else {
-		expression = this.parseExpression()
+		expression = b.parseExpression()
 	}
-	semicolon := this.parseSemicolon()
-	this.endContext()
+	semicolon := b.parseSemicolon()
+	b.endContext()
 	return tree.CreateRollbackStatementNode(rollbackKeyword, expression, semicolon)
 }
 
-func (this *BallerinaParser) parseRollbackKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseRollbackKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.ROLLBACK_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_ROLLBACK_KEYWORD)
-		return this.parseRollbackKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_ROLLBACK_KEYWORD)
+		return b.parseRollbackKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseTransactionalExpression() tree.STNode {
-	transactionalKeyword := this.parseTransactionalKeyword()
+func (b *BallerinaParser) parseTransactionalExpression() tree.STNode {
+	transactionalKeyword := b.parseTransactionalKeyword()
 	return tree.CreateTransactionalExpressionNode(transactionalKeyword)
 }
 
-func (this *BallerinaParser) parseTransactionalKeyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseTransactionalKeyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.TRANSACTIONAL_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_TRANSACTIONAL_KEYWORD)
-		return this.parseTransactionalKeyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_TRANSACTIONAL_KEYWORD)
+		return b.parseTransactionalKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseByteArrayLiteral() tree.STNode {
+func (b *BallerinaParser) parseByteArrayLiteral() tree.STNode {
 	var ty tree.STNode
-	if this.peek().Kind() == common.BASE16_KEYWORD {
-		ty = this.parseBase16Keyword()
+	if b.peek().Kind() == common.BASE16_KEYWORD {
+		ty = b.parseBase16Keyword()
 	} else {
-		ty = this.parseBase64Keyword()
+		ty = b.parseBase64Keyword()
 	}
-	startingBackTick := this.parseBacktickToken(common.PARSER_RULE_CONTEXT_TEMPLATE_START)
+	startingBackTick := b.parseBacktickToken(common.PARSER_RULE_CONTEXT_TEMPLATE_START)
 	if startingBackTick.IsMissing() {
 		startingBackTick = tree.CreateMissingToken(common.BACKTICK_TOKEN, nil)
 		endingBackTick := tree.CreateMissingToken(common.BACKTICK_TOKEN, nil)
@@ -10553,11 +10553,11 @@ func (this *BallerinaParser) parseByteArrayLiteral() tree.STNode {
 		byteArrayLiteral = tree.AddDiagnostic(byteArrayLiteral, &common.ERROR_MISSING_BYTE_ARRAY_CONTENT)
 		return byteArrayLiteral
 	}
-	content := this.parseByteArrayContent()
-	return this.parseByteArrayLiteralWithContent(ty, startingBackTick, content)
+	content := b.parseByteArrayContent()
+	return b.parseByteArrayLiteralWithContent(ty, startingBackTick, content)
 }
 
-func (this *BallerinaParser) parseByteArrayLiteralWithContent(typeKeyword tree.STNode, startingBackTick tree.STNode, byteArrayContent tree.STNode) tree.STNode {
+func (b *BallerinaParser) parseByteArrayLiteralWithContent(typeKeyword tree.STNode, startingBackTick tree.STNode, byteArrayContent tree.STNode) tree.STNode {
 	content := tree.CreateEmptyNode()
 	newStartingBackTick := startingBackTick
 	items, ok := byteArrayContent.(*tree.STNodeList)
@@ -10587,139 +10587,139 @@ func (this *BallerinaParser) parseByteArrayLiteralWithContent(typeKeyword tree.S
 		newStartingBackTick = tree.AddDiagnostic(clonedStartingBackTick,
 			&common.ERROR_INVALID_CONTENT_IN_BYTE_ARRAY_LITERAL)
 	}
-	endingBackTick := this.parseBacktickToken(common.PARSER_RULE_CONTEXT_TEMPLATE_END)
+	endingBackTick := b.parseBacktickToken(common.PARSER_RULE_CONTEXT_TEMPLATE_END)
 	return tree.CreateByteArrayLiteralNode(typeKeyword, newStartingBackTick, content, endingBackTick)
 }
 
-func (this *BallerinaParser) parseBase16Keyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseBase16Keyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.BASE16_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_BASE16_KEYWORD)
-		return this.parseBase16Keyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_BASE16_KEYWORD)
+		return b.parseBase16Keyword()
 	}
 }
 
-func (this *BallerinaParser) parseBase64Keyword() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseBase64Keyword() tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.BASE64_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_BASE64_KEYWORD)
-		return this.parseBase64Keyword()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_BASE64_KEYWORD)
+		return b.parseBase64Keyword()
 	}
 }
 
-func (this *BallerinaParser) parseByteArrayContent() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseByteArrayContent() tree.STNode {
+	nextToken := b.peek()
 	var items []tree.STNode
-	for !this.isEndOfBacktickContent(nextToken.Kind()) {
-		content := this.parseTemplateItem()
+	for !b.isEndOfBacktickContent(nextToken.Kind()) {
+		content := b.parseTemplateItem()
 		items = append(items, content)
-		nextToken = this.peek()
+		nextToken = b.peek()
 	}
 	return tree.CreateNodeList(items...)
 }
 
-func (this *BallerinaParser) parseXMLFilterExpression(lhsExpr tree.STNode) tree.STNode {
-	xmlNamePatternChain := this.parseXMLFilterExpressionRhs()
+func (b *BallerinaParser) parseXMLFilterExpression(lhsExpr tree.STNode) tree.STNode {
+	xmlNamePatternChain := b.parseXMLFilterExpressionRhs()
 	return tree.CreateXMLFilterExpressionNode(lhsExpr, xmlNamePatternChain)
 }
 
-func (this *BallerinaParser) parseXMLFilterExpressionRhs() tree.STNode {
-	dotLTToken := this.parseDotLTToken()
-	return this.parseXMLNamePatternChain(dotLTToken)
+func (b *BallerinaParser) parseXMLFilterExpressionRhs() tree.STNode {
+	dotLTToken := b.parseDotLTToken()
+	return b.parseXMLNamePatternChain(dotLTToken)
 }
 
-func (this *BallerinaParser) parseXMLNamePatternChain(startToken tree.STNode) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_XML_NAME_PATTERN)
-	xmlNamePattern := this.parseXMLNamePattern()
-	gtToken := this.parseGTToken()
-	this.endContext()
-	startToken = this.cloneWithDiagnosticIfListEmpty(xmlNamePattern, startToken,
+func (b *BallerinaParser) parseXMLNamePatternChain(startToken tree.STNode) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_XML_NAME_PATTERN)
+	xmlNamePattern := b.parseXMLNamePattern()
+	gtToken := b.parseGTToken()
+	b.endContext()
+	startToken = b.cloneWithDiagnosticIfListEmpty(xmlNamePattern, startToken,
 		&common.ERROR_MISSING_XML_ATOMIC_NAME_PATTERN)
 	return tree.CreateXMLNamePatternChainingNode(startToken, xmlNamePattern, gtToken)
 }
 
-func (this *BallerinaParser) parseXMLStepExtends() tree.STNode {
-	nextToken := this.peek()
-	if this.isEndOfXMLStepExtend(nextToken.Kind()) {
+func (b *BallerinaParser) parseXMLStepExtends() tree.STNode {
+	nextToken := b.peek()
+	if b.isEndOfXMLStepExtend(nextToken.Kind()) {
 		return tree.CreateEmptyNodeList()
 	}
 	var xmlStepExtendList []tree.STNode
-	this.startContext(common.PARSER_RULE_CONTEXT_XML_STEP_EXTENDS)
+	b.startContext(common.PARSER_RULE_CONTEXT_XML_STEP_EXTENDS)
 	var stepExtension tree.STNode
-	for !this.isEndOfXMLStepExtend(nextToken.Kind()) {
+	for !b.isEndOfXMLStepExtend(nextToken.Kind()) {
 		if nextToken.Kind() == common.DOT_TOKEN {
-			stepExtension = this.parseXMLStepMethodCallExtend()
+			stepExtension = b.parseXMLStepMethodCallExtend()
 		} else if nextToken.Kind() == common.DOT_LT_TOKEN {
-			stepExtension = this.parseXMLFilterExpressionRhs()
+			stepExtension = b.parseXMLFilterExpressionRhs()
 		} else {
-			stepExtension = this.parseXMLIndexedStepExtend()
+			stepExtension = b.parseXMLIndexedStepExtend()
 		}
 		xmlStepExtendList = append(xmlStepExtendList, stepExtension)
-		nextToken = this.peek()
+		nextToken = b.peek()
 	}
-	this.endContext()
+	b.endContext()
 	return tree.CreateNodeList(xmlStepExtendList...)
 }
 
-func (this *BallerinaParser) parseXMLIndexedStepExtend() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_MEMBER_ACCESS_KEY_EXPR)
-	openBracket := this.parseOpenBracket()
-	keyExpr := this.parseKeyExpr(true)
-	closeBracket := this.parseCloseBracket()
-	this.endContext()
+func (b *BallerinaParser) parseXMLIndexedStepExtend() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_MEMBER_ACCESS_KEY_EXPR)
+	openBracket := b.parseOpenBracket()
+	keyExpr := b.parseKeyExpr(true)
+	closeBracket := b.parseCloseBracket()
+	b.endContext()
 	return tree.CreateXMLStepIndexedExtendNode(openBracket, keyExpr, closeBracket)
 }
 
-func (this *BallerinaParser) parseXMLStepMethodCallExtend() tree.STNode {
-	dotToken := this.parseDotToken()
-	methodName := this.parseMethodName()
-	parenthesizedArgsList := this.parseParenthesizedArgList()
+func (b *BallerinaParser) parseXMLStepMethodCallExtend() tree.STNode {
+	dotToken := b.parseDotToken()
+	methodName := b.parseMethodName()
+	parenthesizedArgsList := b.parseParenthesizedArgList()
 	return tree.CreateXMLStepMethodCallExtendNode(dotToken, methodName, parenthesizedArgsList)
 }
 
-func (this *BallerinaParser) parseMethodName() tree.STNode {
-	if this.isSpecialMethodName(this.peek()) {
-		return this.getKeywordAsSimpleNameRef()
+func (b *BallerinaParser) parseMethodName() tree.STNode {
+	if b.isSpecialMethodName(b.peek()) {
+		return b.getKeywordAsSimpleNameRef()
 	}
-	return tree.CreateSimpleNameReferenceNode(this.parseIdentifier(common.PARSER_RULE_CONTEXT_IDENTIFIER))
+	return tree.CreateSimpleNameReferenceNode(b.parseIdentifier(common.PARSER_RULE_CONTEXT_IDENTIFIER))
 }
 
-func (this *BallerinaParser) parseDotLTToken() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseDotLTToken() tree.STNode {
+	nextToken := b.peek()
 	if nextToken.Kind() == common.DOT_LT_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_DOT_LT_TOKEN)
-		return this.parseDotLTToken()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_DOT_LT_TOKEN)
+		return b.parseDotLTToken()
 	}
 }
 
-func (this *BallerinaParser) parseXMLNamePattern() tree.STNode {
+func (b *BallerinaParser) parseXMLNamePattern() tree.STNode {
 	var xmlAtomicNamePatternList []tree.STNode
-	nextToken := this.peek()
-	if this.isEndOfXMLNamePattern(nextToken.Kind()) {
+	nextToken := b.peek()
+	if b.isEndOfXMLNamePattern(nextToken.Kind()) {
 		return tree.CreateNodeList(xmlAtomicNamePatternList...)
 	}
-	xmlAtomicNamePattern := this.parseXMLAtomicNamePattern()
+	xmlAtomicNamePattern := b.parseXMLAtomicNamePattern()
 	xmlAtomicNamePatternList = append(xmlAtomicNamePatternList, xmlAtomicNamePattern)
 	var separator tree.STNode
-	for !this.isEndOfXMLNamePattern(this.peek().Kind()) {
-		separator = this.parseXMLNamePatternSeparator()
+	for !b.isEndOfXMLNamePattern(b.peek().Kind()) {
+		separator = b.parseXMLNamePatternSeparator()
 		if separator == nil {
 			break
 		}
 		xmlAtomicNamePatternList = append(xmlAtomicNamePatternList, separator)
-		xmlAtomicNamePattern = this.parseXMLAtomicNamePattern()
+		xmlAtomicNamePattern = b.parseXMLAtomicNamePattern()
 		xmlAtomicNamePatternList = append(xmlAtomicNamePatternList, xmlAtomicNamePattern)
 	}
 	return tree.CreateNodeList(xmlAtomicNamePatternList...)
 }
 
-func (this *BallerinaParser) isEndOfXMLNamePattern(tokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isEndOfXMLNamePattern(tokenKind common.SyntaxKind) bool {
 	switch tokenKind {
 	case common.GT_TOKEN, common.EOF_TOKEN:
 		return true
@@ -10728,155 +10728,155 @@ func (this *BallerinaParser) isEndOfXMLNamePattern(tokenKind common.SyntaxKind) 
 	}
 }
 
-func (this *BallerinaParser) isEndOfXMLStepExtend(tokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isEndOfXMLStepExtend(tokenKind common.SyntaxKind) bool {
 	switch tokenKind {
 	case common.OPEN_BRACKET_TOKEN, common.DOT_LT_TOKEN:
 		return false
 	case common.DOT_TOKEN:
-		return this.peekN(3).Kind() != common.OPEN_PAREN_TOKEN
+		return b.peekN(3).Kind() != common.OPEN_PAREN_TOKEN
 	default:
 		return true
 	}
 }
 
-func (this *BallerinaParser) parseXMLNamePatternSeparator() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseXMLNamePatternSeparator() tree.STNode {
+	token := b.peek()
 	switch token.Kind() {
 	case common.PIPE_TOKEN:
-		return this.consume()
+		return b.consume()
 	case common.GT_TOKEN, common.EOF_TOKEN:
 		return nil
 	default:
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_XML_NAME_PATTERN_RHS)
-		return this.parseXMLNamePatternSeparator()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_XML_NAME_PATTERN_RHS)
+		return b.parseXMLNamePatternSeparator()
 	}
 }
 
-func (this *BallerinaParser) parseXMLAtomicNamePattern() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_XML_ATOMIC_NAME_PATTERN)
-	atomicNamePattern := this.parseXMLAtomicNamePatternBody()
-	this.endContext()
+func (b *BallerinaParser) parseXMLAtomicNamePattern() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_XML_ATOMIC_NAME_PATTERN)
+	atomicNamePattern := b.parseXMLAtomicNamePatternBody()
+	b.endContext()
 	return atomicNamePattern
 }
 
-func (this *BallerinaParser) parseXMLAtomicNamePatternBody() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseXMLAtomicNamePatternBody() tree.STNode {
+	token := b.peek()
 	var identifier tree.STNode
 	switch token.Kind() {
 	case common.ASTERISK_TOKEN:
-		return this.consume()
+		return b.consume()
 	case common.IDENTIFIER_TOKEN:
-		identifier = this.consume()
+		identifier = b.consume()
 	default:
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_XML_ATOMIC_NAME_PATTERN_START)
-		return this.parseXMLAtomicNamePatternBody()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_XML_ATOMIC_NAME_PATTERN_START)
+		return b.parseXMLAtomicNamePatternBody()
 	}
-	return this.parseXMLAtomicNameIdentifier(identifier)
+	return b.parseXMLAtomicNameIdentifier(identifier)
 }
 
-func (this *BallerinaParser) parseXMLAtomicNameIdentifier(identifier tree.STNode) tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseXMLAtomicNameIdentifier(identifier tree.STNode) tree.STNode {
+	token := b.peek()
 	if token.Kind() == common.COLON_TOKEN {
-		colon := this.consume()
-		nextToken := this.peek()
+		colon := b.consume()
+		nextToken := b.peek()
 		if (nextToken.Kind() == common.IDENTIFIER_TOKEN) || (nextToken.Kind() == common.ASTERISK_TOKEN) {
-			endToken := this.consume()
+			endToken := b.consume()
 			return tree.CreateXMLAtomicNamePatternNode(identifier, colon, endToken)
 		}
 	}
 	return tree.CreateSimpleNameReferenceNode(identifier)
 }
 
-func (this *BallerinaParser) parseXMLStepExpression(lhsExpr tree.STNode) tree.STNode {
-	xmlStepStart := this.parseXMLStepStart()
-	xmlStepExtends := this.parseXMLStepExtends()
+func (b *BallerinaParser) parseXMLStepExpression(lhsExpr tree.STNode) tree.STNode {
+	xmlStepStart := b.parseXMLStepStart()
+	xmlStepExtends := b.parseXMLStepExtends()
 	return tree.CreateXMLStepExpressionNode(lhsExpr, xmlStepStart, xmlStepExtends)
 }
 
-func (this *BallerinaParser) parseXMLStepStart() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseXMLStepStart() tree.STNode {
+	token := b.peek()
 	var startToken tree.STNode
 	switch token.Kind() {
 	case common.SLASH_ASTERISK_TOKEN:
-		return this.consume()
+		return b.consume()
 	case common.DOUBLE_SLASH_DOUBLE_ASTERISK_LT_TOKEN:
-		startToken = this.parseDoubleSlashDoubleAsteriskLTToken()
+		startToken = b.parseDoubleSlashDoubleAsteriskLTToken()
 	case common.SLASH_LT_TOKEN:
 	default:
-		startToken = this.parseSlashLTToken()
+		startToken = b.parseSlashLTToken()
 	}
-	return this.parseXMLNamePatternChain(startToken)
+	return b.parseXMLNamePatternChain(startToken)
 }
 
-func (this *BallerinaParser) parseSlashLTToken() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseSlashLTToken() tree.STNode {
+	nextToken := b.peek()
 	if nextToken.Kind() == common.SLASH_LT_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_SLASH_LT_TOKEN)
-		return this.parseSlashLTToken()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_SLASH_LT_TOKEN)
+		return b.parseSlashLTToken()
 	}
 }
 
-func (this *BallerinaParser) parseDoubleSlashDoubleAsteriskLTToken() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseDoubleSlashDoubleAsteriskLTToken() tree.STNode {
+	nextToken := b.peek()
 	if nextToken.Kind() == common.DOUBLE_SLASH_DOUBLE_ASTERISK_LT_TOKEN {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_DOUBLE_SLASH_DOUBLE_ASTERISK_LT_TOKEN)
-		return this.parseDoubleSlashDoubleAsteriskLTToken()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_DOUBLE_SLASH_DOUBLE_ASTERISK_LT_TOKEN)
+		return b.parseDoubleSlashDoubleAsteriskLTToken()
 	}
 }
 
-func (this *BallerinaParser) parseMatchStatement() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_MATCH_STMT)
-	matchKeyword := this.parseMatchKeyword()
-	actionOrExpr := this.parseActionOrExpression()
-	this.startContext(common.PARSER_RULE_CONTEXT_MATCH_BODY)
-	openBrace := this.parseOpenBrace()
+func (b *BallerinaParser) parseMatchStatement() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_MATCH_STMT)
+	matchKeyword := b.parseMatchKeyword()
+	actionOrExpr := b.parseActionOrExpression()
+	b.startContext(common.PARSER_RULE_CONTEXT_MATCH_BODY)
+	openBrace := b.parseOpenBrace()
 	var matchClausesList []tree.STNode
-	for !this.isEndOfMatchClauses(this.peek().Kind()) {
-		clause := this.parseMatchClause()
+	for !b.isEndOfMatchClauses(b.peek().Kind()) {
+		clause := b.parseMatchClause()
 		matchClausesList = append(matchClausesList, clause)
 	}
 	matchClauses := tree.CreateNodeList(matchClausesList...)
-	if this.isNodeListEmpty(matchClauses) {
+	if b.isNodeListEmpty(matchClauses) {
 		openBrace = tree.AddDiagnostic(openBrace,
 			&common.ERROR_MATCH_STATEMENT_SHOULD_HAVE_ONE_OR_MORE_MATCH_CLAUSES)
 	}
-	closeBrace := this.parseCloseBrace()
-	this.endContext()
-	this.endContext()
-	onFailClause := this.parseOptionalOnFailClause()
+	closeBrace := b.parseCloseBrace()
+	b.endContext()
+	b.endContext()
+	onFailClause := b.parseOptionalOnFailClause()
 	return tree.CreateMatchStatementNode(matchKeyword, actionOrExpr, openBrace, matchClauses, closeBrace,
 		onFailClause)
 }
 
-func (this *BallerinaParser) parseMatchKeyword() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseMatchKeyword() tree.STNode {
+	nextToken := b.peek()
 	if nextToken.Kind() == common.MATCH_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_MATCH_KEYWORD)
-		return this.parseMatchKeyword()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_MATCH_KEYWORD)
+		return b.parseMatchKeyword()
 	}
 }
 
-func (this *BallerinaParser) isEndOfMatchClauses(nextTokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isEndOfMatchClauses(nextTokenKind common.SyntaxKind) bool {
 	switch nextTokenKind {
 	case common.EOF_TOKEN, common.CLOSE_BRACE_TOKEN, common.TYPE_KEYWORD:
 		return true
 	default:
-		return this.isEndOfStatements()
+		return b.isEndOfStatements()
 	}
 }
 
-func (this *BallerinaParser) parseMatchClause() tree.STNode {
-	matchPatterns := this.parseMatchPatternList()
-	matchGuard := this.parseMatchGuard()
-	rightDoubleArrow := this.parseDoubleRightArrow()
-	blockStmt := this.parseBlockNode()
-	if this.isNodeListEmpty(matchPatterns) {
+func (b *BallerinaParser) parseMatchClause() tree.STNode {
+	matchPatterns := b.parseMatchPatternList()
+	matchGuard := b.parseMatchGuard()
+	rightDoubleArrow := b.parseDoubleRightArrow()
+	blockStmt := b.parseBlockNode()
+	if b.isNodeListEmpty(matchPatterns) {
 		identifier := tree.CreateMissingToken(common.IDENTIFIER_TOKEN, nil)
 		constantPattern := tree.CreateSimpleNameReferenceNode(identifier)
 		matchPatterns = tree.CreateNodeList(constantPattern)
@@ -10890,41 +10890,41 @@ func (this *BallerinaParser) parseMatchClause() tree.STNode {
 	return tree.CreateMatchClauseNode(matchPatterns, matchGuard, rightDoubleArrow, blockStmt)
 }
 
-func (this *BallerinaParser) parseMatchGuard() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseMatchGuard() tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.IF_KEYWORD:
-		ifKeyword := this.parseIfKeyword()
-		expr := this.parseExpressionWithMatchGuard(DEFAULT_OP_PRECEDENCE, true, false, true, false)
+		ifKeyword := b.parseIfKeyword()
+		expr := b.parseExpressionWithMatchGuard(DEFAULT_OP_PRECEDENCE, true, false, true, false)
 		return tree.CreateMatchGuardNode(ifKeyword, expr)
 	case common.RIGHT_DOUBLE_ARROW_TOKEN:
 		return tree.CreateEmptyNode()
 	default:
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_OPTIONAL_MATCH_GUARD)
-		return this.parseMatchGuard()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_OPTIONAL_MATCH_GUARD)
+		return b.parseMatchGuard()
 	}
 }
 
-func (this *BallerinaParser) parseMatchPatternList() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_MATCH_PATTERN)
+func (b *BallerinaParser) parseMatchPatternList() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_MATCH_PATTERN)
 	var matchClauses []tree.STNode
-	for !this.isEndOfMatchPattern(this.peek().Kind()) {
-		clause := this.parseMatchPattern()
+	for !b.isEndOfMatchPattern(b.peek().Kind()) {
+		clause := b.parseMatchPattern()
 		if clause == nil {
 			break
 		}
 		matchClauses = append(matchClauses, clause)
-		seperator := this.parseMatchPatternListMemberRhs()
+		seperator := b.parseMatchPatternListMemberRhs()
 		if seperator == nil {
 			break
 		}
 		matchClauses = append(matchClauses, seperator)
 	}
-	this.endContext()
+	b.endContext()
 	return tree.CreateNodeList(matchClauses...)
 }
 
-func (this *BallerinaParser) isEndOfMatchPattern(nextTokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isEndOfMatchPattern(nextTokenKind common.SyntaxKind) bool {
 	switch nextTokenKind {
 	case common.PIPE_TOKEN, common.IF_KEYWORD, common.RIGHT_DOUBLE_ARROW_TOKEN:
 		return true
@@ -10933,11 +10933,11 @@ func (this *BallerinaParser) isEndOfMatchPattern(nextTokenKind common.SyntaxKind
 	}
 }
 
-func (this *BallerinaParser) parseMatchPattern() tree.STNode {
-	nextToken := this.peek()
-	if this.isPredeclaredIdentifier(nextToken.Kind()) {
-		typeRefOrConstExpr := this.parseQualifiedIdentifier(common.PARSER_RULE_CONTEXT_MATCH_PATTERN)
-		return this.parseErrorMatchPatternOrConsPattern(typeRefOrConstExpr)
+func (b *BallerinaParser) parseMatchPattern() tree.STNode {
+	nextToken := b.peek()
+	if b.isPredeclaredIdentifier(nextToken.Kind()) {
+		typeRefOrConstExpr := b.parseQualifiedIdentifier(common.PARSER_RULE_CONTEXT_MATCH_PATTERN)
+		return b.parseErrorMatchPatternOrConsPattern(typeRefOrConstExpr)
 	}
 	switch nextToken.Kind() {
 	case common.OPEN_PAREN_TOKEN,
@@ -10951,61 +10951,61 @@ func (this *BallerinaParser) parseMatchPattern() tree.STNode {
 		common.DECIMAL_FLOATING_POINT_LITERAL_TOKEN,
 		common.HEX_FLOATING_POINT_LITERAL_TOKEN,
 		common.STRING_LITERAL_TOKEN:
-		return this.parseSimpleConstExpr()
+		return b.parseSimpleConstExpr()
 	case common.VAR_KEYWORD:
-		return this.parseVarTypedBindingPattern()
+		return b.parseVarTypedBindingPattern()
 	case common.OPEN_BRACKET_TOKEN:
-		return this.parseListMatchPattern()
+		return b.parseListMatchPattern()
 	case common.OPEN_BRACE_TOKEN:
-		return this.parseMappingMatchPattern()
+		return b.parseMappingMatchPattern()
 	case common.ERROR_KEYWORD:
-		return this.parseErrorMatchPattern()
+		return b.parseErrorMatchPattern()
 	default:
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_MATCH_PATTERN_START)
-		return this.parseMatchPattern()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_MATCH_PATTERN_START)
+		return b.parseMatchPattern()
 	}
 }
 
-func (this *BallerinaParser) parseMatchPatternListMemberRhs() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseMatchPatternListMemberRhs() tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.PIPE_TOKEN:
-		return this.parsePipeToken()
+		return b.parsePipeToken()
 	case common.IF_KEYWORD, common.RIGHT_DOUBLE_ARROW_TOKEN:
 		return nil
 	default:
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_MATCH_PATTERN_LIST_MEMBER_RHS)
-		return this.parseMatchPatternListMemberRhs()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_MATCH_PATTERN_LIST_MEMBER_RHS)
+		return b.parseMatchPatternListMemberRhs()
 	}
 }
 
-func (this *BallerinaParser) parseVarTypedBindingPattern() tree.STNode {
-	varKeyword := this.parseVarKeyword()
+func (b *BallerinaParser) parseVarTypedBindingPattern() tree.STNode {
+	varKeyword := b.parseVarKeyword()
 	varTypeDesc := CreateBuiltinSimpleNameReference(varKeyword)
-	bindingPattern := this.parseBindingPattern()
+	bindingPattern := b.parseBindingPattern()
 	return tree.CreateTypedBindingPatternNode(varTypeDesc, bindingPattern)
 }
 
-func (this *BallerinaParser) parseVarKeyword() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseVarKeyword() tree.STNode {
+	nextToken := b.peek()
 	if nextToken.Kind() == common.VAR_KEYWORD {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_VAR_KEYWORD)
-		return this.parseVarKeyword()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_VAR_KEYWORD)
+		return b.parseVarKeyword()
 	}
 }
 
-func (this *BallerinaParser) parseListMatchPattern() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_LIST_MATCH_PATTERN)
-	openBracketToken := this.parseOpenBracket()
+func (b *BallerinaParser) parseListMatchPattern() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_LIST_MATCH_PATTERN)
+	openBracketToken := b.parseOpenBracket()
 	var matchPatternList []tree.STNode
 	var listMatchPatternMemberRhs tree.STNode
 	isEndOfFields := false
-	for !this.IsEndOfListMatchPattern() {
-		listMatchPatternMember := this.parseListMatchPatternMember()
+	for !b.IsEndOfListMatchPattern() {
+		listMatchPatternMember := b.parseListMatchPatternMember()
 		matchPatternList = append(matchPatternList, listMatchPatternMember)
-		listMatchPatternMemberRhs = this.parseListMatchPatternMemberRhs()
+		listMatchPatternMemberRhs = b.parseListMatchPatternMemberRhs()
 		if listMatchPatternMember.Kind() == common.REST_MATCH_PATTERN {
 			isEndOfFields = true
 			break
@@ -11017,23 +11017,23 @@ func (this *BallerinaParser) parseListMatchPattern() tree.STNode {
 		}
 	}
 	for isEndOfFields && (listMatchPatternMemberRhs != nil) {
-		this.updateLastNodeInListWithInvalidNode(matchPatternList, listMatchPatternMemberRhs, nil)
-		if this.peek().Kind() == common.CLOSE_BRACKET_TOKEN {
+		b.updateLastNodeInListWithInvalidNode(matchPatternList, listMatchPatternMemberRhs, nil)
+		if b.peek().Kind() == common.CLOSE_BRACKET_TOKEN {
 			break
 		}
-		invalidField := this.parseListMatchPatternMember()
-		this.updateLastNodeInListWithInvalidNode(matchPatternList, invalidField,
+		invalidField := b.parseListMatchPatternMember()
+		b.updateLastNodeInListWithInvalidNode(matchPatternList, invalidField,
 			&common.ERROR_MATCH_PATTERN_AFTER_REST_MATCH_PATTERN)
-		listMatchPatternMemberRhs = this.parseListMatchPatternMemberRhs()
+		listMatchPatternMemberRhs = b.parseListMatchPatternMemberRhs()
 	}
 	matchPatternListNode := tree.CreateNodeList(matchPatternList...)
-	closeBracketToken := this.parseCloseBracket()
-	this.endContext()
+	closeBracketToken := b.parseCloseBracket()
+	b.endContext()
 	return tree.CreateListMatchPatternNode(openBracketToken, matchPatternListNode, closeBracketToken)
 }
 
-func (this *BallerinaParser) IsEndOfListMatchPattern() bool {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) IsEndOfListMatchPattern() bool {
+	switch b.peek().Kind() {
 	case common.CLOSE_BRACKET_TOKEN, common.EOF_TOKEN:
 		return true
 	default:
@@ -11041,22 +11041,22 @@ func (this *BallerinaParser) IsEndOfListMatchPattern() bool {
 	}
 }
 
-func (this *BallerinaParser) parseListMatchPatternMember() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseListMatchPatternMember() tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.ELLIPSIS_TOKEN:
-		return this.parseRestMatchPattern()
+		return b.parseRestMatchPattern()
 	default:
-		return this.parseMatchPattern()
+		return b.parseMatchPattern()
 	}
 }
 
-func (this *BallerinaParser) parseRestMatchPattern() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_REST_MATCH_PATTERN)
-	ellipsisToken := this.parseEllipsis()
-	varKeywordToken := this.parseVarKeyword()
-	variableName := this.parseVariableName()
-	this.endContext()
+func (b *BallerinaParser) parseRestMatchPattern() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_REST_MATCH_PATTERN)
+	ellipsisToken := b.parseEllipsis()
+	varKeywordToken := b.parseVarKeyword()
+	variableName := b.parseVariableName()
+	b.endContext()
 	simpleNameReferenceNode, ok := tree.CreateSimpleNameReferenceNode(variableName).(*tree.STSimpleNameReferenceNode)
 	if !ok {
 		panic("expected STSimpleNameReferenceNode")
@@ -11064,62 +11064,62 @@ func (this *BallerinaParser) parseRestMatchPattern() tree.STNode {
 	return tree.CreateRestMatchPatternNode(ellipsisToken, varKeywordToken, simpleNameReferenceNode)
 }
 
-func (this *BallerinaParser) parseListMatchPatternMemberRhs() tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseListMatchPatternMemberRhs() tree.STNode {
+	switch b.peek().Kind() {
 	case common.COMMA_TOKEN:
-		return this.parseComma()
+		return b.parseComma()
 	case common.CLOSE_BRACKET_TOKEN, common.EOF_TOKEN:
 		return nil
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_LIST_MATCH_PATTERN_MEMBER_RHS)
-		return this.parseListMatchPatternMemberRhs()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_LIST_MATCH_PATTERN_MEMBER_RHS)
+		return b.parseListMatchPatternMemberRhs()
 	}
 }
 
-func (this *BallerinaParser) parseMappingMatchPattern() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_MAPPING_MATCH_PATTERN)
-	openBraceToken := this.parseOpenBrace()
-	fieldMatchPatterns := this.parseFieldMatchPatternList()
-	closeBraceToken := this.parseCloseBrace()
-	this.endContext()
+func (b *BallerinaParser) parseMappingMatchPattern() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_MAPPING_MATCH_PATTERN)
+	openBraceToken := b.parseOpenBrace()
+	fieldMatchPatterns := b.parseFieldMatchPatternList()
+	closeBraceToken := b.parseCloseBrace()
+	b.endContext()
 	return tree.CreateMappingMatchPatternNode(openBraceToken, fieldMatchPatterns, closeBraceToken)
 }
 
-func (this *BallerinaParser) parseFieldMatchPatternList() tree.STNode {
+func (b *BallerinaParser) parseFieldMatchPatternList() tree.STNode {
 	var fieldMatchPatterns []tree.STNode
-	fieldMatchPatternMember := this.parseFieldMatchPatternMember()
+	fieldMatchPatternMember := b.parseFieldMatchPatternMember()
 	if fieldMatchPatternMember == nil {
 		return tree.CreateEmptyNodeList()
 	}
 	fieldMatchPatterns = append(fieldMatchPatterns, fieldMatchPatternMember)
 	if fieldMatchPatternMember.Kind() == common.REST_MATCH_PATTERN {
-		this.invalidateExtraFieldMatchPatterns(fieldMatchPatterns)
+		b.invalidateExtraFieldMatchPatterns(fieldMatchPatterns)
 		return tree.CreateNodeList(fieldMatchPatterns...)
 	}
-	return this.parseFieldMatchPatternListWithPatterns(fieldMatchPatterns)
+	return b.parseFieldMatchPatternListWithPatterns(fieldMatchPatterns)
 }
 
-func (this *BallerinaParser) parseFieldMatchPatternListWithPatterns(fieldMatchPatterns []tree.STNode) tree.STNode {
-	for !this.IsEndOfMappingMatchPattern() {
-		fieldMatchPatternRhs := this.parseFieldMatchPatternRhs()
+func (b *BallerinaParser) parseFieldMatchPatternListWithPatterns(fieldMatchPatterns []tree.STNode) tree.STNode {
+	for !b.IsEndOfMappingMatchPattern() {
+		fieldMatchPatternRhs := b.parseFieldMatchPatternRhs()
 		if fieldMatchPatternRhs == nil {
 			break
 		}
 		fieldMatchPatterns = append(fieldMatchPatterns, fieldMatchPatternRhs)
-		fieldMatchPatternMember := this.parseFieldMatchPatternMember()
+		fieldMatchPatternMember := b.parseFieldMatchPatternMember()
 		if fieldMatchPatternMember == nil {
-			fieldMatchPatternMember = this.createMissingFieldMatchPattern()
+			fieldMatchPatternMember = b.createMissingFieldMatchPattern()
 		}
 		fieldMatchPatterns = append(fieldMatchPatterns, fieldMatchPatternMember)
 		if fieldMatchPatternMember.Kind() == common.REST_MATCH_PATTERN {
-			this.invalidateExtraFieldMatchPatterns(fieldMatchPatterns)
+			b.invalidateExtraFieldMatchPatterns(fieldMatchPatterns)
 			break
 		}
 	}
 	return tree.CreateNodeList(fieldMatchPatterns...)
 }
 
-func (this *BallerinaParser) createMissingFieldMatchPattern() tree.STNode {
+func (b *BallerinaParser) createMissingFieldMatchPattern() tree.STNode {
 	fieldName := tree.CreateMissingToken(common.IDENTIFIER_TOKEN, nil)
 	colon := tree.CreateMissingToken(common.COLON_TOKEN, nil)
 	identifier := tree.CreateMissingToken(common.IDENTIFIER_TOKEN, nil)
@@ -11130,52 +11130,52 @@ func (this *BallerinaParser) createMissingFieldMatchPattern() tree.STNode {
 	return fieldMatchPatternMember
 }
 
-func (this *BallerinaParser) invalidateExtraFieldMatchPatterns(fieldMatchPatterns []tree.STNode) {
-	for !this.IsEndOfMappingMatchPattern() {
-		fieldMatchPatternRhs := this.parseFieldMatchPatternRhs()
+func (b *BallerinaParser) invalidateExtraFieldMatchPatterns(fieldMatchPatterns []tree.STNode) {
+	for !b.IsEndOfMappingMatchPattern() {
+		fieldMatchPatternRhs := b.parseFieldMatchPatternRhs()
 		if fieldMatchPatternRhs == nil {
 			break
 		}
-		fieldMatchPatternMember := this.parseFieldMatchPatternMember()
+		fieldMatchPatternMember := b.parseFieldMatchPatternMember()
 		if fieldMatchPatternMember == nil {
 			rhsToken, ok := fieldMatchPatternRhs.(tree.STToken)
 			if !ok {
 				panic("invalidateExtraFieldMatchPatterns: expected STToken")
 			}
-			this.updateLastNodeInListWithInvalidNode(fieldMatchPatterns, fieldMatchPatternRhs,
+			b.updateLastNodeInListWithInvalidNode(fieldMatchPatterns, fieldMatchPatternRhs,
 				&common.ERROR_INVALID_TOKEN, rhsToken.Text())
 		} else {
-			this.updateLastNodeInListWithInvalidNode(fieldMatchPatterns, fieldMatchPatternRhs, nil)
-			this.updateLastNodeInListWithInvalidNode(fieldMatchPatterns, fieldMatchPatternMember,
+			b.updateLastNodeInListWithInvalidNode(fieldMatchPatterns, fieldMatchPatternRhs, nil)
+			b.updateLastNodeInListWithInvalidNode(fieldMatchPatterns, fieldMatchPatternMember,
 				&common.ERROR_MATCH_PATTERN_AFTER_REST_MATCH_PATTERN)
 		}
 	}
 }
 
-func (this *BallerinaParser) parseFieldMatchPatternMember() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseFieldMatchPatternMember() tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.IDENTIFIER_TOKEN:
-		return this.ParseFieldMatchPattern()
+		return b.ParseFieldMatchPattern()
 	case common.ELLIPSIS_TOKEN:
-		return this.parseRestMatchPattern()
+		return b.parseRestMatchPattern()
 	case common.CLOSE_BRACE_TOKEN, common.EOF_TOKEN:
 		return nil
 	default:
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_FIELD_MATCH_PATTERNS_START)
-		return this.parseFieldMatchPatternMember()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_FIELD_MATCH_PATTERNS_START)
+		return b.parseFieldMatchPatternMember()
 	}
 }
 
-func (this *BallerinaParser) ParseFieldMatchPattern() tree.STNode {
-	fieldNameNode := this.parseVariableName()
-	colonToken := this.parseColon()
-	matchPattern := this.parseMatchPattern()
+func (b *BallerinaParser) ParseFieldMatchPattern() tree.STNode {
+	fieldNameNode := b.parseVariableName()
+	colonToken := b.parseColon()
+	matchPattern := b.parseMatchPattern()
 	return tree.CreateFieldMatchPatternNode(fieldNameNode, colonToken, matchPattern)
 }
 
-func (this *BallerinaParser) IsEndOfMappingMatchPattern() bool {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) IsEndOfMappingMatchPattern() bool {
+	switch b.peek().Kind() {
 	case common.CLOSE_BRACE_TOKEN, common.EOF_TOKEN:
 		return true
 	default:
@@ -11183,36 +11183,36 @@ func (this *BallerinaParser) IsEndOfMappingMatchPattern() bool {
 	}
 }
 
-func (this *BallerinaParser) parseFieldMatchPatternRhs() tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseFieldMatchPatternRhs() tree.STNode {
+	switch b.peek().Kind() {
 	case common.COMMA_TOKEN:
-		return this.parseComma()
+		return b.parseComma()
 	case common.CLOSE_BRACE_TOKEN, common.EOF_TOKEN:
 		return nil
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_FIELD_MATCH_PATTERN_MEMBER_RHS)
-		return this.parseFieldMatchPatternRhs()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_FIELD_MATCH_PATTERN_MEMBER_RHS)
+		return b.parseFieldMatchPatternRhs()
 	}
 }
 
-func (this *BallerinaParser) parseErrorMatchPatternOrConsPattern(typeRefOrConstExpr tree.STNode) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseErrorMatchPatternOrConsPattern(typeRefOrConstExpr tree.STNode) tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.OPEN_PAREN_TOKEN:
 		errorKeyword := tree.CreateMissingTokenWithDiagnostics(common.ERROR_KEYWORD,
 			common.PARSER_RULE_CONTEXT_ERROR_KEYWORD.GetErrorCode())
-		this.startContext(common.PARSER_RULE_CONTEXT_ERROR_MATCH_PATTERN)
-		return this.parseErrorMatchPatternWithErrorKeywordAndTypeRef(errorKeyword, typeRefOrConstExpr)
+		b.startContext(common.PARSER_RULE_CONTEXT_ERROR_MATCH_PATTERN)
+		return b.parseErrorMatchPatternWithErrorKeywordAndTypeRef(errorKeyword, typeRefOrConstExpr)
 	default:
-		if this.isMatchPatternEnd(this.peek().Kind()) {
+		if b.isMatchPatternEnd(b.peek().Kind()) {
 			return typeRefOrConstExpr
 		}
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_ERROR_MATCH_PATTERN_OR_CONST_PATTERN)
-		return this.parseErrorMatchPatternOrConsPattern(typeRefOrConstExpr)
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_ERROR_MATCH_PATTERN_OR_CONST_PATTERN)
+		return b.parseErrorMatchPatternOrConsPattern(typeRefOrConstExpr)
 	}
 }
 
-func (this *BallerinaParser) isMatchPatternEnd(tokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isMatchPatternEnd(tokenKind common.SyntaxKind) bool {
 	switch tokenKind {
 	case common.RIGHT_DOUBLE_ARROW_TOKEN,
 		common.COMMA_TOKEN,
@@ -11228,72 +11228,72 @@ func (this *BallerinaParser) isMatchPatternEnd(tokenKind common.SyntaxKind) bool
 	}
 }
 
-func (this *BallerinaParser) parseErrorMatchPattern() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_ERROR_MATCH_PATTERN)
-	errorKeyword := this.consume()
-	return this.parseErrorMatchPatternWithErrorKeyword(errorKeyword)
+func (b *BallerinaParser) parseErrorMatchPattern() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_ERROR_MATCH_PATTERN)
+	errorKeyword := b.consume()
+	return b.parseErrorMatchPatternWithErrorKeyword(errorKeyword)
 }
 
-func (this *BallerinaParser) parseErrorMatchPatternWithErrorKeyword(errorKeyword tree.STNode) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseErrorMatchPatternWithErrorKeyword(errorKeyword tree.STNode) tree.STNode {
+	nextToken := b.peek()
 	var typeRef tree.STNode
 	switch nextToken.Kind() {
 	case common.OPEN_PAREN_TOKEN:
 		typeRef = tree.CreateEmptyNode()
 	default:
-		if this.isPredeclaredIdentifier(nextToken.Kind()) {
-			typeRef = this.parseTypeReference()
+		if b.isPredeclaredIdentifier(nextToken.Kind()) {
+			typeRef = b.parseTypeReference()
 			break
 		}
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_ERROR_MATCH_PATTERN_ERROR_KEYWORD_RHS)
-		return this.parseErrorMatchPatternWithErrorKeyword(errorKeyword)
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_ERROR_MATCH_PATTERN_ERROR_KEYWORD_RHS)
+		return b.parseErrorMatchPatternWithErrorKeyword(errorKeyword)
 	}
-	return this.parseErrorMatchPatternWithErrorKeywordAndTypeRef(errorKeyword, typeRef)
+	return b.parseErrorMatchPatternWithErrorKeywordAndTypeRef(errorKeyword, typeRef)
 }
 
-func (this *BallerinaParser) parseErrorMatchPatternWithErrorKeywordAndTypeRef(errorKeyword tree.STNode, typeRef tree.STNode) tree.STNode {
-	openParenthesisToken := this.parseOpenParenthesis()
-	argListMatchPatternNode := this.parseErrorArgListMatchPatterns()
-	closeParenthesisToken := this.parseCloseParenthesis()
-	this.endContext()
+func (b *BallerinaParser) parseErrorMatchPatternWithErrorKeywordAndTypeRef(errorKeyword tree.STNode, typeRef tree.STNode) tree.STNode {
+	openParenthesisToken := b.parseOpenParenthesis()
+	argListMatchPatternNode := b.parseErrorArgListMatchPatterns()
+	closeParenthesisToken := b.parseCloseParenthesis()
+	b.endContext()
 	return tree.CreateErrorMatchPatternNode(errorKeyword, typeRef, openParenthesisToken,
 		argListMatchPatternNode, closeParenthesisToken)
 }
 
-func (this *BallerinaParser) parseErrorArgListMatchPatterns() tree.STNode {
+func (b *BallerinaParser) parseErrorArgListMatchPatterns() tree.STNode {
 	var argListMatchPatterns []tree.STNode
-	if this.isEndOfErrorFieldMatchPatterns() {
+	if b.isEndOfErrorFieldMatchPatterns() {
 		return tree.CreateNodeList(argListMatchPatterns...)
 	}
-	this.startContext(common.PARSER_RULE_CONTEXT_ERROR_ARG_LIST_MATCH_PATTERN_FIRST_ARG)
-	firstArg := this.parseErrorArgListMatchPattern(common.PARSER_RULE_CONTEXT_ERROR_ARG_LIST_MATCH_PATTERN_START)
-	this.endContext()
-	if this.isSimpleMatchPattern(firstArg.Kind()) {
+	b.startContext(common.PARSER_RULE_CONTEXT_ERROR_ARG_LIST_MATCH_PATTERN_FIRST_ARG)
+	firstArg := b.parseErrorArgListMatchPattern(common.PARSER_RULE_CONTEXT_ERROR_ARG_LIST_MATCH_PATTERN_START)
+	b.endContext()
+	if b.isSimpleMatchPattern(firstArg.Kind()) {
 		argListMatchPatterns = append(argListMatchPatterns, firstArg)
-		argEnd := this.parseErrorArgListMatchPatternEnd(common.PARSER_RULE_CONTEXT_ERROR_MESSAGE_MATCH_PATTERN_END)
+		argEnd := b.parseErrorArgListMatchPatternEnd(common.PARSER_RULE_CONTEXT_ERROR_MESSAGE_MATCH_PATTERN_END)
 		if argEnd != nil {
-			secondArg := this.parseErrorArgListMatchPattern(common.PARSER_RULE_CONTEXT_ERROR_MESSAGE_MATCH_PATTERN_RHS)
-			if this.isValidSecondArgMatchPattern(secondArg.Kind()) {
+			secondArg := b.parseErrorArgListMatchPattern(common.PARSER_RULE_CONTEXT_ERROR_MESSAGE_MATCH_PATTERN_RHS)
+			if b.isValidSecondArgMatchPattern(secondArg.Kind()) {
 				argListMatchPatterns = append(argListMatchPatterns, argEnd)
 				argListMatchPatterns = append(argListMatchPatterns, secondArg)
 			} else {
-				this.updateLastNodeInListWithInvalidNode(argListMatchPatterns, argEnd, nil)
-				this.updateLastNodeInListWithInvalidNode(argListMatchPatterns, secondArg,
+				b.updateLastNodeInListWithInvalidNode(argListMatchPatterns, argEnd, nil)
+				b.updateLastNodeInListWithInvalidNode(argListMatchPatterns, secondArg,
 					&common.ERROR_MATCH_PATTERN_NOT_ALLOWED)
 			}
 		}
 	} else {
 		if (firstArg.Kind() != common.NAMED_ARG_MATCH_PATTERN) && (firstArg.Kind() != common.REST_MATCH_PATTERN) {
-			this.addInvalidNodeToNextToken(firstArg, &common.ERROR_MATCH_PATTERN_NOT_ALLOWED)
+			b.addInvalidNodeToNextToken(firstArg, &common.ERROR_MATCH_PATTERN_NOT_ALLOWED)
 		} else {
 			argListMatchPatterns = append(argListMatchPatterns, firstArg)
 		}
 	}
-	argListMatchPatterns = this.parseErrorFieldMatchPatterns(argListMatchPatterns)
+	argListMatchPatterns = b.parseErrorFieldMatchPatterns(argListMatchPatterns)
 	return tree.CreateNodeList(argListMatchPatterns...)
 }
 
-func (this *BallerinaParser) isSimpleMatchPattern(matchPatternKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isSimpleMatchPattern(matchPatternKind common.SyntaxKind) bool {
 	switch matchPatternKind {
 	case common.IDENTIFIER_TOKEN,
 		common.SIMPLE_NAME_REFERENCE,
@@ -11311,66 +11311,66 @@ func (this *BallerinaParser) isSimpleMatchPattern(matchPatternKind common.Syntax
 	}
 }
 
-func (this *BallerinaParser) isValidSecondArgMatchPattern(syntaxKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isValidSecondArgMatchPattern(syntaxKind common.SyntaxKind) bool {
 	switch syntaxKind {
 	case common.ERROR_MATCH_PATTERN,
 		common.NAMED_ARG_MATCH_PATTERN,
 		common.REST_MATCH_PATTERN:
 		return true
 	default:
-		return this.isSimpleMatchPattern(syntaxKind)
+		return b.isSimpleMatchPattern(syntaxKind)
 	}
 }
 
 // Return modified argListMatchPatterns
-func (this *BallerinaParser) parseErrorFieldMatchPatterns(argListMatchPatterns []tree.STNode) []tree.STNode {
+func (b *BallerinaParser) parseErrorFieldMatchPatterns(argListMatchPatterns []tree.STNode) []tree.STNode {
 	lastValidArgKind := common.NAMED_ARG_MATCH_PATTERN
-	for !this.isEndOfErrorFieldMatchPatterns() {
-		argEnd := this.parseErrorArgListMatchPatternEnd(common.PARSER_RULE_CONTEXT_ERROR_FIELD_MATCH_PATTERN_RHS)
+	for !b.isEndOfErrorFieldMatchPatterns() {
+		argEnd := b.parseErrorArgListMatchPatternEnd(common.PARSER_RULE_CONTEXT_ERROR_FIELD_MATCH_PATTERN_RHS)
 		if argEnd == nil {
 			break
 		}
-		currentArg := this.parseErrorArgListMatchPattern(common.PARSER_RULE_CONTEXT_ERROR_FIELD_MATCH_PATTERN)
-		errorCode := this.validateErrorFieldMatchPatternOrder(lastValidArgKind, currentArg.Kind())
+		currentArg := b.parseErrorArgListMatchPattern(common.PARSER_RULE_CONTEXT_ERROR_FIELD_MATCH_PATTERN)
+		errorCode := b.validateErrorFieldMatchPatternOrder(lastValidArgKind, currentArg.Kind())
 		if errorCode == nil {
 			argListMatchPatterns = append(argListMatchPatterns, argEnd)
 			argListMatchPatterns = append(argListMatchPatterns, currentArg)
 			lastValidArgKind = currentArg.Kind()
 		} else if len(argListMatchPatterns) == 0 {
-			this.addInvalidNodeToNextToken(argEnd, nil)
-			this.addInvalidNodeToNextToken(currentArg, errorCode)
+			b.addInvalidNodeToNextToken(argEnd, nil)
+			b.addInvalidNodeToNextToken(currentArg, errorCode)
 		} else {
-			argListMatchPatterns = this.updateLastNodeInListWithInvalidNode(argListMatchPatterns, argEnd, nil)
-			argListMatchPatterns = this.updateLastNodeInListWithInvalidNode(argListMatchPatterns, currentArg, errorCode)
+			argListMatchPatterns = b.updateLastNodeInListWithInvalidNode(argListMatchPatterns, argEnd, nil)
+			argListMatchPatterns = b.updateLastNodeInListWithInvalidNode(argListMatchPatterns, currentArg, errorCode)
 		}
 	}
 	return argListMatchPatterns
 }
 
-func (this *BallerinaParser) isEndOfErrorFieldMatchPatterns() bool {
-	return this.isEndOfErrorFieldBindingPatterns()
+func (b *BallerinaParser) isEndOfErrorFieldMatchPatterns() bool {
+	return b.isEndOfErrorFieldBindingPatterns()
 }
 
-func (this *BallerinaParser) parseErrorArgListMatchPatternEnd(currentCtx common.ParserRuleContext) tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseErrorArgListMatchPatternEnd(currentCtx common.ParserRuleContext) tree.STNode {
+	switch b.peek().Kind() {
 	case common.COMMA_TOKEN:
-		return this.consume()
+		return b.consume()
 	case common.CLOSE_PAREN_TOKEN:
 		return nil
 	default:
-		this.recoverWithBlockContext(this.peek(), currentCtx)
-		return this.parseErrorArgListMatchPatternEnd(currentCtx)
+		b.recoverWithBlockContext(b.peek(), currentCtx)
+		return b.parseErrorArgListMatchPatternEnd(currentCtx)
 	}
 }
 
-func (this *BallerinaParser) parseErrorArgListMatchPattern(context common.ParserRuleContext) tree.STNode {
-	nextToken := this.peek()
-	if this.isPredeclaredIdentifier(nextToken.Kind()) {
-		return this.parseNamedArgOrSimpleMatchPattern()
+func (b *BallerinaParser) parseErrorArgListMatchPattern(context common.ParserRuleContext) tree.STNode {
+	nextToken := b.peek()
+	if b.isPredeclaredIdentifier(nextToken.Kind()) {
+		return b.parseNamedArgOrSimpleMatchPattern()
 	}
 	switch nextToken.Kind() {
 	case common.ELLIPSIS_TOKEN:
-		return this.parseRestMatchPattern()
+		return b.parseRestMatchPattern()
 	case common.OPEN_PAREN_TOKEN,
 		common.NULL_KEYWORD,
 		common.TRUE_KEYWORD,
@@ -11385,41 +11385,41 @@ func (this *BallerinaParser) parseErrorArgListMatchPattern(context common.Parser
 		common.OPEN_BRACKET_TOKEN,
 		common.OPEN_BRACE_TOKEN,
 		common.ERROR_KEYWORD:
-		return this.parseMatchPattern()
+		return b.parseMatchPattern()
 	case common.VAR_KEYWORD:
-		varType := CreateBuiltinSimpleNameReference(this.consume())
-		variableName := this.createCaptureOrWildcardBP(this.parseVariableName())
+		varType := CreateBuiltinSimpleNameReference(b.consume())
+		variableName := b.createCaptureOrWildcardBP(b.parseVariableName())
 		return tree.CreateTypedBindingPatternNode(varType, variableName)
 	case common.CLOSE_PAREN_TOKEN:
 		return tree.CreateMissingTokenWithDiagnostics(common.IDENTIFIER_TOKEN,
 			&common.ERROR_MISSING_MATCH_PATTERN)
 	default:
-		this.recoverWithBlockContext(nextToken, context)
-		return this.parseErrorArgListMatchPattern(context)
+		b.recoverWithBlockContext(nextToken, context)
+		return b.parseErrorArgListMatchPattern(context)
 	}
 }
 
-func (this *BallerinaParser) parseNamedArgOrSimpleMatchPattern() tree.STNode {
-	constRefExpr := this.parseQualifiedIdentifier(common.PARSER_RULE_CONTEXT_MATCH_PATTERN)
-	if (constRefExpr.Kind() == common.QUALIFIED_NAME_REFERENCE) || (this.peek().Kind() != common.EQUAL_TOKEN) {
+func (b *BallerinaParser) parseNamedArgOrSimpleMatchPattern() tree.STNode {
+	constRefExpr := b.parseQualifiedIdentifier(common.PARSER_RULE_CONTEXT_MATCH_PATTERN)
+	if (constRefExpr.Kind() == common.QUALIFIED_NAME_REFERENCE) || (b.peek().Kind() != common.EQUAL_TOKEN) {
 		return constRefExpr
 	}
 	simpleNameNode, ok := constRefExpr.(*tree.STSimpleNameReferenceNode)
 	if !ok {
 		panic("parseNamedArgOrSimpleMatchPattern: expected STSimpleNameReferenceNode")
 	}
-	return this.parseNamedArgMatchPattern(simpleNameNode.Name)
+	return b.parseNamedArgMatchPattern(simpleNameNode.Name)
 }
 
-func (this *BallerinaParser) parseNamedArgMatchPattern(identifier tree.STNode) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_NAMED_ARG_MATCH_PATTERN)
-	equalToken := this.parseAssignOp()
-	matchPattern := this.parseMatchPattern()
-	this.endContext()
+func (b *BallerinaParser) parseNamedArgMatchPattern(identifier tree.STNode) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_NAMED_ARG_MATCH_PATTERN)
+	equalToken := b.parseAssignOp()
+	matchPattern := b.parseMatchPattern()
+	b.endContext()
 	return tree.CreateNamedArgMatchPatternNode(identifier, equalToken, matchPattern)
 }
 
-func (this *BallerinaParser) validateErrorFieldMatchPatternOrder(prevArgKind common.SyntaxKind, currentArgKind common.SyntaxKind) *common.DiagnosticErrorCode {
+func (b *BallerinaParser) validateErrorFieldMatchPatternOrder(prevArgKind common.SyntaxKind, currentArgKind common.SyntaxKind) *common.DiagnosticErrorCode {
 	switch currentArgKind {
 	case common.NAMED_ARG_MATCH_PATTERN,
 		common.REST_MATCH_PATTERN:
@@ -11432,21 +11432,21 @@ func (this *BallerinaParser) validateErrorFieldMatchPatternOrder(prevArgKind com
 	}
 }
 
-func (this *BallerinaParser) parseMarkdownDocumentation() tree.STNode {
+func (b *BallerinaParser) parseMarkdownDocumentation() tree.STNode {
 	markdownDocLineList := make([]tree.STNode, 0)
-	nextToken := this.peek()
+	nextToken := b.peek()
 	for nextToken.Kind() == common.DOCUMENTATION_STRING {
-		documentationString := this.consume()
-		parsedDocLines := this.parseDocumentationString(documentationString)
-		markdownDocLineList = this.appendParsedDocumentationLines(markdownDocLineList, parsedDocLines)
-		nextToken = this.peek()
+		documentationString := b.consume()
+		parsedDocLines := b.parseDocumentationString(documentationString)
+		markdownDocLineList = b.appendParsedDocumentationLines(markdownDocLineList, parsedDocLines)
+		nextToken = b.peek()
 	}
 	markdownDocLines := tree.CreateNodeList(markdownDocLineList...)
 	return tree.CreateMarkdownDocumentationNode(markdownDocLines)
 }
 
-func (this *BallerinaParser) parseDocumentationString(documentationStringToken tree.STToken) tree.STNode {
-	leadingTriviaList := this.getLeadingTriviaList(documentationStringToken.LeadingMinutiae())
+func (b *BallerinaParser) parseDocumentationString(documentationStringToken tree.STToken) tree.STNode {
+	leadingTriviaList := b.getLeadingTriviaList(documentationStringToken.LeadingMinutiae())
 	diagnostics := documentationStringToken.Diagnostics()
 
 	charReader := text.CharReaderFromText(documentationStringToken.Text())
@@ -11457,7 +11457,7 @@ func (this *BallerinaParser) parseDocumentationString(documentationStringToken t
 	return documentationParser.Parse()
 }
 
-func (this *BallerinaParser) getLeadingTriviaList(leadingMinutiaeNode tree.STNode) []tree.STNode {
+func (b *BallerinaParser) getLeadingTriviaList(leadingMinutiaeNode tree.STNode) []tree.STNode {
 	leadingTriviaList := make([]tree.STNode, 0)
 	bucketCount := leadingMinutiaeNode.BucketCount()
 	i := 0
@@ -11467,7 +11467,7 @@ func (this *BallerinaParser) getLeadingTriviaList(leadingMinutiaeNode tree.STNod
 	return leadingTriviaList
 }
 
-func (this *BallerinaParser) appendParsedDocumentationLines(markdownDocLineList []tree.STNode, parsedDocLines tree.STNode) []tree.STNode {
+func (b *BallerinaParser) appendParsedDocumentationLines(markdownDocLineList []tree.STNode, parsedDocLines tree.STNode) []tree.STNode {
 	bucketCount := parsedDocLines.BucketCount()
 	for i := range bucketCount {
 		markdownDocLine := parsedDocLines.ChildInBucket(i)
@@ -11476,47 +11476,47 @@ func (this *BallerinaParser) appendParsedDocumentationLines(markdownDocLineList 
 	return markdownDocLineList
 }
 
-func (this *BallerinaParser) parseStmtStartsWithTypeOrExpr(annots tree.STNode, qualifiers []tree.STNode) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_AMBIGUOUS_STMT)
-	typeOrExpr := this.parseTypedBindingPatternOrExprWithQualifiers(qualifiers, true)
-	return this.parseStmtStartsWithTypedBPOrExprRhs(annots, typeOrExpr)
+func (b *BallerinaParser) parseStmtStartsWithTypeOrExpr(annots tree.STNode, qualifiers []tree.STNode) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_AMBIGUOUS_STMT)
+	typeOrExpr := b.parseTypedBindingPatternOrExprWithQualifiers(qualifiers, true)
+	return b.parseStmtStartsWithTypedBPOrExprRhs(annots, typeOrExpr)
 }
 
-func (this *BallerinaParser) parseStmtStartsWithTypedBPOrExprRhs(annots tree.STNode, typedBindingPatternOrExpr tree.STNode) tree.STNode {
+func (b *BallerinaParser) parseStmtStartsWithTypedBPOrExprRhs(annots tree.STNode, typedBindingPatternOrExpr tree.STNode) tree.STNode {
 	if typedBindingPatternOrExpr.Kind() == common.TYPED_BINDING_PATTERN {
-		this.switchContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
-		res, _ := this.parseVarDeclRhs(annots, nil, typedBindingPatternOrExpr, false)
+		b.switchContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+		res, _ := b.parseVarDeclRhs(annots, nil, typedBindingPatternOrExpr, false)
 		return res
 	}
-	expr := this.getExpression(typedBindingPatternOrExpr)
-	expr = this.getExpression(this.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, expr, false, true))
-	return this.parseStatementStartWithExprRhs(expr)
+	expr := b.getExpression(typedBindingPatternOrExpr)
+	expr = b.getExpression(b.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, expr, false, true))
+	return b.parseStatementStartWithExprRhs(expr)
 }
 
-func (this *BallerinaParser) parseTypedBindingPatternOrExpr(allowAssignment bool) tree.STNode {
+func (b *BallerinaParser) parseTypedBindingPatternOrExpr(allowAssignment bool) tree.STNode {
 	typeDescQualifiers := make([]tree.STNode, 0)
-	return this.parseTypedBindingPatternOrExprWithQualifiers(typeDescQualifiers, allowAssignment)
+	return b.parseTypedBindingPatternOrExprWithQualifiers(typeDescQualifiers, allowAssignment)
 }
 
-func (this *BallerinaParser) parseTypedBindingPatternOrExprWithQualifiers(qualifiers []tree.STNode, allowAssignment bool) tree.STNode {
-	qualifiers = this.parseTypeDescQualifiers(qualifiers)
-	nextToken := this.peek()
+func (b *BallerinaParser) parseTypedBindingPatternOrExprWithQualifiers(qualifiers []tree.STNode, allowAssignment bool) tree.STNode {
+	qualifiers = b.parseTypeDescQualifiers(qualifiers)
+	nextToken := b.peek()
 	var typeOrExpr tree.STNode
-	if this.isPredeclaredIdentifier(nextToken.Kind()) {
-		this.reportInvalidQualifierList(qualifiers)
-		typeOrExpr = this.parseQualifiedIdentifier(common.PARSER_RULE_CONTEXT_TYPE_NAME_OR_VAR_NAME)
-		return this.parseTypedBindingPatternOrExprRhs(typeOrExpr, allowAssignment)
+	if b.isPredeclaredIdentifier(nextToken.Kind()) {
+		b.reportInvalidQualifierList(qualifiers)
+		typeOrExpr = b.parseQualifiedIdentifier(common.PARSER_RULE_CONTEXT_TYPE_NAME_OR_VAR_NAME)
+		return b.parseTypedBindingPatternOrExprRhs(typeOrExpr, allowAssignment)
 	}
 	switch nextToken.Kind() {
 	case common.OPEN_PAREN_TOKEN:
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseTypedBPOrExprStartsWithOpenParenthesis()
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseTypedBPOrExprStartsWithOpenParenthesis()
 	case common.FUNCTION_KEYWORD:
-		return this.parseAnonFuncExprOrTypedBPWithFuncType(qualifiers)
+		return b.parseAnonFuncExprOrTypedBPWithFuncType(qualifiers)
 	case common.OPEN_BRACKET_TOKEN:
-		this.reportInvalidQualifierList(qualifiers)
-		typeOrExpr = this.parseTupleTypeDescOrListConstructor(tree.CreateEmptyNodeList())
-		return this.parseTypedBindingPatternOrExprRhs(typeOrExpr, allowAssignment)
+		b.reportInvalidQualifierList(qualifiers)
+		typeOrExpr = b.parseTupleTypeDescOrListConstructor(tree.CreateEmptyNodeList())
+		return b.parseTypedBindingPatternOrExprRhs(typeOrExpr, allowAssignment)
 	case common.DECIMAL_INTEGER_LITERAL_TOKEN,
 		common.HEX_INTEGER_LITERAL_TOKEN,
 		common.STRING_LITERAL_TOKEN,
@@ -11525,165 +11525,165 @@ func (this *BallerinaParser) parseTypedBindingPatternOrExprWithQualifiers(qualif
 		common.FALSE_KEYWORD,
 		common.DECIMAL_FLOATING_POINT_LITERAL_TOKEN,
 		common.HEX_FLOATING_POINT_LITERAL_TOKEN:
-		this.reportInvalidQualifierList(qualifiers)
-		basicLiteral := this.parseBasicLiteral()
-		return this.parseTypedBindingPatternOrExprRhs(basicLiteral, allowAssignment)
+		b.reportInvalidQualifierList(qualifiers)
+		basicLiteral := b.parseBasicLiteral()
+		return b.parseTypedBindingPatternOrExprRhs(basicLiteral, allowAssignment)
 	default:
-		if this.isValidExpressionStart(nextToken.Kind(), 1) {
-			this.reportInvalidQualifierList(qualifiers)
-			return this.parseActionOrExpressionInLhs(tree.CreateEmptyNodeList())
+		if b.isValidExpressionStart(nextToken.Kind(), 1) {
+			b.reportInvalidQualifierList(qualifiers)
+			return b.parseActionOrExpressionInLhs(tree.CreateEmptyNodeList())
 		}
-		return this.parseTypedBindingPatternInner(qualifiers, common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+		return b.parseTypedBindingPatternInner(qualifiers, common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
 	}
 }
 
-func (this *BallerinaParser) parseTypedBindingPatternOrExprRhs(typeOrExpr tree.STNode, allowAssignment bool) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseTypedBindingPatternOrExprRhs(typeOrExpr tree.STNode, allowAssignment bool) tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.PIPE_TOKEN, common.BITWISE_AND_TOKEN:
-		nextNextToken := this.peekN(2)
+		nextNextToken := b.peekN(2)
 		if nextNextToken.Kind() == common.EQUAL_TOKEN {
 			return typeOrExpr
 		}
-		pipeOrAndToken := this.parseBinaryOperator()
-		rhsTypedBPOrExpr := this.parseTypedBindingPatternOrExpr(allowAssignment)
+		pipeOrAndToken := b.parseBinaryOperator()
+		rhsTypedBPOrExpr := b.parseTypedBindingPatternOrExpr(allowAssignment)
 		if rhsTypedBPOrExpr.Kind() == common.TYPED_BINDING_PATTERN {
 			typedBP, ok := rhsTypedBPOrExpr.(*tree.STTypedBindingPatternNode)
 			if !ok {
 				panic("expected STTypedBindingPatternNode")
 			}
-			typeOrExpr = this.getTypeDescFromExpr(typeOrExpr)
-			newTypeDesc := this.mergeTypes(typeOrExpr, pipeOrAndToken, typedBP.TypeDescriptor)
+			typeOrExpr = b.getTypeDescFromExpr(typeOrExpr)
+			newTypeDesc := b.mergeTypes(typeOrExpr, pipeOrAndToken, typedBP.TypeDescriptor)
 			return tree.CreateTypedBindingPatternNode(newTypeDesc, typedBP.BindingPattern)
 		}
-		if this.peek().Kind() == common.EQUAL_TOKEN {
-			return this.createCaptureBPWithMissingVarName(typeOrExpr, pipeOrAndToken, rhsTypedBPOrExpr)
+		if b.peek().Kind() == common.EQUAL_TOKEN {
+			return b.createCaptureBPWithMissingVarName(typeOrExpr, pipeOrAndToken, rhsTypedBPOrExpr)
 		}
 		return tree.CreateBinaryExpressionNode(common.BINARY_EXPRESSION, typeOrExpr,
 			pipeOrAndToken, rhsTypedBPOrExpr)
 	case common.SEMICOLON_TOKEN:
-		if this.isExpression(typeOrExpr.Kind()) {
+		if b.isExpression(typeOrExpr.Kind()) {
 			return typeOrExpr
 		}
-		if this.isDefiniteTypeDesc(typeOrExpr.Kind()) || (!this.isAllBasicLiterals(typeOrExpr)) {
-			typeDesc := this.getTypeDescFromExpr(typeOrExpr)
-			return this.parseTypeBindingPatternStartsWithAmbiguousNode(typeDesc)
+		if b.isDefiniteTypeDesc(typeOrExpr.Kind()) || (!b.isAllBasicLiterals(typeOrExpr)) {
+			typeDesc := b.getTypeDescFromExpr(typeOrExpr)
+			return b.parseTypeBindingPatternStartsWithAmbiguousNode(typeDesc)
 		}
 		return typeOrExpr
 	case common.IDENTIFIER_TOKEN, common.QUESTION_MARK_TOKEN:
-		if this.isAmbiguous(typeOrExpr) || this.isDefiniteTypeDesc(typeOrExpr.Kind()) {
-			typeDesc := this.getTypeDescFromExpr(typeOrExpr)
-			return this.parseTypeBindingPatternStartsWithAmbiguousNode(typeDesc)
+		if b.isAmbiguous(typeOrExpr) || b.isDefiniteTypeDesc(typeOrExpr.Kind()) {
+			typeDesc := b.getTypeDescFromExpr(typeOrExpr)
+			return b.parseTypeBindingPatternStartsWithAmbiguousNode(typeDesc)
 		}
 		return typeOrExpr
 	case common.EQUAL_TOKEN:
 		return typeOrExpr
 	case common.OPEN_BRACKET_TOKEN:
-		return this.parseTypedBindingPatternOrMemberAccess(typeOrExpr, false, allowAssignment,
+		return b.parseTypedBindingPatternOrMemberAccess(typeOrExpr, false, allowAssignment,
 			common.PARSER_RULE_CONTEXT_AMBIGUOUS_STMT)
 	case common.OPEN_BRACE_TOKEN, common.ERROR_KEYWORD:
-		typeDesc := this.getTypeDescFromExpr(typeOrExpr)
-		return this.parseTypeBindingPatternStartsWithAmbiguousNode(typeDesc)
+		typeDesc := b.getTypeDescFromExpr(typeOrExpr)
+		return b.parseTypeBindingPatternStartsWithAmbiguousNode(typeDesc)
 	default:
-		if this.isCompoundAssignment(nextToken.Kind()) {
+		if b.isCompoundAssignment(nextToken.Kind()) {
 			return typeOrExpr
 		}
-		if this.isValidExprRhsStart(nextToken.Kind(), typeOrExpr.Kind()) {
+		if b.isValidExprRhsStart(nextToken.Kind(), typeOrExpr.Kind()) {
 			return typeOrExpr
 		}
-		token := this.peek()
+		token := b.peek()
 		typeOrExprKind := typeOrExpr.Kind()
 		if (typeOrExprKind == common.QUALIFIED_NAME_REFERENCE) || (typeOrExprKind == common.SIMPLE_NAME_REFERENCE) {
-			this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_BINDING_PATTERN_OR_VAR_REF_RHS)
+			b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_BINDING_PATTERN_OR_VAR_REF_RHS)
 		} else {
-			this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_BINDING_PATTERN_OR_EXPR_RHS)
+			b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_BINDING_PATTERN_OR_EXPR_RHS)
 		}
-		return this.parseTypedBindingPatternOrExprRhs(typeOrExpr, allowAssignment)
+		return b.parseTypedBindingPatternOrExprRhs(typeOrExpr, allowAssignment)
 	}
 }
 
-func (this *BallerinaParser) createCaptureBPWithMissingVarName(lhsType tree.STNode, separatorToken tree.STNode, rhsType tree.STNode) tree.STNode {
-	lhsType = this.getTypeDescFromExpr(lhsType)
-	rhsType = this.getTypeDescFromExpr(rhsType)
-	newTypeDesc := this.mergeTypes(lhsType, separatorToken, rhsType)
+func (b *BallerinaParser) createCaptureBPWithMissingVarName(lhsType tree.STNode, separatorToken tree.STNode, rhsType tree.STNode) tree.STNode {
+	lhsType = b.getTypeDescFromExpr(lhsType)
+	rhsType = b.getTypeDescFromExpr(rhsType)
+	newTypeDesc := b.mergeTypes(lhsType, separatorToken, rhsType)
 	identifier := tree.CreateMissingTokenWithDiagnosticsFromParserRules(common.IDENTIFIER_TOKEN,
 		common.PARSER_RULE_CONTEXT_VARIABLE_NAME)
 	captureBP := tree.CreateCaptureBindingPatternNode(identifier)
 	return tree.CreateTypedBindingPatternNode(newTypeDesc, captureBP)
 }
 
-func (this *BallerinaParser) parseTypeBindingPatternStartsWithAmbiguousNode(typeDesc tree.STNode) tree.STNode {
-	typeDesc = this.parseComplexTypeDescriptor(typeDesc, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN, true)
-	return this.parseTypedBindingPatternTypeRhs(typeDesc, common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+func (b *BallerinaParser) parseTypeBindingPatternStartsWithAmbiguousNode(typeDesc tree.STNode) tree.STNode {
+	typeDesc = b.parseComplexTypeDescriptor(typeDesc, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN, true)
+	return b.parseTypedBindingPatternTypeRhs(typeDesc, common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
 }
 
-func (this *BallerinaParser) parseTypedBPOrExprStartsWithOpenParenthesis() tree.STNode {
-	exprOrTypeDesc := this.parseTypedDescOrExprStartsWithOpenParenthesis()
-	if this.isDefiniteTypeDesc(exprOrTypeDesc.Kind()) {
-		return this.parseTypeBindingPatternStartsWithAmbiguousNode(exprOrTypeDesc)
+func (b *BallerinaParser) parseTypedBPOrExprStartsWithOpenParenthesis() tree.STNode {
+	exprOrTypeDesc := b.parseTypedDescOrExprStartsWithOpenParenthesis()
+	if b.isDefiniteTypeDesc(exprOrTypeDesc.Kind()) {
+		return b.parseTypeBindingPatternStartsWithAmbiguousNode(exprOrTypeDesc)
 	}
-	return this.parseTypedBindingPatternOrExprRhs(exprOrTypeDesc, false)
+	return b.parseTypedBindingPatternOrExprRhs(exprOrTypeDesc, false)
 }
 
-func (this *BallerinaParser) isDefiniteTypeDesc(kind common.SyntaxKind) bool {
+func (b *BallerinaParser) isDefiniteTypeDesc(kind common.SyntaxKind) bool {
 	return ((kind.CompareTo(common.RECORD_TYPE_DESC) >= 0) && (kind.CompareTo(common.FUTURE_TYPE_DESC) <= 0))
 }
 
-func (this *BallerinaParser) isDefiniteExpr(kind common.SyntaxKind) bool {
+func (b *BallerinaParser) isDefiniteExpr(kind common.SyntaxKind) bool {
 	if (kind == common.QUALIFIED_NAME_REFERENCE) || (kind == common.SIMPLE_NAME_REFERENCE) {
 		return false
 	}
 	return ((kind.CompareTo(common.BINARY_EXPRESSION) >= 0) && (kind.CompareTo(common.ERROR_CONSTRUCTOR) <= 0))
 }
 
-func (this *BallerinaParser) isDefiniteAction(kind common.SyntaxKind) bool {
+func (b *BallerinaParser) isDefiniteAction(kind common.SyntaxKind) bool {
 	return ((kind.CompareTo(common.REMOTE_METHOD_CALL_ACTION) >= 0) && (kind.CompareTo(common.CLIENT_RESOURCE_ACCESS_ACTION) <= 0))
 }
 
-func (this *BallerinaParser) parseTypedDescOrExprStartsWithOpenParenthesis() tree.STNode {
-	openParen := this.parseOpenParenthesis()
-	nextToken := this.peek()
+func (b *BallerinaParser) parseTypedDescOrExprStartsWithOpenParenthesis() tree.STNode {
+	openParen := b.parseOpenParenthesis()
+	nextToken := b.peek()
 	if nextToken.Kind() == common.CLOSE_PAREN_TOKEN {
-		closeParen := this.parseCloseParenthesis()
-		return this.parseTypeOrExprStartWithEmptyParenthesis(openParen, closeParen)
+		closeParen := b.parseCloseParenthesis()
+		return b.parseTypeOrExprStartWithEmptyParenthesis(openParen, closeParen)
 	}
-	typeOrExpr := this.parseTypeDescOrExpr()
-	if this.isAction(typeOrExpr) {
-		closeParen := this.parseCloseParenthesis()
+	typeOrExpr := b.parseTypeDescOrExpr()
+	if b.isAction(typeOrExpr) {
+		closeParen := b.parseCloseParenthesis()
 		return tree.CreateBracedExpressionNode(common.BRACED_ACTION, openParen, typeOrExpr,
 			closeParen)
 	}
-	if this.isExpression(typeOrExpr.Kind()) {
-		this.startContext(common.PARSER_RULE_CONTEXT_BRACED_EXPR_OR_ANON_FUNC_PARAMS)
-		return this.parseBracedExprOrAnonFuncParamRhs(openParen, typeOrExpr, false)
+	if b.isExpression(typeOrExpr.Kind()) {
+		b.startContext(common.PARSER_RULE_CONTEXT_BRACED_EXPR_OR_ANON_FUNC_PARAMS)
+		return b.parseBracedExprOrAnonFuncParamRhs(openParen, typeOrExpr, false)
 	}
-	typeDescNode := this.getTypeDescFromExpr(typeOrExpr)
-	typeDescNode = this.parseComplexTypeDescriptor(typeDescNode, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_PARENTHESIS, false)
-	closeParen := this.parseCloseParenthesis()
+	typeDescNode := b.getTypeDescFromExpr(typeOrExpr)
+	typeDescNode = b.parseComplexTypeDescriptor(typeDescNode, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_PARENTHESIS, false)
+	closeParen := b.parseCloseParenthesis()
 	return tree.CreateParenthesisedTypeDescriptorNode(openParen, typeDescNode, closeParen)
 }
 
-func (this *BallerinaParser) parseTypeDescOrExpr() tree.STNode {
-	return this.parseTypeDescOrExprWithQualifiers(nil)
+func (b *BallerinaParser) parseTypeDescOrExpr() tree.STNode {
+	return b.parseTypeDescOrExprWithQualifiers(nil)
 }
 
-func (this *BallerinaParser) parseTypeDescOrExprWithQualifiers(qualifiers []tree.STNode) tree.STNode {
-	qualifiers = this.parseTypeDescQualifiers(qualifiers)
-	nextToken := this.peek()
+func (b *BallerinaParser) parseTypeDescOrExprWithQualifiers(qualifiers []tree.STNode) tree.STNode {
+	qualifiers = b.parseTypeDescQualifiers(qualifiers)
+	nextToken := b.peek()
 	var typeOrExpr tree.STNode
 	switch nextToken.Kind() {
 	case common.OPEN_PAREN_TOKEN:
-		this.reportInvalidQualifierList(qualifiers)
-		typeOrExpr = this.parseTypedDescOrExprStartsWithOpenParenthesis()
+		b.reportInvalidQualifierList(qualifiers)
+		typeOrExpr = b.parseTypedDescOrExprStartsWithOpenParenthesis()
 	case common.FUNCTION_KEYWORD:
-		typeOrExpr = this.parseAnonFuncExprOrFuncTypeDesc(qualifiers)
+		typeOrExpr = b.parseAnonFuncExprOrFuncTypeDesc(qualifiers)
 	case common.IDENTIFIER_TOKEN:
-		this.reportInvalidQualifierList(qualifiers)
-		typeOrExpr = this.parseQualifiedIdentifier(common.PARSER_RULE_CONTEXT_TYPE_NAME_OR_VAR_NAME)
-		return this.parseTypeDescOrExprRhs(typeOrExpr)
+		b.reportInvalidQualifierList(qualifiers)
+		typeOrExpr = b.parseQualifiedIdentifier(common.PARSER_RULE_CONTEXT_TYPE_NAME_OR_VAR_NAME)
+		return b.parseTypeDescOrExprRhs(typeOrExpr)
 	case common.OPEN_BRACKET_TOKEN:
-		this.reportInvalidQualifierList(qualifiers)
-		typeOrExpr = this.parseTupleTypeDescOrListConstructor(tree.CreateEmptyNodeList())
+		b.reportInvalidQualifierList(qualifiers)
+		typeOrExpr = b.parseTupleTypeDescOrListConstructor(tree.CreateEmptyNodeList())
 	case common.DECIMAL_INTEGER_LITERAL_TOKEN,
 		common.HEX_INTEGER_LITERAL_TOKEN,
 		common.STRING_LITERAL_TOKEN,
@@ -11692,23 +11692,23 @@ func (this *BallerinaParser) parseTypeDescOrExprWithQualifiers(qualifiers []tree
 		common.FALSE_KEYWORD,
 		common.DECIMAL_FLOATING_POINT_LITERAL_TOKEN,
 		common.HEX_FLOATING_POINT_LITERAL_TOKEN:
-		this.reportInvalidQualifierList(qualifiers)
-		basicLiteral := this.parseBasicLiteral()
-		return this.parseTypeDescOrExprRhs(basicLiteral)
+		b.reportInvalidQualifierList(qualifiers)
+		basicLiteral := b.parseBasicLiteral()
+		return b.parseTypeDescOrExprRhs(basicLiteral)
 	default:
-		if this.isValidExpressionStart(nextToken.Kind(), 1) {
-			this.reportInvalidQualifierList(qualifiers)
-			return this.parseActionOrExpressionInLhs(tree.CreateEmptyNodeList())
+		if b.isValidExpressionStart(nextToken.Kind(), 1) {
+			b.reportInvalidQualifierList(qualifiers)
+			return b.parseActionOrExpressionInLhs(tree.CreateEmptyNodeList())
 		}
-		return this.parseTypeDescriptorWithQualifier(qualifiers, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN)
+		return b.parseTypeDescriptorWithQualifier(qualifiers, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN)
 	}
-	if this.isDefiniteTypeDesc(typeOrExpr.Kind()) {
-		return this.parseComplexTypeDescriptor(typeOrExpr, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN, true)
+	if b.isDefiniteTypeDesc(typeOrExpr.Kind()) {
+		return b.parseComplexTypeDescriptor(typeOrExpr, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN, true)
 	}
-	return this.parseTypeDescOrExprRhs(typeOrExpr)
+	return b.parseTypeDescOrExprRhs(typeOrExpr)
 }
 
-func (this *BallerinaParser) isExpression(kind common.SyntaxKind) bool {
+func (b *BallerinaParser) isExpression(kind common.SyntaxKind) bool {
 	switch kind {
 	case common.NUMERIC_LITERAL,
 		common.STRING_LITERAL_TOKEN,
@@ -11721,132 +11721,132 @@ func (this *BallerinaParser) isExpression(kind common.SyntaxKind) bool {
 	}
 }
 
-func (this *BallerinaParser) parseTypeOrExprStartWithEmptyParenthesis(openParen tree.STNode, closeParen tree.STNode) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseTypeOrExprStartWithEmptyParenthesis(openParen tree.STNode, closeParen tree.STNode) tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.RIGHT_DOUBLE_ARROW_TOKEN:
 		params := tree.CreateEmptyNodeList()
 		anonFuncParam := tree.CreateImplicitAnonymousFunctionParameters(openParen, params, closeParen)
-		return this.parseImplicitAnonFuncWithParams(anonFuncParam, false)
+		return b.parseImplicitAnonFuncWithParams(anonFuncParam, false)
 	default:
 		return tree.CreateNilLiteralNode(openParen, closeParen)
 	}
 }
 
-func (this *BallerinaParser) parseAnonFuncExprOrTypedBPWithFuncType(qualifiers []tree.STNode) tree.STNode {
-	exprOrTypeDesc := this.parseAnonFuncExprOrFuncTypeDesc(qualifiers)
-	if this.isAction(exprOrTypeDesc) || this.isExpression(exprOrTypeDesc.Kind()) {
+func (b *BallerinaParser) parseAnonFuncExprOrTypedBPWithFuncType(qualifiers []tree.STNode) tree.STNode {
+	exprOrTypeDesc := b.parseAnonFuncExprOrFuncTypeDesc(qualifiers)
+	if b.isAction(exprOrTypeDesc) || b.isExpression(exprOrTypeDesc.Kind()) {
 		return exprOrTypeDesc
 	}
-	return this.parseTypedBindingPatternTypeRhs(exprOrTypeDesc, common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+	return b.parseTypedBindingPatternTypeRhs(exprOrTypeDesc, common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
 }
 
-func (this *BallerinaParser) parseAnonFuncExprOrFuncTypeDesc(qualifiers []tree.STNode) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_FUNC_TYPE_DESC_OR_ANON_FUNC)
+func (b *BallerinaParser) parseAnonFuncExprOrFuncTypeDesc(qualifiers []tree.STNode) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_FUNC_TYPE_DESC_OR_ANON_FUNC)
 	var qualifierList tree.STNode
-	functionKeyword := this.parseFunctionKeyword()
+	functionKeyword := b.parseFunctionKeyword()
 	var funcSignature tree.STNode
-	if this.peek().Kind() == common.OPEN_PAREN_TOKEN {
-		funcSignature = this.parseFuncSignature(true)
-		nodes := this.createFuncTypeQualNodeList(qualifiers, functionKeyword, true)
+	if b.peek().Kind() == common.OPEN_PAREN_TOKEN {
+		funcSignature = b.parseFuncSignature(true)
+		nodes := b.createFuncTypeQualNodeList(qualifiers, functionKeyword, true)
 		qualifierList = nodes[0]
 		functionKeyword = nodes[1]
-		this.endContext()
-		return this.parseAnonFuncExprOrFuncTypeDescWithComponents(qualifierList, functionKeyword, funcSignature)
+		b.endContext()
+		return b.parseAnonFuncExprOrFuncTypeDescWithComponents(qualifierList, functionKeyword, funcSignature)
 	}
 	funcSignature = tree.CreateEmptyNode()
-	nodes := this.createFuncTypeQualNodeList(qualifiers, functionKeyword, false)
+	nodes := b.createFuncTypeQualNodeList(qualifiers, functionKeyword, false)
 	qualifierList = nodes[0]
 	functionKeyword = nodes[1]
 	funcTypeDesc := tree.CreateFunctionTypeDescriptorNode(qualifierList, functionKeyword,
 		funcSignature)
-	if this.getCurrentContext() != common.PARSER_RULE_CONTEXT_STMT_START_BRACKETED_LIST {
-		this.switchContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
-		return this.parseComplexTypeDescriptor(funcTypeDesc, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN, true)
+	if b.getCurrentContext() != common.PARSER_RULE_CONTEXT_STMT_START_BRACKETED_LIST {
+		b.switchContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+		return b.parseComplexTypeDescriptor(funcTypeDesc, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN, true)
 	}
-	return this.parseComplexTypeDescriptor(funcTypeDesc, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE, false)
+	return b.parseComplexTypeDescriptor(funcTypeDesc, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE, false)
 }
 
-func (this *BallerinaParser) parseAnonFuncExprOrFuncTypeDescWithComponents(qualifierList tree.STNode, functionKeyword tree.STNode, funcSignature tree.STNode) tree.STNode {
-	currentCtx := this.getCurrentContext()
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseAnonFuncExprOrFuncTypeDescWithComponents(qualifierList tree.STNode, functionKeyword tree.STNode, funcSignature tree.STNode) tree.STNode {
+	currentCtx := b.getCurrentContext()
+	switch b.peek().Kind() {
 	case common.OPEN_BRACE_TOKEN, common.RIGHT_DOUBLE_ARROW_TOKEN:
 		if currentCtx != common.PARSER_RULE_CONTEXT_STMT_START_BRACKETED_LIST {
-			this.switchContext(common.PARSER_RULE_CONTEXT_EXPRESSION_STATEMENT)
+			b.switchContext(common.PARSER_RULE_CONTEXT_EXPRESSION_STATEMENT)
 		}
-		this.startContext(common.PARSER_RULE_CONTEXT_ANON_FUNC_EXPRESSION)
+		b.startContext(common.PARSER_RULE_CONTEXT_ANON_FUNC_EXPRESSION)
 		funcSignatureNode, ok := funcSignature.(*tree.STFunctionSignatureNode)
 		if !ok {
 			panic("parseAnonFuncExprOrFuncTypeDescWithComponents: expected STFunctionSignatureNode")
 		}
-		funcSignature = this.validateAndGetFuncParams(*funcSignatureNode)
-		funcBody := this.parseAnonFuncBody(false)
+		funcSignature = b.validateAndGetFuncParams(*funcSignatureNode)
+		funcBody := b.parseAnonFuncBody(false)
 		annots := tree.CreateEmptyNodeList()
 		anonFunc := tree.CreateExplicitAnonymousFunctionExpressionNode(annots, qualifierList,
 			functionKeyword, funcSignature, funcBody)
-		return this.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, anonFunc, false, true)
+		return b.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, anonFunc, false, true)
 	case common.IDENTIFIER_TOKEN:
 		fallthrough
 	default:
 		funcTypeDesc := tree.CreateFunctionTypeDescriptorNode(qualifierList, functionKeyword,
 			funcSignature)
 		if currentCtx != common.PARSER_RULE_CONTEXT_STMT_START_BRACKETED_LIST {
-			this.switchContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
-			return this.parseComplexTypeDescriptor(funcTypeDesc, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN,
+			b.switchContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+			return b.parseComplexTypeDescriptor(funcTypeDesc, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN,
 				true)
 		}
-		return this.parseComplexTypeDescriptor(funcTypeDesc, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE, false)
+		return b.parseComplexTypeDescriptor(funcTypeDesc, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE, false)
 	}
 }
 
-func (this *BallerinaParser) parseTypeDescOrExprRhs(typeOrExpr tree.STNode) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseTypeDescOrExprRhs(typeOrExpr tree.STNode) tree.STNode {
+	nextToken := b.peek()
 	var typeDesc tree.STNode
 	switch nextToken.Kind() {
 	case common.PIPE_TOKEN,
 		common.BITWISE_AND_TOKEN:
-		nextNextToken := this.peekN(2)
+		nextNextToken := b.peekN(2)
 		if nextNextToken.Kind() == common.EQUAL_TOKEN {
 			return typeOrExpr
 		}
-		pipeOrAndToken := this.parseBinaryOperator()
-		rhsTypeDescOrExpr := this.parseTypeDescOrExpr()
-		if this.isExpression(rhsTypeDescOrExpr.Kind()) {
+		pipeOrAndToken := b.parseBinaryOperator()
+		rhsTypeDescOrExpr := b.parseTypeDescOrExpr()
+		if b.isExpression(rhsTypeDescOrExpr.Kind()) {
 			return tree.CreateBinaryExpressionNode(common.BINARY_EXPRESSION, typeOrExpr,
 				pipeOrAndToken, rhsTypeDescOrExpr)
 		}
-		typeDesc = this.getTypeDescFromExpr(typeOrExpr)
-		rhsTypeDescOrExpr = this.getTypeDescFromExpr(rhsTypeDescOrExpr)
-		return this.mergeTypes(typeDesc, pipeOrAndToken, rhsTypeDescOrExpr)
+		typeDesc = b.getTypeDescFromExpr(typeOrExpr)
+		rhsTypeDescOrExpr = b.getTypeDescFromExpr(rhsTypeDescOrExpr)
+		return b.mergeTypes(typeDesc, pipeOrAndToken, rhsTypeDescOrExpr)
 	case common.IDENTIFIER_TOKEN,
 		common.QUESTION_MARK_TOKEN:
-		typeDesc = this.parseComplexTypeDescriptor(this.getTypeDescFromExpr(typeOrExpr),
+		typeDesc = b.parseComplexTypeDescriptor(b.getTypeDescFromExpr(typeOrExpr),
 			common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN, false)
 		return typeDesc
 	case common.SEMICOLON_TOKEN:
-		return this.getTypeDescFromExpr(typeOrExpr)
+		return b.getTypeDescFromExpr(typeOrExpr)
 	case common.EQUAL_TOKEN, common.CLOSE_PAREN_TOKEN, common.CLOSE_BRACE_TOKEN, common.CLOSE_BRACKET_TOKEN, common.EOF_TOKEN, common.COMMA_TOKEN:
 		return typeOrExpr
 	case common.OPEN_BRACKET_TOKEN:
-		return this.parseTypedBindingPatternOrMemberAccess(typeOrExpr, false, true,
+		return b.parseTypedBindingPatternOrMemberAccess(typeOrExpr, false, true,
 			common.PARSER_RULE_CONTEXT_AMBIGUOUS_STMT)
 	case common.ELLIPSIS_TOKEN:
-		ellipsis := this.parseEllipsis()
-		typeOrExpr = this.getTypeDescFromExpr(typeOrExpr)
+		ellipsis := b.parseEllipsis()
+		typeOrExpr = b.getTypeDescFromExpr(typeOrExpr)
 		return tree.CreateRestDescriptorNode(typeOrExpr, ellipsis)
 	default:
-		if this.isCompoundAssignment(nextToken.Kind()) {
+		if b.isCompoundAssignment(nextToken.Kind()) {
 			return typeOrExpr
 		}
-		if this.isValidExprRhsStart(nextToken.Kind(), typeOrExpr.Kind()) {
-			return this.parseExpressionRhsInner(DEFAULT_OP_PRECEDENCE, typeOrExpr, false, false, false, false)
+		if b.isValidExprRhsStart(nextToken.Kind(), typeOrExpr.Kind()) {
+			return b.parseExpressionRhsInner(DEFAULT_OP_PRECEDENCE, typeOrExpr, false, false, false, false)
 		}
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_TYPE_DESC_OR_EXPR_RHS)
-		return this.parseTypeDescOrExprRhs(typeOrExpr)
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_TYPE_DESC_OR_EXPR_RHS)
+		return b.parseTypeDescOrExprRhs(typeOrExpr)
 	}
 }
 
-func (this *BallerinaParser) isAmbiguous(node tree.STNode) bool {
+func (b *BallerinaParser) isAmbiguous(node tree.STNode) bool {
 	switch node.Kind() {
 	case common.SIMPLE_NAME_REFERENCE,
 		common.QUALIFIED_NAME_REFERENCE,
@@ -11865,19 +11865,19 @@ func (this *BallerinaParser) isAmbiguous(node tree.STNode) bool {
 		if binaryExpr.Operator.Kind() != common.PIPE_TOKEN {
 			return false
 		}
-		return (this.isAmbiguous(binaryExpr.LhsExpr) && this.isAmbiguous(binaryExpr.RhsExpr))
+		return (b.isAmbiguous(binaryExpr.LhsExpr) && b.isAmbiguous(binaryExpr.RhsExpr))
 	case common.BRACED_EXPRESSION:
 		bracedExpr, ok := node.(*tree.STBracedExpressionNode)
 		if !ok {
 			panic("isAmbiguous: expected STBracedExpressionNode")
 		}
-		return this.isAmbiguous(bracedExpr.Expression)
+		return b.isAmbiguous(bracedExpr.Expression)
 	case common.INDEXED_EXPRESSION:
 		indexExpr, ok := node.(*tree.STIndexedExpressionNode)
 		if !ok {
 			panic("expected STIndexedExpressionNode")
 		}
-		if !this.isAmbiguous(indexExpr.ContainerExpression) {
+		if !b.isAmbiguous(indexExpr.ContainerExpression) {
 			return false
 		}
 		keys := indexExpr.KeyExpression
@@ -11887,7 +11887,7 @@ func (this *BallerinaParser) isAmbiguous(node tree.STNode) bool {
 			if item.Kind() == common.COMMA_TOKEN {
 				continue
 			}
-			if !this.isAmbiguous(item) {
+			if !b.isAmbiguous(item) {
 				return false
 			}
 		}
@@ -11897,7 +11897,7 @@ func (this *BallerinaParser) isAmbiguous(node tree.STNode) bool {
 	}
 }
 
-func (this *BallerinaParser) isAllBasicLiterals(node tree.STNode) bool {
+func (b *BallerinaParser) isAllBasicLiterals(node tree.STNode) bool {
 	switch node.Kind() {
 	case common.NIL_LITERAL, common.NULL_LITERAL, common.NUMERIC_LITERAL, common.STRING_LITERAL, common.BOOLEAN_LITERAL:
 		return true
@@ -11909,13 +11909,13 @@ func (this *BallerinaParser) isAllBasicLiterals(node tree.STNode) bool {
 		if binaryExpr.Operator.Kind() != common.PIPE_TOKEN {
 			return false
 		}
-		return (this.isAmbiguous(binaryExpr.LhsExpr) && this.isAmbiguous(binaryExpr.RhsExpr))
+		return (b.isAmbiguous(binaryExpr.LhsExpr) && b.isAmbiguous(binaryExpr.RhsExpr))
 	case common.BRACED_EXPRESSION:
 		bracedExpr, ok := node.(*tree.STBracedExpressionNode)
 		if !ok {
 			panic("isAllBasicLiterals: expected STBracedExpressionNode")
 		}
-		return this.isAmbiguous(bracedExpr.Expression)
+		return b.isAmbiguous(bracedExpr.Expression)
 	case common.BRACKETED_LIST:
 		list, ok := node.(*tree.STAmbiguousCollectionNode)
 		if !ok {
@@ -11925,7 +11925,7 @@ func (this *BallerinaParser) isAllBasicLiterals(node tree.STNode) bool {
 			if member.Kind() == common.COMMA_TOKEN {
 				continue
 			}
-			if !this.isAllBasicLiterals(member) {
+			if !b.isAllBasicLiterals(member) {
 				return false
 			}
 		}
@@ -11938,13 +11938,13 @@ func (this *BallerinaParser) isAllBasicLiterals(node tree.STNode) bool {
 		if (unaryExpr.UnaryOperator.Kind() != common.PLUS_TOKEN) && (unaryExpr.UnaryOperator.Kind() != common.MINUS_TOKEN) {
 			return false
 		}
-		return this.isNumericLiteral(unaryExpr.Expression)
+		return b.isNumericLiteral(unaryExpr.Expression)
 	default:
 		return false
 	}
 }
 
-func (this *BallerinaParser) isNumericLiteral(node tree.STNode) bool {
+func (b *BallerinaParser) isNumericLiteral(node tree.STNode) bool {
 	switch node.Kind() {
 	case common.NUMERIC_LITERAL:
 		return true
@@ -11953,30 +11953,30 @@ func (this *BallerinaParser) isNumericLiteral(node tree.STNode) bool {
 	}
 }
 
-func (this *BallerinaParser) parseBindingPattern() tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseBindingPattern() tree.STNode {
+	switch b.peek().Kind() {
 	case common.OPEN_BRACKET_TOKEN:
-		return this.parseListBindingPattern()
+		return b.parseListBindingPattern()
 	case common.IDENTIFIER_TOKEN:
-		return this.parseBindingPatternStartsWithIdentifier()
+		return b.parseBindingPatternStartsWithIdentifier()
 	case common.OPEN_BRACE_TOKEN:
-		return this.parseMappingBindingPattern()
+		return b.parseMappingBindingPattern()
 	case common.ERROR_KEYWORD:
-		return this.parseErrorBindingPattern()
+		return b.parseErrorBindingPattern()
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_BINDING_PATTERN)
-		return this.parseBindingPattern()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_BINDING_PATTERN)
+		return b.parseBindingPattern()
 	}
 }
 
-func (this *BallerinaParser) parseBindingPatternStartsWithIdentifier() tree.STNode {
-	argNameOrBindingPattern := this.parseQualifiedIdentifier(common.PARSER_RULE_CONTEXT_BINDING_PATTERN_STARTING_IDENTIFIER)
-	secondToken := this.peek()
+func (b *BallerinaParser) parseBindingPatternStartsWithIdentifier() tree.STNode {
+	argNameOrBindingPattern := b.parseQualifiedIdentifier(common.PARSER_RULE_CONTEXT_BINDING_PATTERN_STARTING_IDENTIFIER)
+	secondToken := b.peek()
 	if secondToken.Kind() == common.OPEN_PAREN_TOKEN {
-		this.startContext(common.PARSER_RULE_CONTEXT_ERROR_BINDING_PATTERN)
+		b.startContext(common.PARSER_RULE_CONTEXT_ERROR_BINDING_PATTERN)
 		errorKeyword := tree.CreateMissingTokenWithDiagnostics(common.ERROR_KEYWORD,
 			common.PARSER_RULE_CONTEXT_ERROR_KEYWORD.GetErrorCode())
-		return this.parseErrorBindingPatternWithTypeRef(errorKeyword, argNameOrBindingPattern)
+		return b.parseErrorBindingPatternWithTypeRef(errorKeyword, argNameOrBindingPattern)
 	}
 	if argNameOrBindingPattern.Kind() != common.SIMPLE_NAME_REFERENCE {
 		var identifier tree.STNode
@@ -11989,71 +11989,71 @@ func (this *BallerinaParser) parseBindingPatternStartsWithIdentifier() tree.STNo
 	if !ok {
 		panic("parseBindingPatternStartsWithIdentifier: expected STSimpleNameReferenceNode")
 	}
-	return this.createCaptureOrWildcardBP(simpleNameNode.Name)
+	return b.createCaptureOrWildcardBP(simpleNameNode.Name)
 }
 
-func (this *BallerinaParser) createCaptureOrWildcardBP(varName tree.STNode) tree.STNode {
+func (b *BallerinaParser) createCaptureOrWildcardBP(varName tree.STNode) tree.STNode {
 	var bindingPattern tree.STNode
-	if this.isWildcardBP(varName) {
-		bindingPattern = this.getWildcardBindingPattern(varName)
+	if b.isWildcardBP(varName) {
+		bindingPattern = b.getWildcardBindingPattern(varName)
 	} else {
 		bindingPattern = tree.CreateCaptureBindingPatternNode(varName)
 	}
 	return bindingPattern
 }
 
-func (this *BallerinaParser) parseListBindingPattern() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_LIST_BINDING_PATTERN)
-	openBracket := this.parseOpenBracket()
-	listBindingPattern, _ := this.parseListBindingPatternWithOpenBracket(openBracket, nil)
-	this.endContext()
+func (b *BallerinaParser) parseListBindingPattern() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_LIST_BINDING_PATTERN)
+	openBracket := b.parseOpenBracket()
+	listBindingPattern, _ := b.parseListBindingPatternWithOpenBracket(openBracket, nil)
+	b.endContext()
 	return listBindingPattern
 }
 
-func (this *BallerinaParser) parseListBindingPatternWithOpenBracket(openBracket tree.STNode, bindingPatternsList []tree.STNode) (tree.STNode, []tree.STNode) {
-	if this.isEndOfListBindingPattern(this.peek().Kind()) && len(bindingPatternsList) == 0 {
-		closeBracket := this.parseCloseBracket()
+func (b *BallerinaParser) parseListBindingPatternWithOpenBracket(openBracket tree.STNode, bindingPatternsList []tree.STNode) (tree.STNode, []tree.STNode) {
+	if b.isEndOfListBindingPattern(b.peek().Kind()) && len(bindingPatternsList) == 0 {
+		closeBracket := b.parseCloseBracket()
 		bindingPatternsNode := tree.CreateNodeList(bindingPatternsList...)
 		return tree.CreateListBindingPatternNode(openBracket, bindingPatternsNode, closeBracket), bindingPatternsList
 	}
-	listBindingPatternMember := this.parseListBindingPatternMember()
+	listBindingPatternMember := b.parseListBindingPatternMember()
 	bindingPatternsList = append(bindingPatternsList, listBindingPatternMember)
-	listBindingPattern, bindingPatternsList := this.parseListBindingPatternWithFirstMember(openBracket, listBindingPatternMember, bindingPatternsList)
+	listBindingPattern, bindingPatternsList := b.parseListBindingPatternWithFirstMember(openBracket, listBindingPatternMember, bindingPatternsList)
 	return listBindingPattern, bindingPatternsList
 }
 
-func (this *BallerinaParser) parseListBindingPatternWithFirstMember(openBracket tree.STNode, firstMember tree.STNode, bindingPatterns []tree.STNode) (tree.STNode, []tree.STNode) {
+func (b *BallerinaParser) parseListBindingPatternWithFirstMember(openBracket tree.STNode, firstMember tree.STNode, bindingPatterns []tree.STNode) (tree.STNode, []tree.STNode) {
 	member := firstMember
-	token := this.peek()
+	token := b.peek()
 	var listBindingPatternRhs tree.STNode
-	for (!this.isEndOfListBindingPattern(token.Kind())) && (member.Kind() != common.REST_BINDING_PATTERN) {
-		listBindingPatternRhs = this.parseListBindingPatternMemberRhs()
+	for (!b.isEndOfListBindingPattern(token.Kind())) && (member.Kind() != common.REST_BINDING_PATTERN) {
+		listBindingPatternRhs = b.parseListBindingPatternMemberRhs()
 		if listBindingPatternRhs == nil {
 			break
 		}
 		bindingPatterns = append(bindingPatterns, listBindingPatternRhs)
-		member = this.parseListBindingPatternMember()
+		member = b.parseListBindingPatternMember()
 		bindingPatterns = append(bindingPatterns, member)
-		token = this.peek()
+		token = b.peek()
 	}
-	closeBracket := this.parseCloseBracket()
+	closeBracket := b.parseCloseBracket()
 	bindingPatternsNode := tree.CreateNodeList(bindingPatterns...)
 	return tree.CreateListBindingPatternNode(openBracket, bindingPatternsNode, closeBracket), bindingPatterns
 }
 
-func (this *BallerinaParser) parseListBindingPatternMemberRhs() tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseListBindingPatternMemberRhs() tree.STNode {
+	switch b.peek().Kind() {
 	case common.COMMA_TOKEN:
-		return this.parseComma()
+		return b.parseComma()
 	case common.CLOSE_BRACKET_TOKEN:
 		return nil
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_LIST_BINDING_PATTERN_MEMBER_END)
-		return this.parseListBindingPatternMemberRhs()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_LIST_BINDING_PATTERN_MEMBER_END)
+		return b.parseListBindingPatternMemberRhs()
 	}
 }
 
-func (this *BallerinaParser) isEndOfListBindingPattern(nextTokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isEndOfListBindingPattern(nextTokenKind common.SyntaxKind) bool {
 	switch nextTokenKind {
 	case common.CLOSE_BRACKET_TOKEN, common.EOF_TOKEN:
 		return true
@@ -12062,26 +12062,26 @@ func (this *BallerinaParser) isEndOfListBindingPattern(nextTokenKind common.Synt
 	}
 }
 
-func (this *BallerinaParser) parseListBindingPatternMember() tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseListBindingPatternMember() tree.STNode {
+	switch b.peek().Kind() {
 	case common.ELLIPSIS_TOKEN:
-		return this.parseRestBindingPattern()
+		return b.parseRestBindingPattern()
 	case common.OPEN_BRACKET_TOKEN,
 		common.IDENTIFIER_TOKEN,
 		common.OPEN_BRACE_TOKEN,
 		common.ERROR_KEYWORD:
-		return this.parseBindingPattern()
+		return b.parseBindingPattern()
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_LIST_BINDING_PATTERN_MEMBER)
-		return this.parseListBindingPatternMember()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_LIST_BINDING_PATTERN_MEMBER)
+		return b.parseListBindingPatternMember()
 	}
 }
 
-func (this *BallerinaParser) parseRestBindingPattern() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_REST_BINDING_PATTERN)
-	ellipsis := this.parseEllipsis()
-	varName := this.parseVariableName()
-	this.endContext()
+func (b *BallerinaParser) parseRestBindingPattern() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_REST_BINDING_PATTERN)
+	ellipsis := b.parseEllipsis()
+	varName := b.parseVariableName()
+	b.endContext()
 	simpleNameReferenceNode, ok := tree.CreateSimpleNameReferenceNode(varName).(*tree.STSimpleNameReferenceNode)
 	if !ok {
 		panic("expected STSimpleNameReferenceNode")
@@ -12089,193 +12089,193 @@ func (this *BallerinaParser) parseRestBindingPattern() tree.STNode {
 	return tree.CreateRestBindingPatternNode(ellipsis, simpleNameReferenceNode)
 }
 
-func (this *BallerinaParser) parseTypedBindingPatternWithContext(context common.ParserRuleContext) tree.STNode {
-	return this.parseTypedBindingPatternInner(nil, context)
+func (b *BallerinaParser) parseTypedBindingPatternWithContext(context common.ParserRuleContext) tree.STNode {
+	return b.parseTypedBindingPatternInner(nil, context)
 }
 
-func (this *BallerinaParser) parseTypedBindingPatternInner(qualifiers []tree.STNode, context common.ParserRuleContext) tree.STNode {
-	typeDesc := this.parseTypeDescriptorWithinContext(qualifiers,
+func (b *BallerinaParser) parseTypedBindingPatternInner(qualifiers []tree.STNode, context common.ParserRuleContext) tree.STNode {
+	typeDesc := b.parseTypeDescriptorWithinContext(qualifiers,
 		common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN, true, false, TYPE_PRECEDENCE_DEFAULT)
-	typeBindingPattern := this.parseTypedBindingPatternTypeRhs(typeDesc, context)
+	typeBindingPattern := b.parseTypedBindingPatternTypeRhs(typeDesc, context)
 	return typeBindingPattern
 }
 
-func (this *BallerinaParser) parseMappingBindingPattern() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_MAPPING_BINDING_PATTERN)
-	openBrace := this.parseOpenBrace()
-	token := this.peek()
-	if this.isEndOfMappingBindingPattern(token.Kind()) {
-		closeBrace := this.parseCloseBrace()
+func (b *BallerinaParser) parseMappingBindingPattern() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_MAPPING_BINDING_PATTERN)
+	openBrace := b.parseOpenBrace()
+	token := b.peek()
+	if b.isEndOfMappingBindingPattern(token.Kind()) {
+		closeBrace := b.parseCloseBrace()
 		bindingPatternsNode := tree.CreateEmptyNodeList()
-		this.endContext()
+		b.endContext()
 		return tree.CreateMappingBindingPatternNode(openBrace, bindingPatternsNode, closeBrace)
 	}
 	var bindingPatterns []tree.STNode
-	prevMember := this.parseMappingBindingPatternMember()
+	prevMember := b.parseMappingBindingPatternMember()
 	if prevMember.Kind() != common.REST_BINDING_PATTERN {
 		bindingPatterns = append(bindingPatterns, prevMember)
 	}
-	res, _ := this.parseMappingBindingPatternInner(openBrace, bindingPatterns, prevMember)
+	res, _ := b.parseMappingBindingPatternInner(openBrace, bindingPatterns, prevMember)
 	return res
 }
 
-func (this *BallerinaParser) parseMappingBindingPatternInner(openBrace tree.STNode, bindingPatterns []tree.STNode, prevMember tree.STNode) (tree.STNode, []tree.STNode) {
-	token := this.peek()
+func (b *BallerinaParser) parseMappingBindingPatternInner(openBrace tree.STNode, bindingPatterns []tree.STNode, prevMember tree.STNode) (tree.STNode, []tree.STNode) {
+	token := b.peek()
 	var mappingBindingPatternRhs tree.STNode
-	for (!this.isEndOfMappingBindingPattern(token.Kind())) && (prevMember.Kind() != common.REST_BINDING_PATTERN) {
-		mappingBindingPatternRhs = this.parseMappingBindingPatternEnd()
+	for (!b.isEndOfMappingBindingPattern(token.Kind())) && (prevMember.Kind() != common.REST_BINDING_PATTERN) {
+		mappingBindingPatternRhs = b.parseMappingBindingPatternEnd()
 		if mappingBindingPatternRhs == nil {
 			break
 		}
 		bindingPatterns = append(bindingPatterns, mappingBindingPatternRhs)
-		prevMember = this.parseMappingBindingPatternMember()
+		prevMember = b.parseMappingBindingPatternMember()
 		if prevMember.Kind() == common.REST_BINDING_PATTERN {
 			break
 		}
 		bindingPatterns = append(bindingPatterns, prevMember)
-		token = this.peek()
+		token = b.peek()
 	}
 	if prevMember.Kind() == common.REST_BINDING_PATTERN {
 		bindingPatterns = append(bindingPatterns, prevMember)
 	}
-	closeBrace := this.parseCloseBrace()
+	closeBrace := b.parseCloseBrace()
 	bindingPatternsNode := tree.CreateNodeList(bindingPatterns...)
-	this.endContext()
+	b.endContext()
 	return tree.CreateMappingBindingPatternNode(openBrace, bindingPatternsNode, closeBrace), bindingPatterns
 }
 
-func (this *BallerinaParser) parseMappingBindingPatternMember() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseMappingBindingPatternMember() tree.STNode {
+	token := b.peek()
 	switch token.Kind() {
 	case common.ELLIPSIS_TOKEN:
-		return this.parseRestBindingPattern()
+		return b.parseRestBindingPattern()
 	default:
-		return this.parseFieldBindingPattern()
+		return b.parseFieldBindingPattern()
 	}
 }
 
-func (this *BallerinaParser) parseMappingBindingPatternEnd() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseMappingBindingPatternEnd() tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.COMMA_TOKEN:
-		return this.parseComma()
+		return b.parseComma()
 	case common.CLOSE_BRACE_TOKEN:
 		return nil
 	default:
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_MAPPING_BINDING_PATTERN_END)
-		return this.parseMappingBindingPatternEnd()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_MAPPING_BINDING_PATTERN_END)
+		return b.parseMappingBindingPatternEnd()
 	}
 }
 
-func (this *BallerinaParser) parseFieldBindingPattern() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseFieldBindingPattern() tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.IDENTIFIER_TOKEN:
-		identifier := this.parseIdentifier(common.PARSER_RULE_CONTEXT_FIELD_BINDING_PATTERN_NAME)
+		identifier := b.parseIdentifier(common.PARSER_RULE_CONTEXT_FIELD_BINDING_PATTERN_NAME)
 		simpleNameReference := tree.CreateSimpleNameReferenceNode(identifier)
-		return this.parseFieldBindingPatternWithName(simpleNameReference)
+		return b.parseFieldBindingPatternWithName(simpleNameReference)
 	default:
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_FIELD_BINDING_PATTERN_NAME)
-		return this.parseFieldBindingPattern()
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_FIELD_BINDING_PATTERN_NAME)
+		return b.parseFieldBindingPattern()
 	}
 }
 
-func (this *BallerinaParser) parseFieldBindingPatternWithName(simpleNameReference tree.STNode) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseFieldBindingPatternWithName(simpleNameReference tree.STNode) tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.COMMA_TOKEN, common.CLOSE_BRACE_TOKEN:
 		return tree.CreateFieldBindingPatternVarnameNode(simpleNameReference)
 	case common.COLON_TOKEN:
-		colon := this.parseColon()
-		bindingPattern := this.parseBindingPattern()
+		colon := b.parseColon()
+		bindingPattern := b.parseBindingPattern()
 		return tree.CreateFieldBindingPatternFullNode(simpleNameReference, colon, bindingPattern)
 	default:
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_FIELD_BINDING_PATTERN_END)
-		return this.parseFieldBindingPatternWithName(simpleNameReference)
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_FIELD_BINDING_PATTERN_END)
+		return b.parseFieldBindingPatternWithName(simpleNameReference)
 	}
 }
 
-func (this *BallerinaParser) isEndOfMappingBindingPattern(nextTokenKind common.SyntaxKind) bool {
-	return ((nextTokenKind == common.CLOSE_BRACE_TOKEN) || this.isEndOfModuleLevelNode(1))
+func (b *BallerinaParser) isEndOfMappingBindingPattern(nextTokenKind common.SyntaxKind) bool {
+	return ((nextTokenKind == common.CLOSE_BRACE_TOKEN) || b.isEndOfModuleLevelNode(1))
 }
 
-func (this *BallerinaParser) parseErrorTypeDescOrErrorBP(annots tree.STNode) tree.STNode {
-	nextNextToken := this.peekN(2)
+func (b *BallerinaParser) parseErrorTypeDescOrErrorBP(annots tree.STNode) tree.STNode {
+	nextNextToken := b.peekN(2)
 	switch nextNextToken.Kind() {
 	case common.OPEN_PAREN_TOKEN:
-		return this.parseAsErrorBindingPattern()
+		return b.parseAsErrorBindingPattern()
 	case common.LT_TOKEN:
-		return this.parseAsErrorTypeDesc(annots)
+		return b.parseAsErrorTypeDesc(annots)
 	case common.IDENTIFIER_TOKEN:
-		nextNextNextTokenKind := this.peekN(3).Kind()
+		nextNextNextTokenKind := b.peekN(3).Kind()
 		if (nextNextNextTokenKind == common.COLON_TOKEN) || (nextNextNextTokenKind == common.OPEN_PAREN_TOKEN) {
-			return this.parseAsErrorBindingPattern()
+			return b.parseAsErrorBindingPattern()
 		}
 		fallthrough
 	default:
-		return this.parseAsErrorTypeDesc(annots)
+		return b.parseAsErrorTypeDesc(annots)
 	}
 }
 
-func (this *BallerinaParser) parseAsErrorBindingPattern() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_ASSIGNMENT_STMT)
-	return this.parseAssignmentStmtRhs(this.parseErrorBindingPattern())
+func (b *BallerinaParser) parseAsErrorBindingPattern() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_ASSIGNMENT_STMT)
+	return b.parseAssignmentStmtRhs(b.parseErrorBindingPattern())
 }
 
-func (this *BallerinaParser) parseAsErrorTypeDesc(annots tree.STNode) tree.STNode {
+func (b *BallerinaParser) parseAsErrorTypeDesc(annots tree.STNode) tree.STNode {
 	finalKeyword := tree.CreateEmptyNode()
-	return this.parseVariableDecl(this.getAnnotations(annots), finalKeyword)
+	return b.parseVariableDecl(b.getAnnotations(annots), finalKeyword)
 }
 
-func (this *BallerinaParser) parseErrorBindingPattern() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_ERROR_BINDING_PATTERN)
-	errorKeyword := this.parseErrorKeyword()
-	return this.parseErrorBindingPatternWithKeyword(errorKeyword)
+func (b *BallerinaParser) parseErrorBindingPattern() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_ERROR_BINDING_PATTERN)
+	errorKeyword := b.parseErrorKeyword()
+	return b.parseErrorBindingPatternWithKeyword(errorKeyword)
 }
 
-func (this *BallerinaParser) parseErrorBindingPatternWithKeyword(errorKeyword tree.STNode) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseErrorBindingPatternWithKeyword(errorKeyword tree.STNode) tree.STNode {
+	nextToken := b.peek()
 	var typeRef tree.STNode
 	switch nextToken.Kind() {
 	case common.OPEN_PAREN_TOKEN:
 		typeRef = tree.CreateEmptyNode()
 	default:
-		if this.isPredeclaredIdentifier(nextToken.Kind()) {
-			typeRef = this.parseTypeReference()
+		if b.isPredeclaredIdentifier(nextToken.Kind()) {
+			typeRef = b.parseTypeReference()
 			break
 		}
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_ERROR_BINDING_PATTERN_ERROR_KEYWORD_RHS)
-		return this.parseErrorBindingPatternWithKeyword(errorKeyword)
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_ERROR_BINDING_PATTERN_ERROR_KEYWORD_RHS)
+		return b.parseErrorBindingPatternWithKeyword(errorKeyword)
 	}
-	return this.parseErrorBindingPatternWithTypeRef(errorKeyword, typeRef)
+	return b.parseErrorBindingPatternWithTypeRef(errorKeyword, typeRef)
 }
 
-func (this *BallerinaParser) parseErrorBindingPatternWithTypeRef(errorKeyword tree.STNode, typeRef tree.STNode) tree.STNode {
-	openParenthesis := this.parseOpenParenthesis()
-	argListBindingPatterns := this.parseErrorArgListBindingPatterns()
-	closeParenthesis := this.parseCloseParenthesis()
-	this.endContext()
+func (b *BallerinaParser) parseErrorBindingPatternWithTypeRef(errorKeyword tree.STNode, typeRef tree.STNode) tree.STNode {
+	openParenthesis := b.parseOpenParenthesis()
+	argListBindingPatterns := b.parseErrorArgListBindingPatterns()
+	closeParenthesis := b.parseCloseParenthesis()
+	b.endContext()
 	return tree.CreateErrorBindingPatternNode(errorKeyword, typeRef, openParenthesis,
 		argListBindingPatterns, closeParenthesis)
 }
 
-func (this *BallerinaParser) parseErrorArgListBindingPatterns() tree.STNode {
+func (b *BallerinaParser) parseErrorArgListBindingPatterns() tree.STNode {
 	var argListBindingPatterns []tree.STNode
-	if this.isEndOfErrorFieldBindingPatterns() {
+	if b.isEndOfErrorFieldBindingPatterns() {
 		return tree.CreateNodeList(argListBindingPatterns...)
 	}
-	return this.parseErrorArgListBindingPatternsWithList(argListBindingPatterns)
+	return b.parseErrorArgListBindingPatternsWithList(argListBindingPatterns)
 }
 
-func (this *BallerinaParser) parseErrorArgListBindingPatternsWithList(argListBindingPatterns []tree.STNode) tree.STNode {
-	firstArg := this.parseErrorArgListBindingPattern(common.PARSER_RULE_CONTEXT_ERROR_ARG_LIST_BINDING_PATTERN_START, true)
+func (b *BallerinaParser) parseErrorArgListBindingPatternsWithList(argListBindingPatterns []tree.STNode) tree.STNode {
+	firstArg := b.parseErrorArgListBindingPattern(common.PARSER_RULE_CONTEXT_ERROR_ARG_LIST_BINDING_PATTERN_START, true)
 	if firstArg == nil {
 		return tree.CreateNodeList(argListBindingPatterns...)
 	}
 	switch firstArg.Kind() {
 	case common.CAPTURE_BINDING_PATTERN, common.WILDCARD_BINDING_PATTERN:
 		argListBindingPatterns = append(argListBindingPatterns, firstArg)
-		return this.parseErrorArgListBPWithoutErrorMsg(argListBindingPatterns)
+		return b.parseErrorArgListBPWithoutErrorMsg(argListBindingPatterns)
 	case common.ERROR_BINDING_PATTERN:
 		missingIdentifier := tree.CreateMissingToken(common.IDENTIFIER_TOKEN, nil)
 		missingErrorMsgBP := tree.CreateCaptureBindingPatternNode(missingIdentifier)
@@ -12286,23 +12286,23 @@ func (this *BallerinaParser) parseErrorArgListBindingPatternsWithList(argListBin
 		argListBindingPatterns = append(argListBindingPatterns, missingErrorMsgBP)
 		argListBindingPatterns = append(argListBindingPatterns, missingComma)
 		argListBindingPatterns = append(argListBindingPatterns, firstArg)
-		return this.parseErrorArgListBPWithoutErrorMsgAndCause(argListBindingPatterns, firstArg.Kind())
+		return b.parseErrorArgListBPWithoutErrorMsgAndCause(argListBindingPatterns, firstArg.Kind())
 	case common.NAMED_ARG_BINDING_PATTERN, common.REST_BINDING_PATTERN:
 		argListBindingPatterns = append(argListBindingPatterns, firstArg)
-		return this.parseErrorArgListBPWithoutErrorMsgAndCause(argListBindingPatterns, firstArg.Kind())
+		return b.parseErrorArgListBPWithoutErrorMsgAndCause(argListBindingPatterns, firstArg.Kind())
 	default:
-		this.addInvalidNodeToNextToken(firstArg, &common.ERROR_BINDING_PATTERN_NOT_ALLOWED)
-		return this.parseErrorArgListBindingPatternsWithList(argListBindingPatterns)
+		b.addInvalidNodeToNextToken(firstArg, &common.ERROR_BINDING_PATTERN_NOT_ALLOWED)
+		return b.parseErrorArgListBindingPatternsWithList(argListBindingPatterns)
 	}
 }
 
-func (this *BallerinaParser) parseErrorArgListBPWithoutErrorMsg(argListBindingPatterns []tree.STNode) tree.STNode {
-	argEnd := this.parseErrorArgsBindingPatternEnd(common.PARSER_RULE_CONTEXT_ERROR_MESSAGE_BINDING_PATTERN_END)
+func (b *BallerinaParser) parseErrorArgListBPWithoutErrorMsg(argListBindingPatterns []tree.STNode) tree.STNode {
+	argEnd := b.parseErrorArgsBindingPatternEnd(common.PARSER_RULE_CONTEXT_ERROR_MESSAGE_BINDING_PATTERN_END)
 	if argEnd == nil {
 		// null marks the end of args
 		return tree.CreateNodeList(argListBindingPatterns...)
 	}
-	secondArg := this.parseErrorArgListBindingPattern(common.PARSER_RULE_CONTEXT_ERROR_MESSAGE_BINDING_PATTERN_RHS, false)
+	secondArg := b.parseErrorArgListBindingPattern(common.PARSER_RULE_CONTEXT_ERROR_MESSAGE_BINDING_PATTERN_RHS, false)
 	if secondArg == nil { // depending on the recovery context we will not get null here
 		panic("assertion failed")
 	}
@@ -12310,46 +12310,46 @@ func (this *BallerinaParser) parseErrorArgListBPWithoutErrorMsg(argListBindingPa
 	case common.CAPTURE_BINDING_PATTERN, common.WILDCARD_BINDING_PATTERN, common.ERROR_BINDING_PATTERN, common.REST_BINDING_PATTERN, common.NAMED_ARG_BINDING_PATTERN:
 		argListBindingPatterns = append(argListBindingPatterns, argEnd)
 		argListBindingPatterns = append(argListBindingPatterns, secondArg)
-		return this.parseErrorArgListBPWithoutErrorMsgAndCause(argListBindingPatterns, secondArg.Kind())
+		return b.parseErrorArgListBPWithoutErrorMsgAndCause(argListBindingPatterns, secondArg.Kind())
 	default:
 		// we reach here for list and mapping binding patterns
 		// mark them as invalid and re-parse the second arg.
-		this.updateLastNodeInListWithInvalidNode(argListBindingPatterns, argEnd, nil)
-		this.updateLastNodeInListWithInvalidNode(argListBindingPatterns, secondArg,
+		b.updateLastNodeInListWithInvalidNode(argListBindingPatterns, argEnd, nil)
+		b.updateLastNodeInListWithInvalidNode(argListBindingPatterns, secondArg,
 			&common.ERROR_BINDING_PATTERN_NOT_ALLOWED)
-		return this.parseErrorArgListBPWithoutErrorMsg(argListBindingPatterns)
+		return b.parseErrorArgListBPWithoutErrorMsg(argListBindingPatterns)
 	}
 }
 
-func (this *BallerinaParser) parseErrorArgListBPWithoutErrorMsgAndCause(argListBindingPatterns []tree.STNode, lastValidArgKind common.SyntaxKind) tree.STNode {
-	for !this.isEndOfErrorFieldBindingPatterns() {
-		argEnd := this.parseErrorArgsBindingPatternEnd(common.PARSER_RULE_CONTEXT_ERROR_FIELD_BINDING_PATTERN_END)
+func (b *BallerinaParser) parseErrorArgListBPWithoutErrorMsgAndCause(argListBindingPatterns []tree.STNode, lastValidArgKind common.SyntaxKind) tree.STNode {
+	for !b.isEndOfErrorFieldBindingPatterns() {
+		argEnd := b.parseErrorArgsBindingPatternEnd(common.PARSER_RULE_CONTEXT_ERROR_FIELD_BINDING_PATTERN_END)
 		if argEnd == nil {
 			// null marks the end of args
 			break
 		}
-		currentArg := this.parseErrorArgListBindingPattern(common.PARSER_RULE_CONTEXT_ERROR_FIELD_BINDING_PATTERN, false)
+		currentArg := b.parseErrorArgListBindingPattern(common.PARSER_RULE_CONTEXT_ERROR_FIELD_BINDING_PATTERN, false)
 		if currentArg == nil { // depending on the recovery context we will not get null here
 			panic("assertion failed")
 		}
-		errorCode := this.validateErrorFieldBindingPatternOrder(lastValidArgKind, currentArg.Kind())
+		errorCode := b.validateErrorFieldBindingPatternOrder(lastValidArgKind, currentArg.Kind())
 		if errorCode == nil {
 			argListBindingPatterns = append(argListBindingPatterns, argEnd)
 			argListBindingPatterns = append(argListBindingPatterns, currentArg)
 			lastValidArgKind = currentArg.Kind()
 		} else if len(argListBindingPatterns) == 0 {
-			this.addInvalidNodeToNextToken(argEnd, nil)
-			this.addInvalidNodeToNextToken(currentArg, errorCode)
+			b.addInvalidNodeToNextToken(argEnd, nil)
+			b.addInvalidNodeToNextToken(currentArg, errorCode)
 		} else {
-			this.updateLastNodeInListWithInvalidNode(argListBindingPatterns, argEnd, nil)
-			this.updateLastNodeInListWithInvalidNode(argListBindingPatterns, currentArg, errorCode)
+			b.updateLastNodeInListWithInvalidNode(argListBindingPatterns, argEnd, nil)
+			b.updateLastNodeInListWithInvalidNode(argListBindingPatterns, currentArg, errorCode)
 		}
 	}
 	return tree.CreateNodeList(argListBindingPatterns...)
 }
 
-func (this *BallerinaParser) isEndOfErrorFieldBindingPatterns() bool {
-	nextTokenKind := this.peek().Kind()
+func (b *BallerinaParser) isEndOfErrorFieldBindingPatterns() bool {
+	nextTokenKind := b.peek().Kind()
 	switch nextTokenKind {
 	case common.CLOSE_PAREN_TOKEN, common.EOF_TOKEN:
 		return true
@@ -12358,54 +12358,54 @@ func (this *BallerinaParser) isEndOfErrorFieldBindingPatterns() bool {
 	}
 }
 
-func (this *BallerinaParser) parseErrorArgsBindingPatternEnd(currentCtx common.ParserRuleContext) tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseErrorArgsBindingPatternEnd(currentCtx common.ParserRuleContext) tree.STNode {
+	switch b.peek().Kind() {
 	case common.COMMA_TOKEN:
-		return this.parseComma()
+		return b.parseComma()
 	case common.CLOSE_PAREN_TOKEN:
 		return nil
 	default:
-		this.recoverWithBlockContext(this.peek(), currentCtx)
-		return this.parseErrorArgsBindingPatternEnd(currentCtx)
+		b.recoverWithBlockContext(b.peek(), currentCtx)
+		return b.parseErrorArgsBindingPatternEnd(currentCtx)
 	}
 }
 
-func (this *BallerinaParser) parseErrorArgListBindingPattern(context common.ParserRuleContext, isFirstArg bool) tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseErrorArgListBindingPattern(context common.ParserRuleContext, isFirstArg bool) tree.STNode {
+	switch b.peek().Kind() {
 	case common.ELLIPSIS_TOKEN:
-		return this.parseRestBindingPattern()
+		return b.parseRestBindingPattern()
 	case common.IDENTIFIER_TOKEN:
-		argNameOrSimpleBindingPattern := this.consume()
-		return this.parseNamedOrSimpleArgBindingPattern(argNameOrSimpleBindingPattern)
+		argNameOrSimpleBindingPattern := b.consume()
+		return b.parseNamedOrSimpleArgBindingPattern(argNameOrSimpleBindingPattern)
 	case common.OPEN_BRACKET_TOKEN, common.OPEN_BRACE_TOKEN, common.ERROR_KEYWORD:
-		return this.parseBindingPattern()
+		return b.parseBindingPattern()
 	case common.CLOSE_PAREN_TOKEN:
 		if isFirstArg {
 			return nil
 		}
 		fallthrough
 	default:
-		this.recoverWithBlockContext(this.peek(), context)
-		return this.parseErrorArgListBindingPattern(context, isFirstArg)
+		b.recoverWithBlockContext(b.peek(), context)
+		return b.parseErrorArgListBindingPattern(context, isFirstArg)
 	}
 }
 
-func (this *BallerinaParser) parseNamedOrSimpleArgBindingPattern(argNameOrSimpleBindingPattern tree.STNode) tree.STNode {
-	secondToken := this.peek()
+func (b *BallerinaParser) parseNamedOrSimpleArgBindingPattern(argNameOrSimpleBindingPattern tree.STNode) tree.STNode {
+	secondToken := b.peek()
 	switch secondToken.Kind() {
 	case common.EQUAL_TOKEN:
-		equal := this.consume()
-		bindingPattern := this.parseBindingPattern()
+		equal := b.consume()
+		bindingPattern := b.parseBindingPattern()
 		return tree.CreateNamedArgBindingPatternNode(argNameOrSimpleBindingPattern,
 			equal, bindingPattern)
 	case common.COMMA_TOKEN, common.CLOSE_PAREN_TOKEN:
 		fallthrough
 	default:
-		return this.createCaptureOrWildcardBP(argNameOrSimpleBindingPattern)
+		return b.createCaptureOrWildcardBP(argNameOrSimpleBindingPattern)
 	}
 }
 
-func (this *BallerinaParser) validateErrorFieldBindingPatternOrder(prevArgKind common.SyntaxKind, currentArgKind common.SyntaxKind) *common.DiagnosticErrorCode {
+func (b *BallerinaParser) validateErrorFieldBindingPatternOrder(prevArgKind common.SyntaxKind, currentArgKind common.SyntaxKind) *common.DiagnosticErrorCode {
 	switch currentArgKind {
 	case common.NAMED_ARG_BINDING_PATTERN,
 		common.REST_BINDING_PATTERN:
@@ -12418,18 +12418,18 @@ func (this *BallerinaParser) validateErrorFieldBindingPatternOrder(prevArgKind c
 	}
 }
 
-func (this *BallerinaParser) parseTypedBindingPatternTypeRhs(typeDesc tree.STNode, context common.ParserRuleContext) tree.STNode {
-	return this.parseTypedBindingPatternTypeRhsWithRoot(typeDesc, context, true)
+func (b *BallerinaParser) parseTypedBindingPatternTypeRhs(typeDesc tree.STNode, context common.ParserRuleContext) tree.STNode {
+	return b.parseTypedBindingPatternTypeRhsWithRoot(typeDesc, context, true)
 }
 
-func (this *BallerinaParser) parseTypedBindingPatternTypeRhsWithRoot(typeDesc tree.STNode, context common.ParserRuleContext, isRoot bool) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseTypedBindingPatternTypeRhsWithRoot(typeDesc tree.STNode, context common.ParserRuleContext, isRoot bool) tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.IDENTIFIER_TOKEN, common.OPEN_BRACE_TOKEN, common.ERROR_KEYWORD:
-		bindingPattern := this.parseBindingPattern()
+		bindingPattern := b.parseBindingPattern()
 		return tree.CreateTypedBindingPatternNode(typeDesc, bindingPattern)
 	case common.OPEN_BRACKET_TOKEN:
-		typedBindingPattern := this.parseTypedBindingPatternOrMemberAccess(typeDesc, true, true, context)
+		typedBindingPattern := b.parseTypedBindingPatternOrMemberAccess(typeDesc, true, true, context)
 		if typedBindingPattern.Kind() != common.TYPED_BINDING_PATTERN {
 			panic("assertion failed")
 		}
@@ -12440,60 +12440,60 @@ func (this *BallerinaParser) parseTypedBindingPatternTypeRhsWithRoot(typeDesc tr
 		}
 		fallthrough
 	default:
-		this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_TYPED_BINDING_PATTERN_TYPE_RHS)
-		return this.parseTypedBindingPatternTypeRhsWithRoot(typeDesc, context, isRoot)
+		b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_TYPED_BINDING_PATTERN_TYPE_RHS)
+		return b.parseTypedBindingPatternTypeRhsWithRoot(typeDesc, context, isRoot)
 	}
 }
 
-func (this *BallerinaParser) parseTypedBindingPatternOrMemberAccess(typeDescOrExpr tree.STNode, isTypedBindingPattern bool, allowAssignment bool, context common.ParserRuleContext) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_BRACKETED_LIST)
-	openBracket := this.parseOpenBracket()
-	if this.isBracketedListEnd(this.peek().Kind()) {
-		return this.parseAsArrayTypeDesc(typeDescOrExpr, openBracket, tree.CreateEmptyNode(), context)
+func (b *BallerinaParser) parseTypedBindingPatternOrMemberAccess(typeDescOrExpr tree.STNode, isTypedBindingPattern bool, allowAssignment bool, context common.ParserRuleContext) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_BRACKETED_LIST)
+	openBracket := b.parseOpenBracket()
+	if b.isBracketedListEnd(b.peek().Kind()) {
+		return b.parseAsArrayTypeDesc(typeDescOrExpr, openBracket, tree.CreateEmptyNode(), context)
 	}
-	member := this.parseBracketedListMember(isTypedBindingPattern)
-	currentNodeType := this.getBracketedListNodeType(member, isTypedBindingPattern)
+	member := b.parseBracketedListMember(isTypedBindingPattern)
+	currentNodeType := b.getBracketedListNodeType(member, isTypedBindingPattern)
 	switch currentNodeType {
 	case common.ARRAY_TYPE_DESC:
-		typedBindingPattern := this.parseAsArrayTypeDesc(typeDescOrExpr, openBracket, member, context)
+		typedBindingPattern := b.parseAsArrayTypeDesc(typeDescOrExpr, openBracket, member, context)
 		return typedBindingPattern
 	case common.LIST_BINDING_PATTERN:
-		bindingPattern, _ := this.parseAsListBindingPatternWithMemberAndRoot(openBracket, nil, member, false)
-		typeDesc := this.getTypeDescFromExpr(typeDescOrExpr)
+		bindingPattern, _ := b.parseAsListBindingPatternWithMemberAndRoot(openBracket, nil, member, false)
+		typeDesc := b.getTypeDescFromExpr(typeDescOrExpr)
 		return tree.CreateTypedBindingPatternNode(typeDesc, bindingPattern)
 	case common.INDEXED_EXPRESSION:
-		return this.parseAsMemberAccessExpr(typeDescOrExpr, openBracket, member)
+		return b.parseAsMemberAccessExpr(typeDescOrExpr, openBracket, member)
 	case common.ARRAY_TYPE_DESC_OR_MEMBER_ACCESS:
 		break
 	case common.NONE:
 		fallthrough
 	default:
-		memberEnd := this.parseBracketedListMemberEnd()
+		memberEnd := b.parseBracketedListMemberEnd()
 		if memberEnd != nil {
 			var memberList []tree.STNode
-			memberList = append(memberList, this.getBindingPattern(member, true))
+			memberList = append(memberList, b.getBindingPattern(member, true))
 			memberList = append(memberList, memberEnd)
-			bindingPattern, memberList := this.parseAsListBindingPattern(openBracket, memberList) //nolint:staticcheck,ineffassign // memberList will be used when list binding pattern is fully implemented
-			typeDesc := this.getTypeDescFromExpr(typeDescOrExpr)
+			bindingPattern, memberList := b.parseAsListBindingPattern(openBracket, memberList) //nolint:staticcheck,ineffassign // memberList will be used when list binding pattern is fully implemented
+			typeDesc := b.getTypeDescFromExpr(typeDescOrExpr)
 			return tree.CreateTypedBindingPatternNode(typeDesc, bindingPattern)
 		}
 	}
-	closeBracket := this.parseCloseBracket()
-	this.endContext()
-	return this.parseTypedBindingPatternOrMemberAccessRhs(typeDescOrExpr, openBracket, member, closeBracket,
+	closeBracket := b.parseCloseBracket()
+	b.endContext()
+	return b.parseTypedBindingPatternOrMemberAccessRhs(typeDescOrExpr, openBracket, member, closeBracket,
 		isTypedBindingPattern, allowAssignment, context)
 }
 
-func (this *BallerinaParser) parseAsMemberAccessExpr(typeNameOrExpr tree.STNode, openBracket tree.STNode, member tree.STNode) tree.STNode {
-	member = this.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, member, false, true)
-	closeBracket := this.parseCloseBracket()
-	this.endContext()
+func (b *BallerinaParser) parseAsMemberAccessExpr(typeNameOrExpr tree.STNode, openBracket tree.STNode, member tree.STNode) tree.STNode {
+	member = b.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, member, false, true)
+	closeBracket := b.parseCloseBracket()
+	b.endContext()
 	keyExpr := tree.CreateNodeList(member)
 	memberAccessExpr := tree.CreateIndexedExpressionNode(typeNameOrExpr, openBracket, keyExpr, closeBracket)
-	return this.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, memberAccessExpr, false, false)
+	return b.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, memberAccessExpr, false, false)
 }
 
-func (this *BallerinaParser) isBracketedListEnd(nextTokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isBracketedListEnd(nextTokenKind common.SyntaxKind) bool {
 	switch nextTokenKind {
 	case common.EOF_TOKEN, common.CLOSE_BRACKET_TOKEN:
 		return true
@@ -12502,22 +12502,22 @@ func (this *BallerinaParser) isBracketedListEnd(nextTokenKind common.SyntaxKind)
 	}
 }
 
-func (this *BallerinaParser) parseBracketedListMember(isTypedBindingPattern bool) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseBracketedListMember(isTypedBindingPattern bool) tree.STNode {
+	nextToken := b.peek()
 
 	switch nextToken.Kind() {
 	case common.DECIMAL_INTEGER_LITERAL_TOKEN, common.HEX_INTEGER_LITERAL_TOKEN, common.ASTERISK_TOKEN, common.STRING_LITERAL_TOKEN:
-		return this.parseBasicLiteral()
+		return b.parseBasicLiteral()
 	case common.CLOSE_BRACKET_TOKEN:
 		return tree.CreateEmptyNode()
 	case common.OPEN_BRACE_TOKEN, common.ERROR_KEYWORD, common.ELLIPSIS_TOKEN, common.OPEN_BRACKET_TOKEN:
-		return this.parseStatementStartBracketedListMember()
+		return b.parseStatementStartBracketedListMember()
 	case common.IDENTIFIER_TOKEN:
 		if isTypedBindingPattern {
-			return this.parseQualifiedIdentifier(common.PARSER_RULE_CONTEXT_VARIABLE_REF)
+			return b.parseQualifiedIdentifier(common.PARSER_RULE_CONTEXT_VARIABLE_REF)
 		}
 	default:
-		if ((!isTypedBindingPattern) && this.isValidExpressionStart(nextToken.Kind(), 1)) || this.isQualifiedIdentifierPredeclaredPrefix(nextToken.Kind()) {
+		if ((!isTypedBindingPattern) && b.isValidExpressionStart(nextToken.Kind(), 1)) || b.isQualifiedIdentifierPredeclaredPrefix(nextToken.Kind()) {
 			break
 		}
 		var recoverContext common.ParserRuleContext
@@ -12526,97 +12526,97 @@ func (this *BallerinaParser) parseBracketedListMember(isTypedBindingPattern bool
 		} else {
 			recoverContext = common.PARSER_RULE_CONTEXT_BRACKETED_LIST_MEMBER
 		}
-		this.recoverWithBlockContext(this.peek(), recoverContext)
-		return this.parseBracketedListMember(isTypedBindingPattern)
+		b.recoverWithBlockContext(b.peek(), recoverContext)
+		return b.parseBracketedListMember(isTypedBindingPattern)
 	}
-	expr := this.parseExpression()
-	if this.isWildcardBP(expr) {
-		return this.getWildcardBindingPattern(expr)
+	expr := b.parseExpression()
+	if b.isWildcardBP(expr) {
+		return b.getWildcardBindingPattern(expr)
 	}
 
 	// we don't know which one
 	return expr
 }
 
-func (this *BallerinaParser) parseAsArrayTypeDesc(typeDesc tree.STNode, openBracket tree.STNode, member tree.STNode, context common.ParserRuleContext) tree.STNode {
-	typeDesc = this.getTypeDescFromExpr(typeDesc)
-	this.switchContext(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN)
-	this.startContext(common.PARSER_RULE_CONTEXT_ARRAY_TYPE_DESCRIPTOR)
-	closeBracket := this.parseCloseBracket()
-	this.endContext()
-	this.endContext()
-	return this.parseTypedBindingPatternOrMemberAccessRhs(typeDesc, openBracket, member, closeBracket, true, true,
+func (b *BallerinaParser) parseAsArrayTypeDesc(typeDesc tree.STNode, openBracket tree.STNode, member tree.STNode, context common.ParserRuleContext) tree.STNode {
+	typeDesc = b.getTypeDescFromExpr(typeDesc)
+	b.switchContext(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN)
+	b.startContext(common.PARSER_RULE_CONTEXT_ARRAY_TYPE_DESCRIPTOR)
+	closeBracket := b.parseCloseBracket()
+	b.endContext()
+	b.endContext()
+	return b.parseTypedBindingPatternOrMemberAccessRhs(typeDesc, openBracket, member, closeBracket, true, true,
 		context)
 }
 
-func (this *BallerinaParser) parseBracketedListMemberEnd() tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseBracketedListMemberEnd() tree.STNode {
+	switch b.peek().Kind() {
 	case common.COMMA_TOKEN:
-		return this.parseComma()
+		return b.parseComma()
 	case common.CLOSE_BRACKET_TOKEN:
 		return nil
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_BRACKETED_LIST_MEMBER_END)
-		return this.parseBracketedListMemberEnd()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_BRACKETED_LIST_MEMBER_END)
+		return b.parseBracketedListMemberEnd()
 	}
 }
 
-func (this *BallerinaParser) parseTypedBindingPatternOrMemberAccessRhs(typeDescOrExpr tree.STNode, openBracket tree.STNode, member tree.STNode, closeBracket tree.STNode, isTypedBindingPattern bool, allowAssignment bool, context common.ParserRuleContext) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseTypedBindingPatternOrMemberAccessRhs(typeDescOrExpr tree.STNode, openBracket tree.STNode, member tree.STNode, closeBracket tree.STNode, isTypedBindingPattern bool, allowAssignment bool, context common.ParserRuleContext) tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.IDENTIFIER_TOKEN, common.OPEN_BRACE_TOKEN, common.ERROR_KEYWORD:
-		typeDesc := this.getTypeDescFromExpr(typeDescOrExpr)
-		arrayTypeDesc := this.getArrayTypeDesc(openBracket, member, closeBracket, typeDesc)
-		return this.parseTypedBindingPatternTypeRhs(arrayTypeDesc, context)
+		typeDesc := b.getTypeDescFromExpr(typeDescOrExpr)
+		arrayTypeDesc := b.getArrayTypeDesc(openBracket, member, closeBracket, typeDesc)
+		return b.parseTypedBindingPatternTypeRhs(arrayTypeDesc, context)
 	case common.OPEN_BRACKET_TOKEN:
 		if isTypedBindingPattern {
-			typeDesc := this.getTypeDescFromExpr(typeDescOrExpr)
-			arrayTypeDesc := this.getArrayTypeDesc(openBracket, member, closeBracket, typeDesc)
-			return this.parseTypedBindingPatternTypeRhs(arrayTypeDesc, context)
+			typeDesc := b.getTypeDescFromExpr(typeDescOrExpr)
+			arrayTypeDesc := b.getArrayTypeDesc(openBracket, member, closeBracket, typeDesc)
+			return b.parseTypedBindingPatternTypeRhs(arrayTypeDesc, context)
 		}
-		keyExpr := this.getKeyExpr(member)
+		keyExpr := b.getKeyExpr(member)
 		expr := tree.CreateIndexedExpressionNode(typeDescOrExpr, openBracket, keyExpr, closeBracket)
-		return this.parseTypedBindingPatternOrMemberAccess(expr, false, allowAssignment, context)
+		return b.parseTypedBindingPatternOrMemberAccess(expr, false, allowAssignment, context)
 	case common.QUESTION_MARK_TOKEN:
-		typeDesc := this.getTypeDescFromExpr(typeDescOrExpr)
-		arrayTypeDesc := this.getArrayTypeDesc(openBracket, member, closeBracket, typeDesc)
-		typeDesc = this.parseComplexTypeDescriptor(arrayTypeDesc,
+		typeDesc := b.getTypeDescFromExpr(typeDescOrExpr)
+		arrayTypeDesc := b.getArrayTypeDesc(openBracket, member, closeBracket, typeDesc)
+		typeDesc = b.parseComplexTypeDescriptor(arrayTypeDesc,
 			common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN, true)
-		return this.parseTypedBindingPatternTypeRhs(typeDesc, context)
+		return b.parseTypedBindingPatternTypeRhs(typeDesc, context)
 	case common.PIPE_TOKEN, common.BITWISE_AND_TOKEN:
-		return this.parseComplexTypeDescInTypedBPOrExprRhs(typeDescOrExpr, openBracket, member, closeBracket,
+		return b.parseComplexTypeDescInTypedBPOrExprRhs(typeDescOrExpr, openBracket, member, closeBracket,
 			isTypedBindingPattern)
 	case common.IN_KEYWORD:
 		if ((context != common.PARSER_RULE_CONTEXT_FOREACH_STMT) && (context != common.PARSER_RULE_CONTEXT_FROM_CLAUSE)) && (context != common.PARSER_RULE_CONTEXT_JOIN_CLAUSE) {
 			break
 		}
-		return this.createTypedBindingPattern(typeDescOrExpr, openBracket, member, closeBracket)
+		return b.createTypedBindingPattern(typeDescOrExpr, openBracket, member, closeBracket)
 	case common.EQUAL_TOKEN:
 		if (context == common.PARSER_RULE_CONTEXT_FOREACH_STMT) || (context == common.PARSER_RULE_CONTEXT_FROM_CLAUSE) {
 			break
 		}
-		if (isTypedBindingPattern || (!allowAssignment)) || (!this.isValidLVExpr(typeDescOrExpr)) {
-			return this.createTypedBindingPattern(typeDescOrExpr, openBracket, member, closeBracket)
+		if (isTypedBindingPattern || (!allowAssignment)) || (!b.isValidLVExpr(typeDescOrExpr)) {
+			return b.createTypedBindingPattern(typeDescOrExpr, openBracket, member, closeBracket)
 		}
-		keyExpr := this.getKeyExpr(member)
-		typeDescOrExpr = this.getExpression(typeDescOrExpr)
+		keyExpr := b.getKeyExpr(member)
+		typeDescOrExpr = b.getExpression(typeDescOrExpr)
 		return tree.CreateIndexedExpressionNode(typeDescOrExpr, openBracket, keyExpr, closeBracket)
 	case common.SEMICOLON_TOKEN:
 		if (context == common.PARSER_RULE_CONTEXT_FOREACH_STMT) || (context == common.PARSER_RULE_CONTEXT_FROM_CLAUSE) {
 			break
 		}
-		return this.createTypedBindingPattern(typeDescOrExpr, openBracket, member, closeBracket)
+		return b.createTypedBindingPattern(typeDescOrExpr, openBracket, member, closeBracket)
 	case common.CLOSE_BRACE_TOKEN, common.COMMA_TOKEN:
 		if context == common.PARSER_RULE_CONTEXT_AMBIGUOUS_STMT {
-			keyExpr := this.getKeyExpr(member)
+			keyExpr := b.getKeyExpr(member)
 			return tree.CreateIndexedExpressionNode(typeDescOrExpr, openBracket, keyExpr,
 				closeBracket)
 		}
 		return nil
 	default:
-		if (!isTypedBindingPattern) && this.isValidExprRhsStart(nextToken.Kind(), closeBracket.Kind()) {
-			keyExpr := this.getKeyExpr(member)
-			typeDescOrExpr = this.getExpression(typeDescOrExpr)
+		if (!isTypedBindingPattern) && b.isValidExprRhsStart(nextToken.Kind(), closeBracket.Kind()) {
+			keyExpr := b.getKeyExpr(member)
+			typeDescOrExpr = b.getExpression(typeDescOrExpr)
 			return tree.CreateIndexedExpressionNode(typeDescOrExpr, openBracket, keyExpr,
 				closeBracket)
 		}
@@ -12625,12 +12625,12 @@ func (this *BallerinaParser) parseTypedBindingPatternOrMemberAccessRhs(typeDescO
 	if isTypedBindingPattern {
 		recoveryCtx = common.PARSER_RULE_CONTEXT_TYPE_DESC_RHS_OR_BP_RHS
 	}
-	this.recoverWithBlockContext(this.peek(), recoveryCtx)
-	return this.parseTypedBindingPatternOrMemberAccessRhs(typeDescOrExpr, openBracket, member, closeBracket,
+	b.recoverWithBlockContext(b.peek(), recoveryCtx)
+	return b.parseTypedBindingPatternOrMemberAccessRhs(typeDescOrExpr, openBracket, member, closeBracket,
 		isTypedBindingPattern, allowAssignment, context)
 }
 
-func (this *BallerinaParser) getKeyExpr(member tree.STNode) tree.STNode {
+func (b *BallerinaParser) getKeyExpr(member tree.STNode) tree.STNode {
 	if member == nil {
 		keyIdentifier := tree.CreateMissingTokenWithDiagnostics(common.IDENTIFIER_TOKEN,
 			&common.ERROR_MISSING_KEY_EXPR_IN_MEMBER_ACCESS_EXPR)
@@ -12640,73 +12640,73 @@ func (this *BallerinaParser) getKeyExpr(member tree.STNode) tree.STNode {
 	return tree.CreateNodeList(member)
 }
 
-func (this *BallerinaParser) createTypedBindingPattern(typeDescOrExpr tree.STNode, openBracket tree.STNode, member tree.STNode, closeBracket tree.STNode) tree.STNode {
+func (b *BallerinaParser) createTypedBindingPattern(typeDescOrExpr tree.STNode, openBracket tree.STNode, member tree.STNode, closeBracket tree.STNode) tree.STNode {
 	bindingPatterns := tree.CreateEmptyNodeList()
-	if !this.isEmpty(member) {
+	if !b.isEmpty(member) {
 		memberKind := member.Kind()
 		if (memberKind == common.NUMERIC_LITERAL) || (memberKind == common.ASTERISK_LITERAL) {
-			typeDesc := this.getTypeDescFromExpr(typeDescOrExpr)
-			arrayTypeDesc := this.getArrayTypeDesc(openBracket, member, closeBracket, typeDesc)
+			typeDesc := b.getTypeDescFromExpr(typeDescOrExpr)
+			arrayTypeDesc := b.getArrayTypeDesc(openBracket, member, closeBracket, typeDesc)
 			identifierToken := tree.CreateMissingTokenWithDiagnostics(common.IDENTIFIER_TOKEN,
 				&common.ERROR_MISSING_VARIABLE_NAME)
 			variableName := tree.CreateCaptureBindingPatternNode(identifierToken)
 			return tree.CreateTypedBindingPatternNode(arrayTypeDesc, variableName)
 		}
-		bindingPattern := this.getBindingPattern(member, true)
+		bindingPattern := b.getBindingPattern(member, true)
 		bindingPatterns = tree.CreateNodeList(bindingPattern)
 	}
 	bindingPattern := tree.CreateListBindingPatternNode(openBracket, bindingPatterns, closeBracket)
-	typeDesc := this.getTypeDescFromExpr(typeDescOrExpr)
+	typeDesc := b.getTypeDescFromExpr(typeDescOrExpr)
 	return tree.CreateTypedBindingPatternNode(typeDesc, bindingPattern)
 }
 
-func (this *BallerinaParser) parseComplexTypeDescInTypedBPOrExprRhs(typeDescOrExpr tree.STNode, openBracket tree.STNode, member tree.STNode, closeBracket tree.STNode, isTypedBindingPattern bool) tree.STNode {
-	pipeOrAndToken := this.parseUnionOrIntersectionToken()
-	typedBindingPatternOrExpr := this.parseTypedBindingPatternOrExpr(false)
+func (b *BallerinaParser) parseComplexTypeDescInTypedBPOrExprRhs(typeDescOrExpr tree.STNode, openBracket tree.STNode, member tree.STNode, closeBracket tree.STNode, isTypedBindingPattern bool) tree.STNode {
+	pipeOrAndToken := b.parseUnionOrIntersectionToken()
+	typedBindingPatternOrExpr := b.parseTypedBindingPatternOrExpr(false)
 	if typedBindingPatternOrExpr.Kind() == common.TYPED_BINDING_PATTERN {
-		lhsTypeDesc := this.getTypeDescFromExpr(typeDescOrExpr)
-		lhsTypeDesc = this.getArrayTypeDesc(openBracket, member, closeBracket, lhsTypeDesc)
+		lhsTypeDesc := b.getTypeDescFromExpr(typeDescOrExpr)
+		lhsTypeDesc = b.getArrayTypeDesc(openBracket, member, closeBracket, lhsTypeDesc)
 		rhsTypedBindingPattern, ok := typedBindingPatternOrExpr.(*tree.STTypedBindingPatternNode)
 		if !ok {
 			panic("expected *tree.STTypedBindingPatternNode")
 		}
 		rhsTypeDesc := rhsTypedBindingPattern.TypeDescriptor
-		newTypeDesc := this.mergeTypes(lhsTypeDesc, pipeOrAndToken, rhsTypeDesc)
+		newTypeDesc := b.mergeTypes(lhsTypeDesc, pipeOrAndToken, rhsTypeDesc)
 		return tree.CreateTypedBindingPatternNode(newTypeDesc, rhsTypedBindingPattern.BindingPattern)
 	}
 	if isTypedBindingPattern {
-		lhsTypeDesc := this.getTypeDescFromExpr(typeDescOrExpr)
-		lhsTypeDesc = this.getArrayTypeDesc(openBracket, member, closeBracket, lhsTypeDesc)
-		return this.createCaptureBPWithMissingVarName(lhsTypeDesc, pipeOrAndToken, typedBindingPatternOrExpr)
+		lhsTypeDesc := b.getTypeDescFromExpr(typeDescOrExpr)
+		lhsTypeDesc = b.getArrayTypeDesc(openBracket, member, closeBracket, lhsTypeDesc)
+		return b.createCaptureBPWithMissingVarName(lhsTypeDesc, pipeOrAndToken, typedBindingPatternOrExpr)
 	}
-	keyExpr := this.getExpression(member)
-	containerExpr := this.getExpression(typeDescOrExpr)
+	keyExpr := b.getExpression(member)
+	containerExpr := b.getExpression(typeDescOrExpr)
 	lhsExpr := tree.CreateIndexedExpressionNode(containerExpr, openBracket, keyExpr, closeBracket)
 	return tree.CreateBinaryExpressionNode(common.BINARY_EXPRESSION, lhsExpr, pipeOrAndToken,
 		typedBindingPatternOrExpr)
 }
 
-func (this *BallerinaParser) mergeTypes(lhsTypeDesc tree.STNode, pipeOrAndToken tree.STNode, rhsTypeDesc tree.STNode) tree.STNode {
+func (b *BallerinaParser) mergeTypes(lhsTypeDesc tree.STNode, pipeOrAndToken tree.STNode, rhsTypeDesc tree.STNode) tree.STNode {
 	if pipeOrAndToken.Kind() == common.PIPE_TOKEN {
-		return this.mergeTypesWithUnion(lhsTypeDesc, pipeOrAndToken, rhsTypeDesc)
+		return b.mergeTypesWithUnion(lhsTypeDesc, pipeOrAndToken, rhsTypeDesc)
 	} else {
-		return this.mergeTypesWithIntersection(lhsTypeDesc, pipeOrAndToken, rhsTypeDesc)
+		return b.mergeTypesWithIntersection(lhsTypeDesc, pipeOrAndToken, rhsTypeDesc)
 	}
 }
 
-func (this *BallerinaParser) mergeTypesWithUnion(lhsTypeDesc tree.STNode, pipeToken tree.STNode, rhsTypeDesc tree.STNode) tree.STNode {
+func (b *BallerinaParser) mergeTypesWithUnion(lhsTypeDesc tree.STNode, pipeToken tree.STNode, rhsTypeDesc tree.STNode) tree.STNode {
 	if rhsTypeDesc.Kind() == common.UNION_TYPE_DESC {
 		rhsUnionTypeDesc, ok := rhsTypeDesc.(*tree.STUnionTypeDescriptorNode)
 		if !ok {
 			panic("expected *tree.STUnionTypeDescriptorNode")
 		}
-		return this.replaceLeftMostUnionWithAUnion(lhsTypeDesc, pipeToken, rhsUnionTypeDesc)
+		return b.replaceLeftMostUnionWithAUnion(lhsTypeDesc, pipeToken, rhsUnionTypeDesc)
 	} else {
-		return this.createUnionTypeDesc(lhsTypeDesc, pipeToken, rhsTypeDesc)
+		return b.createUnionTypeDesc(lhsTypeDesc, pipeToken, rhsTypeDesc)
 	}
 }
 
-func (this *BallerinaParser) mergeTypesWithIntersection(lhsTypeDesc tree.STNode, bitwiseAndToken tree.STNode, rhsTypeDesc tree.STNode) tree.STNode {
+func (b *BallerinaParser) mergeTypesWithIntersection(lhsTypeDesc tree.STNode, bitwiseAndToken tree.STNode, rhsTypeDesc tree.STNode) tree.STNode {
 	if lhsTypeDesc.Kind() == common.UNION_TYPE_DESC {
 		lhsUnionTypeDesc, ok := lhsTypeDesc.(*tree.STUnionTypeDescriptorNode)
 		if !ok {
@@ -12717,18 +12717,18 @@ func (this *BallerinaParser) mergeTypesWithIntersection(lhsTypeDesc tree.STNode,
 			if !ok {
 				panic("expected *tree.STIntersectionTypeDescriptorNode")
 			}
-			rhsTypeDesc = this.replaceLeftMostIntersectionWithAIntersection(lhsUnionTypeDesc.RightTypeDesc,
+			rhsTypeDesc = b.replaceLeftMostIntersectionWithAIntersection(lhsUnionTypeDesc.RightTypeDesc,
 				bitwiseAndToken, rhsIntSecTypeDesc)
-			return this.createUnionTypeDesc(lhsUnionTypeDesc.LeftTypeDesc, lhsUnionTypeDesc.PipeToken, rhsTypeDesc)
+			return b.createUnionTypeDesc(lhsUnionTypeDesc.LeftTypeDesc, lhsUnionTypeDesc.PipeToken, rhsTypeDesc)
 		} else if rhsTypeDesc.Kind() == common.UNION_TYPE_DESC {
 			rhsUnionTypeDesc, ok := rhsTypeDesc.(*tree.STUnionTypeDescriptorNode)
 			if !ok {
 				panic("expected *tree.STUnionTypeDescriptorNode")
 			}
 			//nolint:staticcheck // rhsTypeDesc reassigned but not yet used in return path
-			rhsTypeDesc = this.replaceLeftMostUnionWithAIntersection(lhsUnionTypeDesc.RightTypeDesc,
+			rhsTypeDesc = b.replaceLeftMostUnionWithAIntersection(lhsUnionTypeDesc.RightTypeDesc,
 				bitwiseAndToken, rhsUnionTypeDesc)
-			return this.replaceLeftMostUnionWithAUnion(lhsUnionTypeDesc.LeftTypeDesc,
+			return b.replaceLeftMostUnionWithAUnion(lhsUnionTypeDesc.LeftTypeDesc,
 				lhsUnionTypeDesc.PipeToken, rhsUnionTypeDesc)
 		}
 	}
@@ -12737,39 +12737,39 @@ func (this *BallerinaParser) mergeTypesWithIntersection(lhsTypeDesc tree.STNode,
 		if !ok {
 			panic("expected *tree.STUnionTypeDescriptorNode")
 		}
-		return this.replaceLeftMostUnionWithAIntersection(lhsTypeDesc, bitwiseAndToken, rhsUnionTypeDesc)
+		return b.replaceLeftMostUnionWithAIntersection(lhsTypeDesc, bitwiseAndToken, rhsUnionTypeDesc)
 	} else if rhsTypeDesc.Kind() == common.INTERSECTION_TYPE_DESC {
 		rhsIntSecTypeDesc, ok := rhsTypeDesc.(*tree.STIntersectionTypeDescriptorNode)
 		if !ok {
 			panic("expected *tree.STIntersectionTypeDescriptorNode")
 		}
-		return this.replaceLeftMostIntersectionWithAIntersection(lhsTypeDesc, bitwiseAndToken, rhsIntSecTypeDesc)
+		return b.replaceLeftMostIntersectionWithAIntersection(lhsTypeDesc, bitwiseAndToken, rhsIntSecTypeDesc)
 	}
-	return this.createIntersectionTypeDesc(lhsTypeDesc, bitwiseAndToken, rhsTypeDesc)
+	return b.createIntersectionTypeDesc(lhsTypeDesc, bitwiseAndToken, rhsTypeDesc)
 }
 
-func (this *BallerinaParser) replaceLeftMostUnionWithAUnion(typeDesc tree.STNode, pipeToken tree.STNode, unionTypeDesc *tree.STUnionTypeDescriptorNode) tree.STNode {
+func (b *BallerinaParser) replaceLeftMostUnionWithAUnion(typeDesc tree.STNode, pipeToken tree.STNode, unionTypeDesc *tree.STUnionTypeDescriptorNode) tree.STNode {
 	leftTypeDesc := unionTypeDesc.LeftTypeDesc
 	if leftTypeDesc.Kind() == common.UNION_TYPE_DESC {
 		leftUnionTypeDesc, ok := leftTypeDesc.(*tree.STUnionTypeDescriptorNode)
 		if !ok {
 			panic("expected *tree.STUnionTypeDescriptorNode")
 		}
-		newLeftTypeDesc := this.replaceLeftMostUnionWithAUnion(typeDesc, pipeToken, leftUnionTypeDesc)
+		newLeftTypeDesc := b.replaceLeftMostUnionWithAUnion(typeDesc, pipeToken, leftUnionTypeDesc)
 		return tree.Replace(unionTypeDesc, unionTypeDesc.LeftTypeDesc, newLeftTypeDesc)
 	}
-	leftTypeDesc = this.createUnionTypeDesc(typeDesc, pipeToken, leftTypeDesc)
+	leftTypeDesc = b.createUnionTypeDesc(typeDesc, pipeToken, leftTypeDesc)
 	return tree.Replace(unionTypeDesc, unionTypeDesc.LeftTypeDesc, leftTypeDesc)
 }
 
-func (this *BallerinaParser) replaceLeftMostUnionWithAIntersection(typeDesc tree.STNode, bitwiseAndToken tree.STNode, unionTypeDesc *tree.STUnionTypeDescriptorNode) tree.STNode {
+func (b *BallerinaParser) replaceLeftMostUnionWithAIntersection(typeDesc tree.STNode, bitwiseAndToken tree.STNode, unionTypeDesc *tree.STUnionTypeDescriptorNode) tree.STNode {
 	leftTypeDesc := unionTypeDesc.LeftTypeDesc
 	if leftTypeDesc.Kind() == common.UNION_TYPE_DESC {
 		leftUnionTypeDesc, ok := leftTypeDesc.(*tree.STUnionTypeDescriptorNode)
 		if !ok {
 			panic("expected *tree.STUnionTypeDescriptorNode")
 		}
-		newLeftTypeDesc := this.replaceLeftMostUnionWithAIntersection(typeDesc, bitwiseAndToken, leftUnionTypeDesc)
+		newLeftTypeDesc := b.replaceLeftMostUnionWithAIntersection(typeDesc, bitwiseAndToken, leftUnionTypeDesc)
 		return tree.Replace(unionTypeDesc, unionTypeDesc.LeftTypeDesc, newLeftTypeDesc)
 	}
 	if leftTypeDesc.Kind() == common.INTERSECTION_TYPE_DESC {
@@ -12777,64 +12777,64 @@ func (this *BallerinaParser) replaceLeftMostUnionWithAIntersection(typeDesc tree
 		if !ok {
 			panic("expected *tree.STIntersectionTypeDescriptorNode")
 		}
-		newLeftTypeDesc := this.replaceLeftMostIntersectionWithAIntersection(typeDesc, bitwiseAndToken, leftIntersectionTypeDesc)
+		newLeftTypeDesc := b.replaceLeftMostIntersectionWithAIntersection(typeDesc, bitwiseAndToken, leftIntersectionTypeDesc)
 		return tree.Replace(unionTypeDesc, unionTypeDesc.LeftTypeDesc, newLeftTypeDesc)
 	}
-	leftTypeDesc = this.createIntersectionTypeDesc(typeDesc, bitwiseAndToken, leftTypeDesc)
+	leftTypeDesc = b.createIntersectionTypeDesc(typeDesc, bitwiseAndToken, leftTypeDesc)
 	return tree.Replace(unionTypeDesc, unionTypeDesc.LeftTypeDesc, leftTypeDesc)
 }
 
-func (this *BallerinaParser) replaceLeftMostIntersectionWithAIntersection(typeDesc tree.STNode, bitwiseAndToken tree.STNode, intersectionTypeDesc *tree.STIntersectionTypeDescriptorNode) tree.STNode {
+func (b *BallerinaParser) replaceLeftMostIntersectionWithAIntersection(typeDesc tree.STNode, bitwiseAndToken tree.STNode, intersectionTypeDesc *tree.STIntersectionTypeDescriptorNode) tree.STNode {
 	leftTypeDesc := intersectionTypeDesc.LeftTypeDesc
 	if leftTypeDesc.Kind() == common.INTERSECTION_TYPE_DESC {
 		leftIntersectionTypeDesc, ok := leftTypeDesc.(*tree.STIntersectionTypeDescriptorNode)
 		if !ok {
 			panic("expected *tree.STIntersectionTypeDescriptorNode")
 		}
-		newLeftTypeDesc := this.replaceLeftMostIntersectionWithAIntersection(typeDesc, bitwiseAndToken, leftIntersectionTypeDesc)
+		newLeftTypeDesc := b.replaceLeftMostIntersectionWithAIntersection(typeDesc, bitwiseAndToken, leftIntersectionTypeDesc)
 		return tree.Replace(intersectionTypeDesc, intersectionTypeDesc.LeftTypeDesc, newLeftTypeDesc)
 	}
-	leftTypeDesc = this.createIntersectionTypeDesc(typeDesc, bitwiseAndToken, leftTypeDesc)
+	leftTypeDesc = b.createIntersectionTypeDesc(typeDesc, bitwiseAndToken, leftTypeDesc)
 	return tree.Replace(intersectionTypeDesc, intersectionTypeDesc.LeftTypeDesc, leftTypeDesc)
 }
 
-func (this *BallerinaParser) getArrayTypeDesc(openBracket tree.STNode, member tree.STNode, closeBracket tree.STNode, lhsTypeDesc tree.STNode) tree.STNode {
+func (b *BallerinaParser) getArrayTypeDesc(openBracket tree.STNode, member tree.STNode, closeBracket tree.STNode, lhsTypeDesc tree.STNode) tree.STNode {
 	if lhsTypeDesc.Kind() == common.UNION_TYPE_DESC {
 		unionTypeDesc, ok := lhsTypeDesc.(*tree.STUnionTypeDescriptorNode)
 		if !ok {
 			panic("expected *tree.STUnionTypeDescriptorNode")
 		}
-		middleTypeDesc := this.getArrayTypeDesc(openBracket, member, closeBracket, unionTypeDesc.RightTypeDesc)
-		lhsTypeDesc = this.mergeTypesWithUnion(unionTypeDesc.LeftTypeDesc, unionTypeDesc.PipeToken, middleTypeDesc)
+		middleTypeDesc := b.getArrayTypeDesc(openBracket, member, closeBracket, unionTypeDesc.RightTypeDesc)
+		lhsTypeDesc = b.mergeTypesWithUnion(unionTypeDesc.LeftTypeDesc, unionTypeDesc.PipeToken, middleTypeDesc)
 	} else if lhsTypeDesc.Kind() == common.INTERSECTION_TYPE_DESC {
 		intersectionTypeDesc, ok := lhsTypeDesc.(*tree.STIntersectionTypeDescriptorNode)
 		if !ok {
 			panic("expected *tree.STIntersectionTypeDescriptorNode")
 		}
-		middleTypeDesc := this.getArrayTypeDesc(openBracket, member, closeBracket, intersectionTypeDesc.RightTypeDesc)
-		lhsTypeDesc = this.mergeTypesWithIntersection(intersectionTypeDesc.LeftTypeDesc,
+		middleTypeDesc := b.getArrayTypeDesc(openBracket, member, closeBracket, intersectionTypeDesc.RightTypeDesc)
+		lhsTypeDesc = b.mergeTypesWithIntersection(intersectionTypeDesc.LeftTypeDesc,
 			intersectionTypeDesc.BitwiseAndToken, middleTypeDesc)
 	} else {
-		lhsTypeDesc = this.createArrayTypeDesc(lhsTypeDesc, openBracket, member, closeBracket)
+		lhsTypeDesc = b.createArrayTypeDesc(lhsTypeDesc, openBracket, member, closeBracket)
 	}
 	return lhsTypeDesc
 }
 
-func (this *BallerinaParser) parseUnionOrIntersectionToken() tree.STNode {
-	token := this.peek()
+func (b *BallerinaParser) parseUnionOrIntersectionToken() tree.STNode {
+	token := b.peek()
 	if (token.Kind() == common.PIPE_TOKEN) || (token.Kind() == common.BITWISE_AND_TOKEN) {
-		return this.consume()
+		return b.consume()
 	} else {
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_UNION_OR_INTERSECTION_TOKEN)
-		return this.parseUnionOrIntersectionToken()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_UNION_OR_INTERSECTION_TOKEN)
+		return b.parseUnionOrIntersectionToken()
 	}
 }
 
-func (this *BallerinaParser) getBracketedListNodeType(memberNode tree.STNode, isTypedBindingPattern bool) common.SyntaxKind {
-	if this.isEmpty(memberNode) {
+func (b *BallerinaParser) getBracketedListNodeType(memberNode tree.STNode, isTypedBindingPattern bool) common.SyntaxKind {
+	if b.isEmpty(memberNode) {
 		return common.NONE
 	}
-	if this.isDefiniteTypeDesc(memberNode.Kind()) {
+	if b.isDefiniteTypeDesc(memberNode.Kind()) {
 		return common.TUPLE_TYPE_DESC
 	}
 	switch memberNode.Kind() {
@@ -12866,7 +12866,7 @@ func (this *BallerinaParser) getBracketedListNodeType(memberNode tree.STNode, is
 		if !ok {
 			panic("getBracketedListNodeType: expected STErrorConstructorExpressionNode")
 		}
-		if this.isPossibleErrorBindingPattern(*errorCtorNode) {
+		if b.isPossibleErrorBindingPattern(*errorCtorNode) {
 			return common.NONE
 		}
 		return common.INDEXED_EXPRESSION
@@ -12878,137 +12878,137 @@ func (this *BallerinaParser) getBracketedListNodeType(memberNode tree.STNode, is
 	}
 }
 
-func (this *BallerinaParser) parseStatementStartsWithOpenBracket(annots tree.STNode, possibleMappingField bool) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_ASSIGNMENT_OR_VAR_DECL_STMT)
-	return this.parseStatementStartsWithOpenBracketWithRoot(annots, true, possibleMappingField)
+func (b *BallerinaParser) parseStatementStartsWithOpenBracket(annots tree.STNode, possibleMappingField bool) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_ASSIGNMENT_OR_VAR_DECL_STMT)
+	return b.parseStatementStartsWithOpenBracketWithRoot(annots, true, possibleMappingField)
 }
 
-func (this *BallerinaParser) parseMemberBracketedList() tree.STNode {
+func (b *BallerinaParser) parseMemberBracketedList() tree.STNode {
 	annots := tree.CreateEmptyNodeList()
-	return this.parseStatementStartsWithOpenBracketWithRoot(annots, false, false)
+	return b.parseStatementStartsWithOpenBracketWithRoot(annots, false, false)
 }
 
-func (this *BallerinaParser) parseStatementStartsWithOpenBracketWithRoot(annots tree.STNode, isRoot bool, possibleMappingField bool) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_STMT_START_BRACKETED_LIST)
-	openBracket := this.parseOpenBracket()
+func (b *BallerinaParser) parseStatementStartsWithOpenBracketWithRoot(annots tree.STNode, isRoot bool, possibleMappingField bool) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_STMT_START_BRACKETED_LIST)
+	openBracket := b.parseOpenBracket()
 	var memberList []tree.STNode
-	for !this.isBracketedListEnd(this.peek().Kind()) {
-		member := this.parseStatementStartBracketedListMember()
-		currentNodeType := this.getStmtStartBracketedListType(member)
+	for !b.isBracketedListEnd(b.peek().Kind()) {
+		member := b.parseStatementStartBracketedListMember()
+		currentNodeType := b.getStmtStartBracketedListType(member)
 		switch currentNodeType {
 		case common.TUPLE_TYPE_DESC:
-			member = this.parseComplexTypeDescriptor(member, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE, false)
-			member = this.createMemberOrRestNode(tree.CreateEmptyNodeList(), member)
-			return this.parseAsTupleTypeDesc(annots, openBracket, memberList, member, isRoot)
+			member = b.parseComplexTypeDescriptor(member, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE, false)
+			member = b.createMemberOrRestNode(tree.CreateEmptyNodeList(), member)
+			return b.parseAsTupleTypeDesc(annots, openBracket, memberList, member, isRoot)
 		case common.MEMBER_TYPE_DESC, common.REST_TYPE:
-			return this.parseAsTupleTypeDesc(annots, openBracket, memberList, member, isRoot)
+			return b.parseAsTupleTypeDesc(annots, openBracket, memberList, member, isRoot)
 		case common.LIST_BINDING_PATTERN:
-			res, _ := this.parseAsListBindingPatternWithMemberAndRoot(openBracket, memberList, member, isRoot)
+			res, _ := b.parseAsListBindingPatternWithMemberAndRoot(openBracket, memberList, member, isRoot)
 			return res
 		case common.LIST_CONSTRUCTOR:
-			res, _ := this.parseAsListConstructor(openBracket, memberList, member, isRoot)
+			res, _ := b.parseAsListConstructor(openBracket, memberList, member, isRoot)
 			return res
 		case common.LIST_BP_OR_LIST_CONSTRUCTOR:
-			res, _ := this.parseAsListBindingPatternOrListConstructor(openBracket, memberList, member, isRoot)
+			res, _ := b.parseAsListBindingPatternOrListConstructor(openBracket, memberList, member, isRoot)
 			return res
 		case common.TUPLE_TYPE_DESC_OR_LIST_CONST:
-			res, _ := this.parseAsTupleTypeDescOrListConstructor(annots, openBracket, memberList, member, isRoot)
+			res, _ := b.parseAsTupleTypeDescOrListConstructor(annots, openBracket, memberList, member, isRoot)
 			return res
 		case common.NONE:
 			fallthrough
 		default:
 			memberList = append(memberList, member)
 		}
-		memberEnd := this.parseBracketedListMemberEnd()
+		memberEnd := b.parseBracketedListMemberEnd()
 		if memberEnd == nil {
 			break
 		}
 		memberList = append(memberList, memberEnd)
 	}
-	closeBracket := this.parseCloseBracket()
-	bracketedList := this.parseStatementStartBracketedListRhs(annots, openBracket, memberList, closeBracket,
+	closeBracket := b.parseCloseBracket()
+	bracketedList := b.parseStatementStartBracketedListRhs(annots, openBracket, memberList, closeBracket,
 		isRoot, possibleMappingField)
 	return bracketedList
 }
 
-func (this *BallerinaParser) parseStatementStartBracketedListMember() tree.STNode {
-	return this.parseStatementStartBracketedListMemberWithQualifiers(nil)
+func (b *BallerinaParser) parseStatementStartBracketedListMember() tree.STNode {
+	return b.parseStatementStartBracketedListMemberWithQualifiers(nil)
 }
 
-func (this *BallerinaParser) parseStatementStartBracketedListMemberWithQualifiers(qualifiers []tree.STNode) tree.STNode {
-	qualifiers = this.parseTypeDescQualifiers(qualifiers)
-	nextToken := this.peek()
+func (b *BallerinaParser) parseStatementStartBracketedListMemberWithQualifiers(qualifiers []tree.STNode) tree.STNode {
+	qualifiers = b.parseTypeDescQualifiers(qualifiers)
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.OPEN_BRACKET_TOKEN:
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseMemberBracketedList()
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseMemberBracketedList()
 	case common.IDENTIFIER_TOKEN:
-		this.reportInvalidQualifierList(qualifiers)
-		identifier := this.parseQualifiedIdentifier(common.PARSER_RULE_CONTEXT_VARIABLE_REF)
-		if this.isWildcardBP(identifier) {
+		b.reportInvalidQualifierList(qualifiers)
+		identifier := b.parseQualifiedIdentifier(common.PARSER_RULE_CONTEXT_VARIABLE_REF)
+		if b.isWildcardBP(identifier) {
 			simpleNameNode, ok := identifier.(*tree.STSimpleNameReferenceNode)
 			if !ok {
 				panic("parseStatementStartBracketedListMember: expected STSimpleNameReferenceNode")
 			}
 			varName := simpleNameNode.Name
-			return this.getWildcardBindingPattern(varName)
+			return b.getWildcardBindingPattern(varName)
 		}
-		nextToken = this.peek()
+		nextToken = b.peek()
 		if nextToken.Kind() == common.ELLIPSIS_TOKEN {
-			ellipsis := this.parseEllipsis()
+			ellipsis := b.parseEllipsis()
 			return tree.CreateRestDescriptorNode(identifier, ellipsis)
 		}
-		if (nextToken.Kind() != common.OPEN_BRACKET_TOKEN) && this.isValidTypeContinuationToken(nextToken) {
-			return this.parseComplexTypeDescriptor(identifier, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE, false)
+		if (nextToken.Kind() != common.OPEN_BRACKET_TOKEN) && b.isValidTypeContinuationToken(nextToken) {
+			return b.parseComplexTypeDescriptor(identifier, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE, false)
 		}
-		return this.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, identifier, false, true)
+		return b.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, identifier, false, true)
 	case common.OPEN_BRACE_TOKEN:
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseMappingBindingPatterOrMappingConstructor()
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseMappingBindingPatterOrMappingConstructor()
 	case common.ERROR_KEYWORD:
-		this.reportInvalidQualifierList(qualifiers)
-		nextNextToken := this.getNextNextToken()
+		b.reportInvalidQualifierList(qualifiers)
+		nextNextToken := b.getNextNextToken()
 		if (nextNextToken.Kind() == common.OPEN_PAREN_TOKEN) || (nextNextToken.Kind() == common.IDENTIFIER_TOKEN) {
-			return this.parseErrorBindingPatternOrErrorConstructor()
+			return b.parseErrorBindingPatternOrErrorConstructor()
 		}
-		return this.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE)
+		return b.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE)
 	case common.ELLIPSIS_TOKEN:
-		this.reportInvalidQualifierList(qualifiers)
-		return this.parseRestBindingOrSpreadMember()
+		b.reportInvalidQualifierList(qualifiers)
+		return b.parseRestBindingOrSpreadMember()
 	case common.XML_KEYWORD, common.STRING_KEYWORD:
-		this.reportInvalidQualifierList(qualifiers)
-		if this.getNextNextToken().Kind() == common.BACKTICK_TOKEN {
-			return this.parseExpressionPossibleRhsExpr(false)
+		b.reportInvalidQualifierList(qualifiers)
+		if b.getNextNextToken().Kind() == common.BACKTICK_TOKEN {
+			return b.parseExpressionPossibleRhsExpr(false)
 		}
-		return this.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE)
+		return b.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE)
 	case common.TABLE_KEYWORD, common.STREAM_KEYWORD:
-		this.reportInvalidQualifierList(qualifiers)
-		if this.getNextNextToken().Kind() == common.LT_TOKEN {
-			return this.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE)
+		b.reportInvalidQualifierList(qualifiers)
+		if b.getNextNextToken().Kind() == common.LT_TOKEN {
+			return b.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE)
 		}
-		return this.parseExpressionPossibleRhsExpr(false)
+		return b.parseExpressionPossibleRhsExpr(false)
 	case common.OPEN_PAREN_TOKEN:
-		return this.parseTypeDescOrExprWithQualifiers(qualifiers)
+		return b.parseTypeDescOrExprWithQualifiers(qualifiers)
 	case common.FUNCTION_KEYWORD:
-		return this.parseAnonFuncExprOrFuncTypeDesc(qualifiers)
+		return b.parseAnonFuncExprOrFuncTypeDesc(qualifiers)
 	case common.AT_TOKEN:
-		return this.parseTupleMember()
+		return b.parseTupleMember()
 	default:
-		if this.isValidExpressionStart(nextToken.Kind(), 1) {
-			this.reportInvalidQualifierList(qualifiers)
-			return this.parseExpressionPossibleRhsExpr(false)
+		if b.isValidExpressionStart(nextToken.Kind(), 1) {
+			b.reportInvalidQualifierList(qualifiers)
+			return b.parseExpressionPossibleRhsExpr(false)
 		}
-		if this.isTypeStartingToken(nextToken.Kind()) {
-			return this.parseTypeDescriptorWithQualifier(qualifiers, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE)
+		if b.isTypeStartingToken(nextToken.Kind()) {
+			return b.parseTypeDescriptorWithQualifier(qualifiers, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE)
 		}
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_STMT_START_BRACKETED_LIST_MEMBER)
-		return this.parseStatementStartBracketedListMemberWithQualifiers(qualifiers)
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_STMT_START_BRACKETED_LIST_MEMBER)
+		return b.parseStatementStartBracketedListMemberWithQualifiers(qualifiers)
 	}
 }
 
-func (this *BallerinaParser) parseRestBindingOrSpreadMember() tree.STNode {
-	ellipsis := this.parseEllipsis()
-	expr := this.parseExpression()
+func (b *BallerinaParser) parseRestBindingOrSpreadMember() tree.STNode {
+	ellipsis := b.parseEllipsis()
+	expr := b.parseExpression()
 	if expr.Kind() == common.SIMPLE_NAME_REFERENCE {
 		return tree.CreateRestBindingPatternNode(ellipsis, expr)
 	} else {
@@ -13017,204 +13017,204 @@ func (this *BallerinaParser) parseRestBindingOrSpreadMember() tree.STNode {
 }
 
 // return result and modified memberList
-func (this *BallerinaParser) parseAsTupleTypeDescOrListConstructor(annots tree.STNode, openBracket tree.STNode, memberList []tree.STNode, member tree.STNode, isRoot bool) (tree.STNode, []tree.STNode) {
+func (b *BallerinaParser) parseAsTupleTypeDescOrListConstructor(annots tree.STNode, openBracket tree.STNode, memberList []tree.STNode, member tree.STNode, isRoot bool) (tree.STNode, []tree.STNode) {
 	memberList = append(memberList, member)
-	memberEnd := this.parseBracketedListMemberEnd()
+	memberEnd := b.parseBracketedListMemberEnd()
 	var tupleTypeDescOrListCons tree.STNode
 	if memberEnd == nil {
-		closeBracket := this.parseCloseBracket()
-		tupleTypeDescOrListCons = this.parseTupleTypeDescOrListConstructorRhs(openBracket, memberList, closeBracket, isRoot)
+		closeBracket := b.parseCloseBracket()
+		tupleTypeDescOrListCons = b.parseTupleTypeDescOrListConstructorRhs(openBracket, memberList, closeBracket, isRoot)
 	} else {
 		memberList = append(memberList, memberEnd)
-		tupleTypeDescOrListCons, memberList = this.parseTupleTypeDescOrListConstructorWithBracketAndMembers(annots, openBracket, memberList, isRoot)
+		tupleTypeDescOrListCons, memberList = b.parseTupleTypeDescOrListConstructorWithBracketAndMembers(annots, openBracket, memberList, isRoot)
 	}
 	return tupleTypeDescOrListCons, memberList
 }
 
-func (this *BallerinaParser) parseTupleTypeDescOrListConstructor(annots tree.STNode) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_BRACKETED_LIST)
-	openBracket := this.parseOpenBracket()
+func (b *BallerinaParser) parseTupleTypeDescOrListConstructor(annots tree.STNode) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_BRACKETED_LIST)
+	openBracket := b.parseOpenBracket()
 	var memberList []tree.STNode
-	result, _ := this.parseTupleTypeDescOrListConstructorWithBracketAndMembers(annots, openBracket, memberList, false)
+	result, _ := b.parseTupleTypeDescOrListConstructorWithBracketAndMembers(annots, openBracket, memberList, false)
 	return result
 }
 
-func (this *BallerinaParser) parseTupleTypeDescOrListConstructorWithBracketAndMembers(annots tree.STNode, openBracket tree.STNode, memberList []tree.STNode, isRoot bool) (tree.STNode, []tree.STNode) {
-	nextToken := this.peek()
-	for !this.isBracketedListEnd(nextToken.Kind()) {
-		member := this.parseTupleTypeDescOrListConstructorMember(annots)
-		currentNodeType := this.getParsingNodeTypeOfTupleTypeOrListCons(member)
+func (b *BallerinaParser) parseTupleTypeDescOrListConstructorWithBracketAndMembers(annots tree.STNode, openBracket tree.STNode, memberList []tree.STNode, isRoot bool) (tree.STNode, []tree.STNode) {
+	nextToken := b.peek()
+	for !b.isBracketedListEnd(nextToken.Kind()) {
+		member := b.parseTupleTypeDescOrListConstructorMember(annots)
+		currentNodeType := b.getParsingNodeTypeOfTupleTypeOrListCons(member)
 		switch currentNodeType {
 		case common.LIST_CONSTRUCTOR:
-			return this.parseAsListConstructor(openBracket, memberList, member, isRoot)
+			return b.parseAsListConstructor(openBracket, memberList, member, isRoot)
 		case common.REST_TYPE, common.MEMBER_TYPE_DESC:
-			return this.parseAsTupleTypeDesc(annots, openBracket, memberList, member, isRoot), memberList
+			return b.parseAsTupleTypeDesc(annots, openBracket, memberList, member, isRoot), memberList
 		case common.TUPLE_TYPE_DESC:
-			member = this.parseComplexTypeDescriptor(member, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE, false)
-			member = this.createMemberOrRestNode(tree.CreateEmptyNodeList(), member)
-			return this.parseAsTupleTypeDesc(annots, openBracket, memberList, member, isRoot), memberList
+			member = b.parseComplexTypeDescriptor(member, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE, false)
+			member = b.createMemberOrRestNode(tree.CreateEmptyNodeList(), member)
+			return b.parseAsTupleTypeDesc(annots, openBracket, memberList, member, isRoot), memberList
 		case common.TUPLE_TYPE_DESC_OR_LIST_CONST:
 			fallthrough
 		default:
 			memberList = append(memberList, member)
 		}
-		memberEnd := this.parseBracketedListMemberEnd()
+		memberEnd := b.parseBracketedListMemberEnd()
 		if memberEnd == nil {
 			break
 		}
 		memberList = append(memberList, memberEnd)
-		nextToken = this.peek()
+		nextToken = b.peek()
 	}
-	closeBracket := this.parseCloseBracket()
-	return this.parseTupleTypeDescOrListConstructorRhs(openBracket, memberList, closeBracket, isRoot), memberList
+	closeBracket := b.parseCloseBracket()
+	return b.parseTupleTypeDescOrListConstructorRhs(openBracket, memberList, closeBracket, isRoot), memberList
 }
 
-func (this *BallerinaParser) parseTupleTypeDescOrListConstructorMember(annots tree.STNode) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseTupleTypeDescOrListConstructorMember(annots tree.STNode) tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.OPEN_BRACKET_TOKEN:
-		return this.parseTupleTypeDescOrListConstructor(annots)
+		return b.parseTupleTypeDescOrListConstructor(annots)
 	case common.IDENTIFIER_TOKEN:
-		identifier := this.parseQualifiedIdentifier(common.PARSER_RULE_CONTEXT_VARIABLE_REF)
-		if this.peek().Kind() == common.ELLIPSIS_TOKEN {
-			ellipsis := this.parseEllipsis()
+		identifier := b.parseQualifiedIdentifier(common.PARSER_RULE_CONTEXT_VARIABLE_REF)
+		if b.peek().Kind() == common.ELLIPSIS_TOKEN {
+			ellipsis := b.parseEllipsis()
 			return tree.CreateRestDescriptorNode(identifier, ellipsis)
 		}
-		return this.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, identifier, false, false)
+		return b.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, identifier, false, false)
 	case common.OPEN_BRACE_TOKEN:
-		return this.parseMappingConstructorExpr()
+		return b.parseMappingConstructorExpr()
 	case common.ERROR_KEYWORD:
-		nextNextToken := this.getNextNextToken()
+		nextNextToken := b.getNextNextToken()
 		if (nextNextToken.Kind() == common.OPEN_PAREN_TOKEN) || (nextNextToken.Kind() == common.IDENTIFIER_TOKEN) {
-			return this.parseErrorConstructorExprAmbiguous(false)
+			return b.parseErrorConstructorExprAmbiguous(false)
 		}
-		return this.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE)
+		return b.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE)
 	case common.XML_KEYWORD, common.STRING_KEYWORD:
-		if this.getNextNextToken().Kind() == common.BACKTICK_TOKEN {
-			return this.parseExpressionPossibleRhsExpr(false)
+		if b.getNextNextToken().Kind() == common.BACKTICK_TOKEN {
+			return b.parseExpressionPossibleRhsExpr(false)
 		}
-		return this.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE)
+		return b.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE)
 	case common.TABLE_KEYWORD, common.STREAM_KEYWORD:
-		if this.getNextNextToken().Kind() == common.LT_TOKEN {
-			return this.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE)
+		if b.getNextNextToken().Kind() == common.LT_TOKEN {
+			return b.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE)
 		}
-		return this.parseExpressionPossibleRhsExpr(false)
+		return b.parseExpressionPossibleRhsExpr(false)
 	case common.OPEN_PAREN_TOKEN:
-		return this.parseTypeDescOrExpr()
+		return b.parseTypeDescOrExpr()
 	case common.AT_TOKEN:
-		return this.parseTupleMember()
+		return b.parseTupleMember()
 	default:
-		if this.isValidExpressionStart(nextToken.Kind(), 1) {
-			return this.parseExpressionPossibleRhsExpr(false)
+		if b.isValidExpressionStart(nextToken.Kind(), 1) {
+			return b.parseExpressionPossibleRhsExpr(false)
 		}
-		if this.isTypeStartingToken(nextToken.Kind()) {
-			return this.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE)
+		if b.isTypeStartingToken(nextToken.Kind()) {
+			return b.parseTypeDescriptor(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE)
 		}
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_TUPLE_TYPE_DESC_OR_LIST_CONST_MEMBER)
-		return this.parseTupleTypeDescOrListConstructorMember(annots)
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_TUPLE_TYPE_DESC_OR_LIST_CONST_MEMBER)
+		return b.parseTupleTypeDescOrListConstructorMember(annots)
 	}
 }
 
-func (this *BallerinaParser) getParsingNodeTypeOfTupleTypeOrListCons(memberNode tree.STNode) common.SyntaxKind {
-	return this.getStmtStartBracketedListType(memberNode)
+func (b *BallerinaParser) getParsingNodeTypeOfTupleTypeOrListCons(memberNode tree.STNode) common.SyntaxKind {
+	return b.getStmtStartBracketedListType(memberNode)
 }
 
-func (this *BallerinaParser) parseTupleTypeDescOrListConstructorRhs(openBracket tree.STNode, members []tree.STNode, closeBracket tree.STNode, isRoot bool) tree.STNode {
+func (b *BallerinaParser) parseTupleTypeDescOrListConstructorRhs(openBracket tree.STNode, members []tree.STNode, closeBracket tree.STNode, isRoot bool) tree.STNode {
 	var tupleTypeOrListConst tree.STNode
-	switch this.peek().Kind() {
+	switch b.peek().Kind() {
 	case common.COMMA_TOKEN, common.CLOSE_BRACE_TOKEN, common.CLOSE_BRACKET_TOKEN, common.PIPE_TOKEN, common.BITWISE_AND_TOKEN:
 		if !isRoot {
-			this.endContext()
+			b.endContext()
 			return tree.CreateAmbiguousCollectionNode(common.TUPLE_TYPE_DESC_OR_LIST_CONST, openBracket, members, closeBracket)
 		}
 	default:
-		if this.isValidExprRhsStart(this.peek().Kind(), closeBracket.Kind()) || (isRoot && (this.peek().Kind() == common.EQUAL_TOKEN)) {
-			members = this.getExpressionList(members, false)
+		if b.isValidExprRhsStart(b.peek().Kind(), closeBracket.Kind()) || (isRoot && (b.peek().Kind() == common.EQUAL_TOKEN)) {
+			members = b.getExpressionList(members, false)
 			memberExpressions := tree.CreateNodeList(members...)
 			tupleTypeOrListConst = tree.CreateListConstructorExpressionNode(openBracket,
 				memberExpressions, closeBracket)
 			break
 		}
-		memberTypeDescs := tree.CreateNodeList(this.getTupleMemberList(members)...)
+		memberTypeDescs := tree.CreateNodeList(b.getTupleMemberList(members)...)
 		tupleTypeDesc := tree.CreateTupleTypeDescriptorNode(openBracket, memberTypeDescs, closeBracket)
-		tupleTypeOrListConst = this.parseComplexTypeDescriptor(tupleTypeDesc, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE, false)
+		tupleTypeOrListConst = b.parseComplexTypeDescriptor(tupleTypeDesc, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE, false)
 	}
-	this.endContext()
+	b.endContext()
 	if !isRoot {
 		return tupleTypeOrListConst
 	}
 	annots := tree.CreateEmptyNodeList()
-	return this.parseStmtStartsWithTupleTypeOrExprRhs(annots, tupleTypeOrListConst, true)
+	return b.parseStmtStartsWithTupleTypeOrExprRhs(annots, tupleTypeOrListConst, true)
 }
 
-func (this *BallerinaParser) parseStmtStartsWithTupleTypeOrExprRhs(annots tree.STNode, tupleTypeOrListConst tree.STNode, isRoot bool) tree.STNode {
+func (b *BallerinaParser) parseStmtStartsWithTupleTypeOrExprRhs(annots tree.STNode, tupleTypeOrListConst tree.STNode, isRoot bool) tree.STNode {
 	if (tupleTypeOrListConst.Kind().CompareTo(common.RECORD_TYPE_DESC) >= 0) && (tupleTypeOrListConst.Kind().CompareTo(common.TYPEDESC_TYPE_DESC) <= 0) {
-		typedBindingPattern := this.parseTypedBindingPatternTypeRhsWithRoot(tupleTypeOrListConst, common.PARSER_RULE_CONTEXT_VAR_DECL_STMT, isRoot)
+		typedBindingPattern := b.parseTypedBindingPatternTypeRhsWithRoot(tupleTypeOrListConst, common.PARSER_RULE_CONTEXT_VAR_DECL_STMT, isRoot)
 		if !isRoot {
 			return typedBindingPattern
 		}
-		this.switchContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
-		res, _ := this.parseVarDeclRhs(annots, nil, typedBindingPattern, false)
+		b.switchContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+		res, _ := b.parseVarDeclRhs(annots, nil, typedBindingPattern, false)
 		return res
 	}
-	expr := this.getExpression(tupleTypeOrListConst)
-	expr = this.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, expr, false, true)
-	return this.parseStatementStartWithExprRhs(expr)
+	expr := b.getExpression(tupleTypeOrListConst)
+	expr = b.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, expr, false, true)
+	return b.parseStatementStartWithExprRhs(expr)
 }
 
-func (this *BallerinaParser) parseAsTupleTypeDesc(annots tree.STNode, openBracket tree.STNode, memberList []tree.STNode, member tree.STNode, isRoot bool) tree.STNode {
-	memberList = this.getTupleMemberList(memberList)
-	this.startContext(common.PARSER_RULE_CONTEXT_TUPLE_MEMBERS)
-	tupleTypeMembers, memberList := this.parseTupleTypeMembers(member, memberList) //nolint:staticcheck,ineffassign // memberList will be used when tuple rest descriptor is fully implemented
-	closeBracket := this.parseCloseBracket()
-	this.endContext()
+func (b *BallerinaParser) parseAsTupleTypeDesc(annots tree.STNode, openBracket tree.STNode, memberList []tree.STNode, member tree.STNode, isRoot bool) tree.STNode {
+	memberList = b.getTupleMemberList(memberList)
+	b.startContext(common.PARSER_RULE_CONTEXT_TUPLE_MEMBERS)
+	tupleTypeMembers, memberList := b.parseTupleTypeMembers(member, memberList) //nolint:staticcheck,ineffassign // memberList will be used when tuple rest descriptor is fully implemented
+	closeBracket := b.parseCloseBracket()
+	b.endContext()
 	tupleType := tree.CreateTupleTypeDescriptorNode(openBracket, tupleTypeMembers, closeBracket)
-	typeDesc := this.parseComplexTypeDescriptor(tupleType, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN, true)
-	this.endContext()
+	typeDesc := b.parseComplexTypeDescriptor(tupleType, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN, true)
+	b.endContext()
 	if !isRoot {
 		return typeDesc
 	}
-	typedBindingPattern := this.parseTypedBindingPatternTypeRhsWithRoot(typeDesc, common.PARSER_RULE_CONTEXT_VAR_DECL_STMT, true)
-	this.switchContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
-	res, _ := this.parseVarDeclRhs(annots, nil, typedBindingPattern, false)
+	typedBindingPattern := b.parseTypedBindingPatternTypeRhsWithRoot(typeDesc, common.PARSER_RULE_CONTEXT_VAR_DECL_STMT, true)
+	b.switchContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+	res, _ := b.parseVarDeclRhs(annots, nil, typedBindingPattern, false)
 	return res
 }
 
-func (this *BallerinaParser) parseAsListBindingPatternWithMemberAndRoot(openBracket tree.STNode, memberList []tree.STNode, member tree.STNode, isRoot bool) (tree.STNode, []tree.STNode) {
-	memberList = this.getBindingPatternsList(memberList, true)
-	memberList = append(memberList, this.getBindingPattern(member, true))
-	this.switchContext(common.PARSER_RULE_CONTEXT_LIST_BINDING_PATTERN)
-	listBindingPattern, memberList := this.parseListBindingPatternWithFirstMember(openBracket, member, memberList)
-	this.endContext()
+func (b *BallerinaParser) parseAsListBindingPatternWithMemberAndRoot(openBracket tree.STNode, memberList []tree.STNode, member tree.STNode, isRoot bool) (tree.STNode, []tree.STNode) {
+	memberList = b.getBindingPatternsList(memberList, true)
+	memberList = append(memberList, b.getBindingPattern(member, true))
+	b.switchContext(common.PARSER_RULE_CONTEXT_LIST_BINDING_PATTERN)
+	listBindingPattern, memberList := b.parseListBindingPatternWithFirstMember(openBracket, member, memberList)
+	b.endContext()
 	if !isRoot {
 		return listBindingPattern, memberList
 	}
-	return this.parseAssignmentStmtRhs(listBindingPattern), memberList
+	return b.parseAssignmentStmtRhs(listBindingPattern), memberList
 }
 
-func (this *BallerinaParser) parseAsListBindingPattern(openBracket tree.STNode, memberList []tree.STNode) (tree.STNode, []tree.STNode) {
-	memberList = this.getBindingPatternsList(memberList, true)
-	this.switchContext(common.PARSER_RULE_CONTEXT_LIST_BINDING_PATTERN)
-	listBindingPattern, memberList := this.parseListBindingPatternWithOpenBracket(openBracket, memberList)
-	this.endContext()
+func (b *BallerinaParser) parseAsListBindingPattern(openBracket tree.STNode, memberList []tree.STNode) (tree.STNode, []tree.STNode) {
+	memberList = b.getBindingPatternsList(memberList, true)
+	b.switchContext(common.PARSER_RULE_CONTEXT_LIST_BINDING_PATTERN)
+	listBindingPattern, memberList := b.parseListBindingPatternWithOpenBracket(openBracket, memberList)
+	b.endContext()
 	return listBindingPattern, memberList
 }
 
-func (this *BallerinaParser) parseAsListBindingPatternOrListConstructor(openBracket tree.STNode, memberList []tree.STNode, member tree.STNode, isRoot bool) (tree.STNode, []tree.STNode) {
+func (b *BallerinaParser) parseAsListBindingPatternOrListConstructor(openBracket tree.STNode, memberList []tree.STNode, member tree.STNode, isRoot bool) (tree.STNode, []tree.STNode) {
 	memberList = append(memberList, member)
-	memberEnd := this.parseBracketedListMemberEnd()
+	memberEnd := b.parseBracketedListMemberEnd()
 	var listBindingPatternOrListCons tree.STNode
 	if memberEnd == nil {
-		closeBracket := this.parseCloseBracket()
-		listBindingPatternOrListCons = this.parseListBindingPatternOrListConstructorWithCloseBracket(openBracket, memberList, closeBracket, isRoot)
+		closeBracket := b.parseCloseBracket()
+		listBindingPatternOrListCons = b.parseListBindingPatternOrListConstructorWithCloseBracket(openBracket, memberList, closeBracket, isRoot)
 	} else {
 		memberList = append(memberList, memberEnd)
-		listBindingPatternOrListCons, memberList = this.parseListBindingPatternOrListConstructorInner(openBracket, memberList, isRoot)
+		listBindingPatternOrListCons, memberList = b.parseListBindingPatternOrListConstructorInner(openBracket, memberList, isRoot)
 	}
 	return listBindingPatternOrListCons, memberList
 }
 
-func (this *BallerinaParser) getStmtStartBracketedListType(memberNode tree.STNode) common.SyntaxKind {
+func (b *BallerinaParser) getStmtStartBracketedListType(memberNode tree.STNode) common.SyntaxKind {
 	if (memberNode.Kind().CompareTo(common.RECORD_TYPE_DESC) >= 0) && (memberNode.Kind().CompareTo(common.FUTURE_TYPE_DESC) <= 0) {
 		return common.TUPLE_TYPE_DESC
 	}
@@ -13242,7 +13242,7 @@ func (this *BallerinaParser) getStmtStartBracketedListType(memberNode tree.STNod
 		if !ok {
 			panic("getStmtStartBracketedListType: expected STErrorConstructorExpressionNode")
 		}
-		if this.isPossibleErrorBindingPattern(*errorCtorNode) {
+		if b.isPossibleErrorBindingPattern(*errorCtorNode) {
 			return common.NONE
 		}
 		return common.LIST_CONSTRUCTOR
@@ -13253,14 +13253,14 @@ func (this *BallerinaParser) getStmtStartBracketedListType(memberNode tree.STNod
 	case common.REST_TYPE:
 		return common.REST_TYPE
 	default:
-		if (this.isExpression(memberNode.Kind()) && (!this.isAllBasicLiterals(memberNode))) && (!this.isAmbiguous(memberNode)) {
+		if (b.isExpression(memberNode.Kind()) && (!b.isAllBasicLiterals(memberNode))) && (!b.isAmbiguous(memberNode)) {
 			return common.LIST_CONSTRUCTOR
 		}
 		return common.NONE
 	}
 }
 
-func (this *BallerinaParser) isPossibleErrorBindingPattern(errorConstructor tree.STErrorConstructorExpressionNode) bool {
+func (b *BallerinaParser) isPossibleErrorBindingPattern(errorConstructor tree.STErrorConstructorExpressionNode) bool {
 	args := errorConstructor.Arguments
 	size := args.BucketCount()
 	i := 0
@@ -13270,27 +13270,27 @@ func (this *BallerinaParser) isPossibleErrorBindingPattern(errorConstructor tree
 			continue
 		}
 		functionArg := arg
-		if !this.isPosibleArgBindingPattern(functionArg) {
+		if !b.isPosibleArgBindingPattern(functionArg) {
 			return false
 		}
 	}
 	return true
 }
 
-func (this *BallerinaParser) isPosibleArgBindingPattern(arg tree.STFunctionArgumentNode) bool {
+func (b *BallerinaParser) isPosibleArgBindingPattern(arg tree.STFunctionArgumentNode) bool {
 	switch arg.Kind() {
 	case common.POSITIONAL_ARG:
 		positionalArg, ok := arg.(*tree.STPositionalArgumentNode)
 		if !ok {
 			panic("isPosibleArgBindingPattern: expected STPositionalArgumentNode")
 		}
-		return this.isPosibleBindingPattern(positionalArg.Expression)
+		return b.isPosibleBindingPattern(positionalArg.Expression)
 	case common.NAMED_ARG:
 		namedArg, ok := arg.(*tree.STNamedArgumentNode)
 		if !ok {
 			panic("isPosibleArgBindingPattern: expected STNamedArgumentNode")
 		}
-		return this.isPosibleBindingPattern(namedArg.Expression)
+		return b.isPosibleBindingPattern(namedArg.Expression)
 	case common.REST_ARG:
 		restArg, ok := arg.(*tree.STRestArgumentNode)
 		if !ok {
@@ -13302,7 +13302,7 @@ func (this *BallerinaParser) isPosibleArgBindingPattern(arg tree.STFunctionArgum
 	}
 }
 
-func (this *BallerinaParser) isPosibleBindingPattern(node tree.STNode) bool {
+func (b *BallerinaParser) isPosibleBindingPattern(node tree.STNode) bool {
 	switch node.Kind() {
 	case common.SIMPLE_NAME_REFERENCE:
 		return true
@@ -13314,7 +13314,7 @@ func (this *BallerinaParser) isPosibleBindingPattern(node tree.STNode) bool {
 		i := 0
 		for ; i < listConstructor.BucketCount(); i++ {
 			expr := listConstructor.ChildInBucket(i)
-			if !this.isPosibleBindingPattern(expr) {
+			if !b.isPosibleBindingPattern(expr) {
 				return false
 			}
 		}
@@ -13327,7 +13327,7 @@ func (this *BallerinaParser) isPosibleBindingPattern(node tree.STNode) bool {
 		i := 0
 		for ; i < mappingConstructor.BucketCount(); i++ {
 			expr := mappingConstructor.ChildInBucket(i)
-			if !this.isPosibleBindingPattern(expr) {
+			if !b.isPosibleBindingPattern(expr) {
 				return false
 			}
 		}
@@ -13343,90 +13343,90 @@ func (this *BallerinaParser) isPosibleBindingPattern(node tree.STNode) bool {
 		if specificField.ValueExpr == nil {
 			return true
 		}
-		return this.isPosibleBindingPattern(specificField.ValueExpr)
+		return b.isPosibleBindingPattern(specificField.ValueExpr)
 	case common.ERROR_CONSTRUCTOR:
 		errorCtorNode, ok := node.(*tree.STErrorConstructorExpressionNode)
 		if !ok {
 			panic("isPosibleBindingPattern: expected STErrorConstructorExpressionNode")
 		}
-		return this.isPossibleErrorBindingPattern(*errorCtorNode)
+		return b.isPossibleErrorBindingPattern(*errorCtorNode)
 	default:
 		return false
 	}
 }
 
 // return result, and modified memberList
-func (this *BallerinaParser) parseStatementStartBracketedListRhs(annots tree.STNode, openBracket tree.STNode, members []tree.STNode, closeBracket tree.STNode, isRoot bool, possibleMappingField bool) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseStatementStartBracketedListRhs(annots tree.STNode, openBracket tree.STNode, members []tree.STNode, closeBracket tree.STNode, isRoot bool, possibleMappingField bool) tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.EQUAL_TOKEN:
 		if !isRoot {
-			this.endContext()
+			b.endContext()
 			return tree.CreateAmbiguousCollectionNode(common.BRACKETED_LIST, openBracket, members, closeBracket)
 		}
-		memberBindingPatterns := tree.CreateNodeList(this.getBindingPatternsList(members, true)...)
+		memberBindingPatterns := tree.CreateNodeList(b.getBindingPatternsList(members, true)...)
 		listBindingPattern := tree.CreateListBindingPatternNode(openBracket,
 			memberBindingPatterns, closeBracket)
-		this.endContext() // end tuple typ-desc
-		this.switchContext(common.PARSER_RULE_CONTEXT_ASSIGNMENT_STMT)
-		return this.parseAssignmentStmtRhs(listBindingPattern)
+		b.endContext() // end tuple typ-desc
+		b.switchContext(common.PARSER_RULE_CONTEXT_ASSIGNMENT_STMT)
+		return b.parseAssignmentStmtRhs(listBindingPattern)
 	case common.IDENTIFIER_TOKEN, common.OPEN_BRACE_TOKEN:
 		if !isRoot {
-			this.endContext()
+			b.endContext()
 			return tree.CreateAmbiguousCollectionNode(common.BRACKETED_LIST, openBracket, members, closeBracket)
 		}
 		if len(members) == 0 {
 			openBracket = tree.AddDiagnostic(openBracket, &common.ERROR_MISSING_TUPLE_MEMBER)
 		}
-		this.switchContext(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN)
-		this.startContext(common.PARSER_RULE_CONTEXT_TUPLE_MEMBERS)
-		memberTypeDescs := tree.CreateNodeList(this.getTupleMemberList(members)...)
+		b.switchContext(common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN)
+		b.startContext(common.PARSER_RULE_CONTEXT_TUPLE_MEMBERS)
+		memberTypeDescs := tree.CreateNodeList(b.getTupleMemberList(members)...)
 		tupleTypeDesc := tree.CreateTupleTypeDescriptorNode(openBracket, memberTypeDescs, closeBracket)
-		this.endContext() // end tuple typ-desc
-		typeDesc := this.parseComplexTypeDescriptor(tupleTypeDesc,
+		b.endContext() // end tuple typ-desc
+		typeDesc := b.parseComplexTypeDescriptor(tupleTypeDesc,
 			common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN, true)
-		this.endContext() // end binding pattern
-		typedBindingPattern := this.parseTypedBindingPatternTypeRhs(typeDesc, common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
-		return this.parseStmtStartsWithTypedBPOrExprRhs(annots, typedBindingPattern)
+		b.endContext() // end binding pattern
+		typedBindingPattern := b.parseTypedBindingPatternTypeRhs(typeDesc, common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+		return b.parseStmtStartsWithTypedBPOrExprRhs(annots, typedBindingPattern)
 	case common.OPEN_BRACKET_TOKEN:
 		// [a, ..][..
 		// definitely not binding pattern. Can be type-desc or list-constructor
 		if !isRoot {
 			// if this is a member, treat as type-desc.
 			// TODO: handle expression case.
-			memberTypeDescs := tree.CreateNodeList(this.getTupleMemberList(members)...)
+			memberTypeDescs := tree.CreateNodeList(b.getTupleMemberList(members)...)
 			tupleTypeDesc := tree.CreateTupleTypeDescriptorNode(openBracket, memberTypeDescs, closeBracket)
-			this.endContext()
-			typeDesc := this.parseComplexTypeDescriptor(tupleTypeDesc, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE, false)
+			b.endContext()
+			typeDesc := b.parseComplexTypeDescriptor(tupleTypeDesc, common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TUPLE, false)
 			return typeDesc
 		}
 		list := tree.CreateAmbiguousCollectionNode(common.BRACKETED_LIST, openBracket, members, closeBracket)
-		this.endContext()
-		tpbOrExpr := this.parseTypedBindingPatternOrExprRhs(list, true)
-		return this.parseStmtStartsWithTypedBPOrExprRhs(annots, tpbOrExpr)
+		b.endContext()
+		tpbOrExpr := b.parseTypedBindingPatternOrExprRhs(list, true)
+		return b.parseStmtStartsWithTypedBPOrExprRhs(annots, tpbOrExpr)
 	case common.COLON_TOKEN: // "{[a]:" could be a computed-name-field in mapping-constructor
 		if possibleMappingField && (len(members) == 1) {
-			this.startContext(common.PARSER_RULE_CONTEXT_MAPPING_CONSTRUCTOR)
-			colon := this.parseColon()
-			fieldNameExpr := this.getExpression(members[0])
-			valueExpr := this.parseExpression()
+			b.startContext(common.PARSER_RULE_CONTEXT_MAPPING_CONSTRUCTOR)
+			colon := b.parseColon()
+			fieldNameExpr := b.getExpression(members[0])
+			valueExpr := b.parseExpression()
 			return tree.CreateComputedNameFieldNode(openBracket, fieldNameExpr, closeBracket, colon,
 				valueExpr)
 		}
 		// fall through
 		fallthrough
 	default:
-		this.endContext()
+		b.endContext()
 		if !isRoot {
 			return tree.CreateAmbiguousCollectionNode(common.BRACKETED_LIST, openBracket, members, closeBracket)
 		}
 		list := tree.CreateAmbiguousCollectionNode(common.BRACKETED_LIST, openBracket, members, closeBracket)
-		exprOrTPB := this.parseTypedBindingPatternOrExprRhs(list, false)
-		return this.parseStmtStartsWithTypedBPOrExprRhs(annots, exprOrTPB)
+		exprOrTPB := b.parseTypedBindingPatternOrExprRhs(list, false)
+		return b.parseStmtStartsWithTypedBPOrExprRhs(annots, exprOrTPB)
 	}
 }
 
-func (this *BallerinaParser) isWildcardBP(node tree.STNode) bool {
+func (b *BallerinaParser) isWildcardBP(node tree.STNode) bool {
 	switch node.Kind() {
 	case common.SIMPLE_NAME_REFERENCE:
 		simpleNameNode, ok := node.(*tree.STSimpleNameReferenceNode)
@@ -13437,23 +13437,23 @@ func (this *BallerinaParser) isWildcardBP(node tree.STNode) bool {
 		if !ok {
 			panic("isWildcardBP: expected STToken")
 		}
-		return this.isUnderscoreToken(nameToken)
+		return b.isUnderscoreToken(nameToken)
 	case common.IDENTIFIER_TOKEN:
 		identifierToken, ok := node.(tree.STToken)
 		if !ok {
 			panic("isWildcardBP: expected STToken")
 		}
-		return this.isUnderscoreToken(identifierToken)
+		return b.isUnderscoreToken(identifierToken)
 	default:
 		return false
 	}
 }
 
-func (this *BallerinaParser) isUnderscoreToken(token tree.STToken) bool {
+func (b *BallerinaParser) isUnderscoreToken(token tree.STToken) bool {
 	return token.Text() == "_"
 }
 
-func (this *BallerinaParser) getWildcardBindingPattern(identifier tree.STNode) tree.STNode {
+func (b *BallerinaParser) getWildcardBindingPattern(identifier tree.STNode) tree.STNode {
 	var underscore tree.STNode
 	switch identifier.Kind() {
 	case common.SIMPLE_NAME_REFERENCE:
@@ -13466,282 +13466,282 @@ func (this *BallerinaParser) getWildcardBindingPattern(identifier tree.STNode) t
 		if !ok {
 			panic("getWildcardBindingPattern: expected STToken")
 		}
-		underscore = this.getUnderscoreKeyword(nameToken)
+		underscore = b.getUnderscoreKeyword(nameToken)
 		return tree.CreateWildcardBindingPatternNode(underscore)
 	case common.IDENTIFIER_TOKEN:
 		identifierToken, ok := identifier.(tree.STToken)
 		if !ok {
 			panic("getWildcardBindingPattern: expected STToken")
 		}
-		underscore = this.getUnderscoreKeyword(identifierToken)
+		underscore = b.getUnderscoreKeyword(identifierToken)
 		return tree.CreateWildcardBindingPatternNode(underscore)
 	default:
 		panic("getWildcardBindingPattern: expected SIMPLE_NAME_REFERENCE or IDENTIFIER_TOKEN")
 	}
 }
 
-func (this *BallerinaParser) parseStatementStartsWithOpenBrace() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_AMBIGUOUS_STMT)
-	openBrace := this.parseOpenBrace()
-	if this.peek().Kind() == common.CLOSE_BRACE_TOKEN {
-		closeBrace := this.parseCloseBrace()
-		switch this.peek().Kind() {
+func (b *BallerinaParser) parseStatementStartsWithOpenBrace() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_AMBIGUOUS_STMT)
+	openBrace := b.parseOpenBrace()
+	if b.peek().Kind() == common.CLOSE_BRACE_TOKEN {
+		closeBrace := b.parseCloseBrace()
+		switch b.peek().Kind() {
 		case common.EQUAL_TOKEN:
-			this.switchContext(common.PARSER_RULE_CONTEXT_ASSIGNMENT_STMT)
+			b.switchContext(common.PARSER_RULE_CONTEXT_ASSIGNMENT_STMT)
 			fields := tree.CreateEmptyNodeList()
 			bindingPattern := tree.CreateMappingBindingPatternNode(openBrace, fields,
 				closeBrace)
-			return this.parseAssignmentStmtRhs(bindingPattern)
+			return b.parseAssignmentStmtRhs(bindingPattern)
 		case common.RIGHT_ARROW_TOKEN, common.SYNC_SEND_TOKEN:
-			this.switchContext(common.PARSER_RULE_CONTEXT_EXPRESSION_STATEMENT)
+			b.switchContext(common.PARSER_RULE_CONTEXT_EXPRESSION_STATEMENT)
 			fields := tree.CreateEmptyNodeList()
 			expr := tree.CreateMappingConstructorExpressionNode(openBrace, fields, closeBrace)
-			expr = this.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, expr, false, true)
-			return this.parseStatementStartWithExprRhs(expr)
+			expr = b.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, expr, false, true)
+			return b.parseStatementStartWithExprRhs(expr)
 		default:
 			statements := tree.CreateEmptyNodeList()
-			this.endContext()
+			b.endContext()
 			return tree.CreateBlockStatementNode(openBrace, statements, closeBrace)
 		}
 	}
-	member := this.parseStatementStartingBracedListFirstMember(openBrace.IsMissing())
-	nodeType := this.getBracedListType(member)
+	member := b.parseStatementStartingBracedListFirstMember(openBrace.IsMissing())
+	nodeType := b.getBracedListType(member)
 	var stmt tree.STNode
 	switch nodeType {
 	case common.MAPPING_BINDING_PATTERN:
-		return this.parseStmtAsMappingBindingPatternStart(openBrace, member)
+		return b.parseStmtAsMappingBindingPatternStart(openBrace, member)
 	case common.MAPPING_CONSTRUCTOR:
-		return this.parseStmtAsMappingConstructorStart(openBrace, member)
+		return b.parseStmtAsMappingConstructorStart(openBrace, member)
 	case common.MAPPING_BP_OR_MAPPING_CONSTRUCTOR:
-		return this.parseStmtAsMappingBPOrMappingConsStart(openBrace, member)
+		return b.parseStmtAsMappingBPOrMappingConsStart(openBrace, member)
 	case common.BLOCK_STATEMENT:
-		closeBrace := this.parseCloseBrace()
+		closeBrace := b.parseCloseBrace()
 		stmt = tree.CreateBlockStatementNode(openBrace, member, closeBrace)
-		this.endContext()
+		b.endContext()
 		return stmt
 	default:
 		var stmts []tree.STNode
 		stmts = append(stmts, member)
-		statements, stmts := this.parseStatementsInner(stmts) //nolint:staticcheck,ineffassign // stmts will be used for error recovery
-		closeBrace := this.parseCloseBrace()
-		this.endContext()
+		statements, stmts := b.parseStatementsInner(stmts) //nolint:staticcheck,ineffassign // stmts will be used for error recovery
+		closeBrace := b.parseCloseBrace()
+		b.endContext()
 		return tree.CreateBlockStatementNode(openBrace, statements, closeBrace)
 	}
 }
 
-func (this *BallerinaParser) parseStmtAsMappingBindingPatternStart(openBrace tree.STNode, firstMappingField tree.STNode) tree.STNode {
-	this.switchContext(common.PARSER_RULE_CONTEXT_ASSIGNMENT_STMT)
-	this.startContext(common.PARSER_RULE_CONTEXT_MAPPING_BINDING_PATTERN)
+func (b *BallerinaParser) parseStmtAsMappingBindingPatternStart(openBrace tree.STNode, firstMappingField tree.STNode) tree.STNode {
+	b.switchContext(common.PARSER_RULE_CONTEXT_ASSIGNMENT_STMT)
+	b.startContext(common.PARSER_RULE_CONTEXT_MAPPING_BINDING_PATTERN)
 	var bindingPatterns []tree.STNode
 	if firstMappingField.Kind() != common.REST_BINDING_PATTERN {
-		bindingPatterns = append(bindingPatterns, this.getBindingPattern(firstMappingField, false))
+		bindingPatterns = append(bindingPatterns, b.getBindingPattern(firstMappingField, false))
 	}
-	mappingBP, _ := this.parseMappingBindingPatternInner(openBrace, bindingPatterns, firstMappingField)
-	return this.parseAssignmentStmtRhs(mappingBP)
+	mappingBP, _ := b.parseMappingBindingPatternInner(openBrace, bindingPatterns, firstMappingField)
+	return b.parseAssignmentStmtRhs(mappingBP)
 }
 
-func (this *BallerinaParser) parseStmtAsMappingConstructorStart(openBrace tree.STNode, firstMember tree.STNode) tree.STNode {
-	this.switchContext(common.PARSER_RULE_CONTEXT_EXPRESSION_STATEMENT)
-	this.startContext(common.PARSER_RULE_CONTEXT_MAPPING_CONSTRUCTOR)
-	mappingCons, _ := this.parseAsMappingConstructor(openBrace, nil, firstMember)
-	expr := this.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, mappingCons, false, true)
-	return this.parseStatementStartWithExprRhs(expr)
+func (b *BallerinaParser) parseStmtAsMappingConstructorStart(openBrace tree.STNode, firstMember tree.STNode) tree.STNode {
+	b.switchContext(common.PARSER_RULE_CONTEXT_EXPRESSION_STATEMENT)
+	b.startContext(common.PARSER_RULE_CONTEXT_MAPPING_CONSTRUCTOR)
+	mappingCons, _ := b.parseAsMappingConstructor(openBrace, nil, firstMember)
+	expr := b.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, mappingCons, false, true)
+	return b.parseStatementStartWithExprRhs(expr)
 }
 
-func (this *BallerinaParser) parseAsMappingConstructor(openBrace tree.STNode, members []tree.STNode, member tree.STNode) (tree.STNode, []tree.STNode) {
+func (b *BallerinaParser) parseAsMappingConstructor(openBrace tree.STNode, members []tree.STNode, member tree.STNode) (tree.STNode, []tree.STNode) {
 	members = append(members, member)
-	members = this.getExpressionList(members, true)
-	this.switchContext(common.PARSER_RULE_CONTEXT_MAPPING_CONSTRUCTOR)
-	fields := this.finishParseMappingConstructorFields(members)
-	closeBrace := this.parseCloseBrace()
-	this.endContext()
+	members = b.getExpressionList(members, true)
+	b.switchContext(common.PARSER_RULE_CONTEXT_MAPPING_CONSTRUCTOR)
+	fields := b.finishParseMappingConstructorFields(members)
+	closeBrace := b.parseCloseBrace()
+	b.endContext()
 	return tree.CreateMappingConstructorExpressionNode(openBrace, fields, closeBrace), members
 }
 
-func (this *BallerinaParser) parseStmtAsMappingBPOrMappingConsStart(openBrace tree.STNode, member tree.STNode) tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_MAPPING_BP_OR_MAPPING_CONSTRUCTOR)
+func (b *BallerinaParser) parseStmtAsMappingBPOrMappingConsStart(openBrace tree.STNode, member tree.STNode) tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_MAPPING_BP_OR_MAPPING_CONSTRUCTOR)
 	var members []tree.STNode
 	members = append(members, member)
 	var bpOrConstructor tree.STNode
-	memberEnd := this.parseMappingFieldEnd()
+	memberEnd := b.parseMappingFieldEnd()
 	if memberEnd == nil {
-		closeBrace := this.parseCloseBrace()
-		bpOrConstructor = this.parseMappingBindingPatternOrMappingConstructorWithCloseBrace(openBrace, members, closeBrace)
+		closeBrace := b.parseCloseBrace()
+		bpOrConstructor = b.parseMappingBindingPatternOrMappingConstructorWithCloseBrace(openBrace, members, closeBrace)
 	} else {
 		members = append(members, memberEnd)
-		bpOrConstructor, members = this.parseMappingBindingPatternOrMappingConstructor(openBrace, members) //nolint:staticcheck,ineffassign // members will be used when mapping binding pattern is fully implemented
+		bpOrConstructor, members = b.parseMappingBindingPatternOrMappingConstructor(openBrace, members) //nolint:staticcheck,ineffassign // members will be used when mapping binding pattern is fully implemented
 	}
 	switch bpOrConstructor.Kind() {
 	case common.MAPPING_CONSTRUCTOR:
-		this.switchContext(common.PARSER_RULE_CONTEXT_EXPRESSION_STATEMENT)
-		expr := this.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, bpOrConstructor, false, true)
-		return this.parseStatementStartWithExprRhs(expr)
+		b.switchContext(common.PARSER_RULE_CONTEXT_EXPRESSION_STATEMENT)
+		expr := b.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, bpOrConstructor, false, true)
+		return b.parseStatementStartWithExprRhs(expr)
 	case common.MAPPING_BINDING_PATTERN:
-		this.switchContext(common.PARSER_RULE_CONTEXT_ASSIGNMENT_STMT)
-		bindingPattern := this.getBindingPattern(bpOrConstructor, false)
-		return this.parseAssignmentStmtRhs(bindingPattern)
+		b.switchContext(common.PARSER_RULE_CONTEXT_ASSIGNMENT_STMT)
+		bindingPattern := b.getBindingPattern(bpOrConstructor, false)
+		return b.parseAssignmentStmtRhs(bindingPattern)
 	case common.MAPPING_BP_OR_MAPPING_CONSTRUCTOR:
 		fallthrough
 	default:
-		if this.peek().Kind() == common.EQUAL_TOKEN {
-			this.switchContext(common.PARSER_RULE_CONTEXT_ASSIGNMENT_STMT)
-			bindingPattern := this.getBindingPattern(bpOrConstructor, false)
-			return this.parseAssignmentStmtRhs(bindingPattern)
+		if b.peek().Kind() == common.EQUAL_TOKEN {
+			b.switchContext(common.PARSER_RULE_CONTEXT_ASSIGNMENT_STMT)
+			bindingPattern := b.getBindingPattern(bpOrConstructor, false)
+			return b.parseAssignmentStmtRhs(bindingPattern)
 		}
-		this.switchContext(common.PARSER_RULE_CONTEXT_EXPRESSION_STATEMENT)
-		expr := this.getExpression(bpOrConstructor)
-		expr = this.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, expr, false, true)
-		return this.parseStatementStartWithExprRhs(expr)
+		b.switchContext(common.PARSER_RULE_CONTEXT_EXPRESSION_STATEMENT)
+		expr := b.getExpression(bpOrConstructor)
+		expr = b.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, expr, false, true)
+		return b.parseStatementStartWithExprRhs(expr)
 	}
 }
 
-func (this *BallerinaParser) parseStatementStartingBracedListFirstMember(isOpenBraceMissing bool) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseStatementStartingBracedListFirstMember(isOpenBraceMissing bool) tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.READONLY_KEYWORD:
-		readonlyKeyword := this.parseReadonlyKeyword()
-		return this.bracedListMemberStartsWithReadonly(readonlyKeyword)
+		readonlyKeyword := b.parseReadonlyKeyword()
+		return b.bracedListMemberStartsWithReadonly(readonlyKeyword)
 	case common.IDENTIFIER_TOKEN:
 		readonlyKeyword := tree.CreateEmptyNode()
-		return this.parseIdentifierRhsInStmtStartingBrace(readonlyKeyword)
+		return b.parseIdentifierRhsInStmtStartingBrace(readonlyKeyword)
 	case common.STRING_LITERAL_TOKEN:
-		key := this.parseStringLiteral()
-		if this.peek().Kind() == common.COLON_TOKEN {
+		key := b.parseStringLiteral()
+		if b.peek().Kind() == common.COLON_TOKEN {
 			readonlyKeyword := tree.CreateEmptyNode()
-			colon := this.parseColon()
-			valueExpr := this.parseExpression()
+			colon := b.parseColon()
+			valueExpr := b.parseExpression()
 			return tree.CreateSpecificFieldNode(readonlyKeyword, key, colon, valueExpr)
 		}
-		this.switchContext(common.PARSER_RULE_CONTEXT_BLOCK_STMT)
-		this.startContext(common.PARSER_RULE_CONTEXT_AMBIGUOUS_STMT)
-		expr := this.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, key, false, true)
-		return this.parseStatementStartWithExprRhs(expr)
+		b.switchContext(common.PARSER_RULE_CONTEXT_BLOCK_STMT)
+		b.startContext(common.PARSER_RULE_CONTEXT_AMBIGUOUS_STMT)
+		expr := b.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, key, false, true)
+		return b.parseStatementStartWithExprRhs(expr)
 	case common.OPEN_BRACKET_TOKEN:
 		annots := tree.CreateEmptyNodeList()
-		return this.parseStatementStartsWithOpenBracket(annots, true)
+		return b.parseStatementStartsWithOpenBracket(annots, true)
 	case common.OPEN_BRACE_TOKEN:
-		this.switchContext(common.PARSER_RULE_CONTEXT_BLOCK_STMT)
-		return this.parseStatementStartsWithOpenBrace()
+		b.switchContext(common.PARSER_RULE_CONTEXT_BLOCK_STMT)
+		return b.parseStatementStartsWithOpenBrace()
 	case common.ELLIPSIS_TOKEN:
-		return this.parseRestBindingPattern()
+		return b.parseRestBindingPattern()
 	default:
 		if isOpenBraceMissing {
 			readonlyKeyword := tree.CreateEmptyNode()
-			return this.parseIdentifierRhsInStmtStartingBrace(readonlyKeyword)
+			return b.parseIdentifierRhsInStmtStartingBrace(readonlyKeyword)
 		}
-		this.switchContext(common.PARSER_RULE_CONTEXT_BLOCK_STMT)
-		return this.parseStatements()
+		b.switchContext(common.PARSER_RULE_CONTEXT_BLOCK_STMT)
+		return b.parseStatements()
 	}
 }
 
-func (this *BallerinaParser) bracedListMemberStartsWithReadonly(readonlyKeyword tree.STNode) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) bracedListMemberStartsWithReadonly(readonlyKeyword tree.STNode) tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.IDENTIFIER_TOKEN:
-		return this.parseIdentifierRhsInStmtStartingBrace(readonlyKeyword)
+		return b.parseIdentifierRhsInStmtStartingBrace(readonlyKeyword)
 	case common.STRING_LITERAL_TOKEN:
-		if this.peekN(2).Kind() == common.COLON_TOKEN {
-			key := this.parseStringLiteral()
-			colon := this.parseColon()
-			valueExpr := this.parseExpression()
+		if b.peekN(2).Kind() == common.COLON_TOKEN {
+			key := b.parseStringLiteral()
+			colon := b.parseColon()
+			valueExpr := b.parseExpression()
 			return tree.CreateSpecificFieldNode(readonlyKeyword, key, colon, valueExpr)
 		}
 		fallthrough
 	default:
-		this.switchContext(common.PARSER_RULE_CONTEXT_BLOCK_STMT)
+		b.switchContext(common.PARSER_RULE_CONTEXT_BLOCK_STMT)
 		typeDesc := CreateBuiltinSimpleNameReference(readonlyKeyword)
-		res, _ := this.parseVarDeclTypeDescRhs(typeDesc, tree.CreateEmptyNodeList(), nil,
+		res, _ := b.parseVarDeclTypeDescRhs(typeDesc, tree.CreateEmptyNodeList(), nil,
 			true, false)
 		return res
 	}
 }
 
-func (this *BallerinaParser) parseIdentifierRhsInStmtStartingBrace(readonlyKeyword tree.STNode) tree.STNode {
-	identifier := this.parseIdentifier(common.PARSER_RULE_CONTEXT_VARIABLE_REF)
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseIdentifierRhsInStmtStartingBrace(readonlyKeyword tree.STNode) tree.STNode {
+	identifier := b.parseIdentifier(common.PARSER_RULE_CONTEXT_VARIABLE_REF)
+	switch b.peek().Kind() {
 	case common.COMMA_TOKEN, common.CLOSE_BRACE_TOKEN:
 		colon := tree.CreateEmptyNode()
 		value := tree.CreateEmptyNode()
 		return tree.CreateSpecificFieldNode(readonlyKeyword, identifier, colon, value)
 	case common.COLON_TOKEN:
-		colon := this.parseColon()
-		if !this.isEmpty(readonlyKeyword) {
-			value := this.parseExpression()
+		colon := b.parseColon()
+		if !b.isEmpty(readonlyKeyword) {
+			value := b.parseExpression()
 			return tree.CreateSpecificFieldNode(readonlyKeyword, identifier, colon, value)
 		}
-		switch this.peek().Kind() {
+		switch b.peek().Kind() {
 		case common.OPEN_BRACKET_TOKEN:
-			bindingPatternOrExpr := this.parseListBindingPatternOrListConstructor()
-			return this.getMappingField(identifier, colon, bindingPatternOrExpr)
+			bindingPatternOrExpr := b.parseListBindingPatternOrListConstructor()
+			return b.getMappingField(identifier, colon, bindingPatternOrExpr)
 		case common.OPEN_BRACE_TOKEN:
-			bindingPatternOrExpr := this.parseMappingBindingPatterOrMappingConstructor()
-			return this.getMappingField(identifier, colon, bindingPatternOrExpr)
+			bindingPatternOrExpr := b.parseMappingBindingPatterOrMappingConstructor()
+			return b.getMappingField(identifier, colon, bindingPatternOrExpr)
 		case common.ERROR_KEYWORD:
-			bindingPatternOrExpr := this.parseErrorBindingPatternOrErrorConstructor()
-			return this.getMappingField(identifier, colon, bindingPatternOrExpr)
+			bindingPatternOrExpr := b.parseErrorBindingPatternOrErrorConstructor()
+			return b.getMappingField(identifier, colon, bindingPatternOrExpr)
 		case common.IDENTIFIER_TOKEN:
-			return this.parseQualifiedIdentifierRhsInStmtStartBrace(identifier, colon)
+			return b.parseQualifiedIdentifierRhsInStmtStartBrace(identifier, colon)
 		default:
-			expr := this.parseExpression()
-			return this.getMappingField(identifier, colon, expr)
+			expr := b.parseExpression()
+			return b.getMappingField(identifier, colon, expr)
 		}
 	default:
-		this.switchContext(common.PARSER_RULE_CONTEXT_BLOCK_STMT)
-		if !this.isEmpty(readonlyKeyword) {
-			this.startContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+		b.switchContext(common.PARSER_RULE_CONTEXT_BLOCK_STMT)
+		if !b.isEmpty(readonlyKeyword) {
+			b.startContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
 			bindingPattern := tree.CreateCaptureBindingPatternNode(identifier)
 			typedBindingPattern := tree.CreateTypedBindingPatternNode(readonlyKeyword, bindingPattern)
 			annots := tree.CreateEmptyNodeList()
-			res, _ := this.parseVarDeclRhs(annots, nil, typedBindingPattern, false)
+			res, _ := b.parseVarDeclRhs(annots, nil, typedBindingPattern, false)
 			return res
 		}
-		this.startContext(common.PARSER_RULE_CONTEXT_AMBIGUOUS_STMT)
-		qualifiedIdentifier := this.parseQualifiedIdentifierNode(identifier, false)
-		expr := this.parseTypedBindingPatternOrExprRhs(qualifiedIdentifier, true)
+		b.startContext(common.PARSER_RULE_CONTEXT_AMBIGUOUS_STMT)
+		qualifiedIdentifier := b.parseQualifiedIdentifierNode(identifier, false)
+		expr := b.parseTypedBindingPatternOrExprRhs(qualifiedIdentifier, true)
 		annots := tree.CreateEmptyNodeList()
-		return this.parseStmtStartsWithTypedBPOrExprRhs(annots, expr)
+		return b.parseStmtStartsWithTypedBPOrExprRhs(annots, expr)
 	}
 }
 
-func (this *BallerinaParser) parseQualifiedIdentifierRhsInStmtStartBrace(identifier tree.STNode, colon tree.STNode) tree.STNode {
-	secondIdentifier := this.parseIdentifier(common.PARSER_RULE_CONTEXT_VARIABLE_REF)
+func (b *BallerinaParser) parseQualifiedIdentifierRhsInStmtStartBrace(identifier tree.STNode, colon tree.STNode) tree.STNode {
+	secondIdentifier := b.parseIdentifier(common.PARSER_RULE_CONTEXT_VARIABLE_REF)
 	secondNameRef := tree.CreateSimpleNameReferenceNode(secondIdentifier)
-	if this.isWildcardBP(secondIdentifier) {
-		wildcardBP := this.getWildcardBindingPattern(secondIdentifier)
+	if b.isWildcardBP(secondIdentifier) {
+		wildcardBP := b.getWildcardBindingPattern(secondIdentifier)
 		nameRef := tree.CreateSimpleNameReferenceNode(identifier)
 		return tree.CreateFieldBindingPatternFullNode(nameRef, colon, wildcardBP)
 	}
-	qualifiedNameRef := this.createQualifiedNameReferenceNode(identifier, colon, secondIdentifier)
-	switch this.peek().Kind() {
+	qualifiedNameRef := b.createQualifiedNameReferenceNode(identifier, colon, secondIdentifier)
+	switch b.peek().Kind() {
 	case common.COMMA_TOKEN:
 		return tree.CreateSpecificFieldNode(tree.CreateEmptyNode(), identifier, colon,
 			secondNameRef)
 	case common.OPEN_BRACE_TOKEN, common.IDENTIFIER_TOKEN:
-		this.switchContext(common.PARSER_RULE_CONTEXT_BLOCK_STMT)
-		this.startContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
-		typeBindingPattern := this.parseTypedBindingPatternTypeRhs(qualifiedNameRef, common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+		b.switchContext(common.PARSER_RULE_CONTEXT_BLOCK_STMT)
+		b.startContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+		typeBindingPattern := b.parseTypedBindingPatternTypeRhs(qualifiedNameRef, common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
 		annots := tree.CreateEmptyNodeList()
-		res, _ := this.parseVarDeclRhs(annots, nil, typeBindingPattern, false)
+		res, _ := b.parseVarDeclRhs(annots, nil, typeBindingPattern, false)
 		return res
 	case common.OPEN_BRACKET_TOKEN:
-		return this.parseMemberRhsInStmtStartWithBrace(identifier, colon, secondIdentifier, secondNameRef)
+		return b.parseMemberRhsInStmtStartWithBrace(identifier, colon, secondIdentifier, secondNameRef)
 	case common.QUESTION_MARK_TOKEN:
-		typeDesc := this.parseComplexTypeDescriptor(qualifiedNameRef,
+		typeDesc := b.parseComplexTypeDescriptor(qualifiedNameRef,
 			common.PARSER_RULE_CONTEXT_TYPE_DESC_IN_TYPE_BINDING_PATTERN, true)
-		typeBindingPattern := this.parseTypedBindingPatternTypeRhs(typeDesc, common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+		typeBindingPattern := b.parseTypedBindingPatternTypeRhs(typeDesc, common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
 		annots := tree.CreateEmptyNodeList()
-		res, _ := this.parseVarDeclRhs(annots, nil, typeBindingPattern, false)
+		res, _ := b.parseVarDeclRhs(annots, nil, typeBindingPattern, false)
 		return res
 	case common.EQUAL_TOKEN, common.SEMICOLON_TOKEN:
-		return this.parseStatementStartWithExprRhs(qualifiedNameRef)
+		return b.parseStatementStartWithExprRhs(qualifiedNameRef)
 	case common.PIPE_TOKEN, common.BITWISE_AND_TOKEN:
 		fallthrough
 	default:
-		return this.parseMemberWithExprInRhs(identifier, colon, secondIdentifier, secondNameRef)
+		return b.parseMemberWithExprInRhs(identifier, colon, secondIdentifier, secondNameRef)
 	}
 }
 
-func (this *BallerinaParser) getBracedListType(member tree.STNode) common.SyntaxKind {
+func (b *BallerinaParser) getBracedListType(member tree.STNode) common.SyntaxKind {
 	switch member.Kind() {
 	case common.FIELD_BINDING_PATTERN,
 		common.CAPTURE_BINDING_PATTERN,
@@ -13770,7 +13770,7 @@ func (this *BallerinaParser) getBracedListType(member tree.STNode) common.Syntax
 			if !ok {
 				panic("getBracedListType: expected STErrorConstructorExpressionNode")
 			}
-			if this.isPossibleErrorBindingPattern(*errorCtorNode) {
+			if b.isPossibleErrorBindingPattern(*errorCtorNode) {
 				return common.MAPPING_BP_OR_MAPPING_CONSTRUCTOR
 			}
 			return common.MAPPING_CONSTRUCTOR
@@ -13793,14 +13793,14 @@ func (this *BallerinaParser) getBracedListType(member tree.STNode) common.Syntax
 	}
 }
 
-func (this *BallerinaParser) parseMappingBindingPatterOrMappingConstructor() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_MAPPING_BP_OR_MAPPING_CONSTRUCTOR)
-	openBrace := this.parseOpenBrace()
-	res, _ := this.parseMappingBindingPatternOrMappingConstructor(openBrace, nil)
+func (b *BallerinaParser) parseMappingBindingPatterOrMappingConstructor() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_MAPPING_BP_OR_MAPPING_CONSTRUCTOR)
+	openBrace := b.parseOpenBrace()
+	res, _ := b.parseMappingBindingPatternOrMappingConstructor(openBrace, nil)
 	return res
 }
 
-func (this *BallerinaParser) isBracedListEnd(nextTokenKind common.SyntaxKind) bool {
+func (b *BallerinaParser) isBracedListEnd(nextTokenKind common.SyntaxKind) bool {
 	switch nextTokenKind {
 	case common.EOF_TOKEN, common.CLOSE_BRACE_TOKEN:
 		return true
@@ -13809,91 +13809,91 @@ func (this *BallerinaParser) isBracedListEnd(nextTokenKind common.SyntaxKind) bo
 	}
 }
 
-func (this *BallerinaParser) parseMappingBindingPatternOrMappingConstructor(openBrace tree.STNode, memberList []tree.STNode) (tree.STNode, []tree.STNode) {
-	nextToken := this.peek()
-	for !this.isBracedListEnd(nextToken.Kind()) {
-		member := this.parseMappingBindingPatterOrMappingConstructorMember()
-		currentNodeType := this.getTypeOfMappingBPOrMappingCons(member)
+func (b *BallerinaParser) parseMappingBindingPatternOrMappingConstructor(openBrace tree.STNode, memberList []tree.STNode) (tree.STNode, []tree.STNode) {
+	nextToken := b.peek()
+	for !b.isBracedListEnd(nextToken.Kind()) {
+		member := b.parseMappingBindingPatterOrMappingConstructorMember()
+		currentNodeType := b.getTypeOfMappingBPOrMappingCons(member)
 		switch currentNodeType {
 		case common.MAPPING_CONSTRUCTOR:
-			return this.parseAsMappingConstructor(openBrace, memberList, member)
+			return b.parseAsMappingConstructor(openBrace, memberList, member)
 		case common.MAPPING_BINDING_PATTERN:
-			return this.parseAsMappingBindingPattern(openBrace, memberList, member)
+			return b.parseAsMappingBindingPattern(openBrace, memberList, member)
 		case common.MAPPING_BP_OR_MAPPING_CONSTRUCTOR:
 			fallthrough
 		default:
 			memberList = append(memberList, member)
 		}
-		memberEnd := this.parseMappingFieldEnd()
+		memberEnd := b.parseMappingFieldEnd()
 		if memberEnd == nil {
 			break
 		}
 		memberList = append(memberList, memberEnd)
-		nextToken = this.peek()
+		nextToken = b.peek()
 	}
-	closeBrace := this.parseCloseBrace()
-	return this.parseMappingBindingPatternOrMappingConstructorWithCloseBrace(openBrace, memberList, closeBrace), memberList
+	closeBrace := b.parseCloseBrace()
+	return b.parseMappingBindingPatternOrMappingConstructorWithCloseBrace(openBrace, memberList, closeBrace), memberList
 }
 
-func (this *BallerinaParser) parseMappingBindingPatterOrMappingConstructorMember() tree.STNode {
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseMappingBindingPatterOrMappingConstructorMember() tree.STNode {
+	switch b.peek().Kind() {
 	case common.IDENTIFIER_TOKEN:
-		key := this.parseIdentifier(common.PARSER_RULE_CONTEXT_MAPPING_FIELD_NAME)
-		return this.parseMappingFieldRhs(key)
+		key := b.parseIdentifier(common.PARSER_RULE_CONTEXT_MAPPING_FIELD_NAME)
+		return b.parseMappingFieldRhs(key)
 	case common.STRING_LITERAL_TOKEN:
 		readonlyKeyword := tree.CreateEmptyNode()
-		key := this.parseStringLiteral()
-		colon := this.parseColon()
-		valueExpr := this.parseExpression()
+		key := b.parseStringLiteral()
+		colon := b.parseColon()
+		valueExpr := b.parseExpression()
 		return tree.CreateSpecificFieldNode(readonlyKeyword, key, colon, valueExpr)
 	case common.OPEN_BRACKET_TOKEN:
-		return this.parseComputedField()
+		return b.parseComputedField()
 	case common.ELLIPSIS_TOKEN:
-		ellipsis := this.parseEllipsis()
-		expr := this.parseExpression()
+		ellipsis := b.parseEllipsis()
+		expr := b.parseExpression()
 		if expr.Kind() == common.SIMPLE_NAME_REFERENCE {
 			return tree.CreateRestBindingPatternNode(ellipsis, expr)
 		}
 		return tree.CreateSpreadFieldNode(ellipsis, expr)
 	default:
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_MAPPING_BP_OR_MAPPING_CONSTRUCTOR_MEMBER)
-		return this.parseMappingBindingPatterOrMappingConstructorMember()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_MAPPING_BP_OR_MAPPING_CONSTRUCTOR_MEMBER)
+		return b.parseMappingBindingPatterOrMappingConstructorMember()
 	}
 }
 
-func (this *BallerinaParser) parseMappingFieldRhs(key tree.STNode) tree.STNode {
+func (b *BallerinaParser) parseMappingFieldRhs(key tree.STNode) tree.STNode {
 	var colon tree.STNode
 	var valueExpr tree.STNode
-	switch this.peek().Kind() {
+	switch b.peek().Kind() {
 	case common.COLON_TOKEN:
-		colon = this.parseColon()
-		return this.parseMappingFieldValue(key, colon)
+		colon = b.parseColon()
+		return b.parseMappingFieldValue(key, colon)
 	case common.COMMA_TOKEN, common.CLOSE_BRACE_TOKEN:
 		readonlyKeyword := tree.CreateEmptyNode()
 		colon = tree.CreateEmptyNode()
 		valueExpr = tree.CreateEmptyNode()
 		return tree.CreateSpecificFieldNode(readonlyKeyword, key, colon, valueExpr)
 	default:
-		token := this.peek()
-		this.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_FIELD_BINDING_PATTERN_END)
+		token := b.peek()
+		b.recoverWithBlockContext(token, common.PARSER_RULE_CONTEXT_FIELD_BINDING_PATTERN_END)
 		readonlyKeyword := tree.CreateEmptyNode()
-		return this.parseSpecificFieldRhs(readonlyKeyword, key)
+		return b.parseSpecificFieldRhs(readonlyKeyword, key)
 	}
 }
 
-func (this *BallerinaParser) parseMappingFieldValue(key tree.STNode, colon tree.STNode) tree.STNode {
+func (b *BallerinaParser) parseMappingFieldValue(key tree.STNode, colon tree.STNode) tree.STNode {
 	var expr tree.STNode
-	switch this.peek().Kind() {
+	switch b.peek().Kind() {
 	case common.IDENTIFIER_TOKEN:
-		expr = this.parseExpression()
+		expr = b.parseExpression()
 	case common.OPEN_BRACKET_TOKEN:
-		expr = this.parseListBindingPatternOrListConstructor()
+		expr = b.parseListBindingPatternOrListConstructor()
 	case common.OPEN_BRACE_TOKEN:
-		expr = this.parseMappingBindingPatterOrMappingConstructor()
+		expr = b.parseMappingBindingPatterOrMappingConstructor()
 	default:
-		expr = this.parseExpression()
+		expr = b.parseExpression()
 	}
-	if this.isBindingPattern(expr.Kind()) {
+	if b.isBindingPattern(expr.Kind()) {
 		key = tree.CreateSimpleNameReferenceNode(key)
 		return tree.CreateFieldBindingPatternFullNode(key, colon, expr)
 	}
@@ -13901,7 +13901,7 @@ func (this *BallerinaParser) parseMappingFieldValue(key tree.STNode, colon tree.
 	return tree.CreateSpecificFieldNode(readonlyKeyword, key, colon, expr)
 }
 
-func (this *BallerinaParser) isBindingPattern(kind common.SyntaxKind) bool {
+func (b *BallerinaParser) isBindingPattern(kind common.SyntaxKind) bool {
 	switch kind {
 	case common.FIELD_BINDING_PATTERN,
 		common.MAPPING_BINDING_PATTERN,
@@ -13914,7 +13914,7 @@ func (this *BallerinaParser) isBindingPattern(kind common.SyntaxKind) bool {
 	}
 }
 
-func (this *BallerinaParser) getTypeOfMappingBPOrMappingCons(memberNode tree.STNode) common.SyntaxKind {
+func (b *BallerinaParser) getTypeOfMappingBPOrMappingCons(memberNode tree.STNode) common.SyntaxKind {
 	switch memberNode.Kind() {
 	case common.FIELD_BINDING_PATTERN,
 		common.MAPPING_BINDING_PATTERN,
@@ -13942,77 +13942,77 @@ func (this *BallerinaParser) getTypeOfMappingBPOrMappingCons(memberNode tree.STN
 	}
 }
 
-func (this *BallerinaParser) parseMappingBindingPatternOrMappingConstructorWithCloseBrace(openBrace tree.STNode, members []tree.STNode, closeBrace tree.STNode) tree.STNode {
-	this.endContext()
+func (b *BallerinaParser) parseMappingBindingPatternOrMappingConstructorWithCloseBrace(openBrace tree.STNode, members []tree.STNode, closeBrace tree.STNode) tree.STNode {
+	b.endContext()
 	return tree.CreateAmbiguousCollectionNode(common.MAPPING_BP_OR_MAPPING_CONSTRUCTOR, openBrace, members, closeBrace)
 }
 
-func (this *BallerinaParser) parseAsMappingBindingPattern(openBrace tree.STNode, members []tree.STNode, member tree.STNode) (tree.STNode, []tree.STNode) {
+func (b *BallerinaParser) parseAsMappingBindingPattern(openBrace tree.STNode, members []tree.STNode, member tree.STNode) (tree.STNode, []tree.STNode) {
 	members = append(members, member)
-	members = this.getBindingPatternsList(members, false)
-	this.switchContext(common.PARSER_RULE_CONTEXT_MAPPING_BINDING_PATTERN)
-	return this.parseMappingBindingPatternInner(openBrace, members, member)
+	members = b.getBindingPatternsList(members, false)
+	b.switchContext(common.PARSER_RULE_CONTEXT_MAPPING_BINDING_PATTERN)
+	return b.parseMappingBindingPatternInner(openBrace, members, member)
 }
 
-func (this *BallerinaParser) parseListBindingPatternOrListConstructor() tree.STNode {
-	this.startContext(common.PARSER_RULE_CONTEXT_BRACKETED_LIST)
-	openBracket := this.parseOpenBracket()
-	res, _ := this.parseListBindingPatternOrListConstructorInner(openBracket, nil, false)
+func (b *BallerinaParser) parseListBindingPatternOrListConstructor() tree.STNode {
+	b.startContext(common.PARSER_RULE_CONTEXT_BRACKETED_LIST)
+	openBracket := b.parseOpenBracket()
+	res, _ := b.parseListBindingPatternOrListConstructorInner(openBracket, nil, false)
 	return res
 }
 
 // return result, and modified memberList
-func (this *BallerinaParser) parseListBindingPatternOrListConstructorInner(openBracket tree.STNode, memberList []tree.STNode, isRoot bool) (tree.STNode, []tree.STNode) {
-	nextToken := this.peek()
-	for !this.isBracketedListEnd(nextToken.Kind()) {
-		member := this.parseListBindingPatternOrListConstructorMember()
-		currentNodeType := this.getParsingNodeTypeOfListBPOrListCons(member)
+func (b *BallerinaParser) parseListBindingPatternOrListConstructorInner(openBracket tree.STNode, memberList []tree.STNode, isRoot bool) (tree.STNode, []tree.STNode) {
+	nextToken := b.peek()
+	for !b.isBracketedListEnd(nextToken.Kind()) {
+		member := b.parseListBindingPatternOrListConstructorMember()
+		currentNodeType := b.getParsingNodeTypeOfListBPOrListCons(member)
 		switch currentNodeType {
 		case common.LIST_CONSTRUCTOR:
-			return this.parseAsListConstructor(openBracket, memberList, member, isRoot)
+			return b.parseAsListConstructor(openBracket, memberList, member, isRoot)
 		case common.LIST_BINDING_PATTERN:
-			return this.parseAsListBindingPatternWithMemberAndRoot(openBracket, memberList, member, isRoot)
+			return b.parseAsListBindingPatternWithMemberAndRoot(openBracket, memberList, member, isRoot)
 		case common.LIST_BP_OR_LIST_CONSTRUCTOR:
 			fallthrough
 		default:
 			memberList = append(memberList, member)
 		}
-		memberEnd := this.parseBracketedListMemberEnd()
+		memberEnd := b.parseBracketedListMemberEnd()
 		if memberEnd == nil {
 			break
 		}
 		memberList = append(memberList, memberEnd)
-		nextToken = this.peek()
+		nextToken = b.peek()
 	}
-	closeBracket := this.parseCloseBracket()
-	return this.parseListBindingPatternOrListConstructorWithCloseBracket(openBracket, memberList, closeBracket, isRoot), memberList
+	closeBracket := b.parseCloseBracket()
+	return b.parseListBindingPatternOrListConstructorWithCloseBracket(openBracket, memberList, closeBracket, isRoot), memberList
 }
 
-func (this *BallerinaParser) parseListBindingPatternOrListConstructorMember() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseListBindingPatternOrListConstructorMember() tree.STNode {
+	nextToken := b.peek()
 	switch nextToken.Kind() {
 	case common.OPEN_BRACKET_TOKEN:
-		return this.parseListBindingPatternOrListConstructor()
+		return b.parseListBindingPatternOrListConstructor()
 	case common.IDENTIFIER_TOKEN:
-		identifier := this.parseQualifiedIdentifier(common.PARSER_RULE_CONTEXT_VARIABLE_REF)
-		if this.isWildcardBP(identifier) {
-			return this.getWildcardBindingPattern(identifier)
+		identifier := b.parseQualifiedIdentifier(common.PARSER_RULE_CONTEXT_VARIABLE_REF)
+		if b.isWildcardBP(identifier) {
+			return b.getWildcardBindingPattern(identifier)
 		}
-		return this.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, identifier, false, false)
+		return b.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, identifier, false, false)
 	case common.OPEN_BRACE_TOKEN:
-		return this.parseMappingBindingPatterOrMappingConstructor()
+		return b.parseMappingBindingPatterOrMappingConstructor()
 	case common.ELLIPSIS_TOKEN:
-		return this.parseRestBindingOrSpreadMember()
+		return b.parseRestBindingOrSpreadMember()
 	default:
-		if this.isValidExpressionStart(nextToken.Kind(), 1) {
-			return this.parseExpression()
+		if b.isValidExpressionStart(nextToken.Kind(), 1) {
+			return b.parseExpression()
 		}
-		this.recoverWithBlockContext(this.peek(), common.PARSER_RULE_CONTEXT_LIST_BP_OR_LIST_CONSTRUCTOR_MEMBER)
-		return this.parseListBindingPatternOrListConstructorMember()
+		b.recoverWithBlockContext(b.peek(), common.PARSER_RULE_CONTEXT_LIST_BP_OR_LIST_CONSTRUCTOR_MEMBER)
+		return b.parseListBindingPatternOrListConstructorMember()
 	}
 }
 
-func (this *BallerinaParser) getParsingNodeTypeOfListBPOrListCons(memberNode tree.STNode) common.SyntaxKind {
+func (b *BallerinaParser) getParsingNodeTypeOfListBPOrListCons(memberNode tree.STNode) common.SyntaxKind {
 	switch memberNode.Kind() {
 	case common.CAPTURE_BINDING_PATTERN,
 		common.LIST_BINDING_PATTERN,
@@ -14030,125 +14030,125 @@ func (this *BallerinaParser) getParsingNodeTypeOfListBPOrListCons(memberNode tre
 }
 
 // Return res and modified memberList
-func (this *BallerinaParser) parseAsListConstructor(openBracket tree.STNode, memberList []tree.STNode, member tree.STNode, isRoot bool) (tree.STNode, []tree.STNode) {
+func (b *BallerinaParser) parseAsListConstructor(openBracket tree.STNode, memberList []tree.STNode, member tree.STNode, isRoot bool) (tree.STNode, []tree.STNode) {
 	memberList = append(memberList, member)
-	memberList = this.getExpressionList(memberList, false)
-	this.switchContext(common.PARSER_RULE_CONTEXT_LIST_CONSTRUCTOR)
-	listMembers := this.parseListMembersInner(memberList)
-	closeBracket := this.parseCloseBracket()
+	memberList = b.getExpressionList(memberList, false)
+	b.switchContext(common.PARSER_RULE_CONTEXT_LIST_CONSTRUCTOR)
+	listMembers := b.parseListMembersInner(memberList)
+	closeBracket := b.parseCloseBracket()
 	listConstructor := tree.CreateListConstructorExpressionNode(openBracket, listMembers, closeBracket)
-	this.endContext()
-	expr := this.parseExpressionRhs(OPERATOR_PRECEDENCE_DEFAULT, listConstructor, false, true)
+	b.endContext()
+	expr := b.parseExpressionRhs(OPERATOR_PRECEDENCE_DEFAULT, listConstructor, false, true)
 	if !isRoot {
 		return expr, memberList
 	}
-	return this.parseStatementStartWithExprRhs(expr), memberList
+	return b.parseStatementStartWithExprRhs(expr), memberList
 }
 
-func (this *BallerinaParser) parseListBindingPatternOrListConstructorWithCloseBracket(openBracket tree.STNode, members []tree.STNode, closeBracket tree.STNode, isRoot bool) tree.STNode {
+func (b *BallerinaParser) parseListBindingPatternOrListConstructorWithCloseBracket(openBracket tree.STNode, members []tree.STNode, closeBracket tree.STNode, isRoot bool) tree.STNode {
 	var lbpOrListCons tree.STNode
-	switch this.peek().Kind() {
+	switch b.peek().Kind() {
 	case common.COMMA_TOKEN,
 		common.CLOSE_BRACE_TOKEN,
 		common.CLOSE_BRACKET_TOKEN:
 		if !isRoot {
-			this.endContext()
+			b.endContext()
 			return tree.CreateAmbiguousCollectionNode(common.LIST_BP_OR_LIST_CONSTRUCTOR, openBracket, members, closeBracket)
 		}
 		fallthrough
 	default:
-		nextTokenKind := this.peek().Kind()
-		if this.isValidExprRhsStart(nextTokenKind, closeBracket.Kind()) || ((nextTokenKind == common.SEMICOLON_TOKEN) && isRoot) {
-			members = this.getExpressionList(members, false)
+		nextTokenKind := b.peek().Kind()
+		if b.isValidExprRhsStart(nextTokenKind, closeBracket.Kind()) || ((nextTokenKind == common.SEMICOLON_TOKEN) && isRoot) {
+			members = b.getExpressionList(members, false)
 			memberExpressions := tree.CreateNodeList(members...)
 			lbpOrListCons = tree.CreateListConstructorExpressionNode(openBracket, memberExpressions,
 				closeBracket)
-			lbpOrListCons = this.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, lbpOrListCons, false, true)
+			lbpOrListCons = b.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, lbpOrListCons, false, true)
 			break
 		}
-		members = this.getBindingPatternsList(members, true)
+		members = b.getBindingPatternsList(members, true)
 		bindingPatternsNode := tree.CreateNodeList(members...)
 		lbpOrListCons = tree.CreateListBindingPatternNode(openBracket, bindingPatternsNode,
 			closeBracket)
 	}
-	this.endContext()
+	b.endContext()
 	if !isRoot {
 		return lbpOrListCons
 	}
 	if lbpOrListCons.Kind() == common.LIST_BINDING_PATTERN {
-		return this.parseAssignmentStmtRhs(lbpOrListCons)
+		return b.parseAssignmentStmtRhs(lbpOrListCons)
 	} else {
-		return this.parseStatementStartWithExprRhs(lbpOrListCons)
+		return b.parseStatementStartWithExprRhs(lbpOrListCons)
 	}
 }
 
-func (this *BallerinaParser) parseMemberRhsInStmtStartWithBrace(identifier tree.STNode, colon tree.STNode, secondIdentifier tree.STNode, secondNameRef tree.STNode) tree.STNode {
-	typedBPOrExpr := this.parseTypedBindingPatternOrMemberAccess(secondNameRef, false, true, common.PARSER_RULE_CONTEXT_AMBIGUOUS_STMT)
-	if this.isExpression(typedBPOrExpr.Kind()) {
-		return this.parseMemberWithExprInRhs(identifier, colon, secondIdentifier, typedBPOrExpr)
+func (b *BallerinaParser) parseMemberRhsInStmtStartWithBrace(identifier tree.STNode, colon tree.STNode, secondIdentifier tree.STNode, secondNameRef tree.STNode) tree.STNode {
+	typedBPOrExpr := b.parseTypedBindingPatternOrMemberAccess(secondNameRef, false, true, common.PARSER_RULE_CONTEXT_AMBIGUOUS_STMT)
+	if b.isExpression(typedBPOrExpr.Kind()) {
+		return b.parseMemberWithExprInRhs(identifier, colon, secondIdentifier, typedBPOrExpr)
 	}
-	this.switchContext(common.PARSER_RULE_CONTEXT_BLOCK_STMT)
-	this.startContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
+	b.switchContext(common.PARSER_RULE_CONTEXT_BLOCK_STMT)
+	b.startContext(common.PARSER_RULE_CONTEXT_VAR_DECL_STMT)
 	varDeclQualifiers := []tree.STNode{}
 	annots := tree.CreateEmptyNodeList()
 	typedBP, ok := typedBPOrExpr.(*tree.STTypedBindingPatternNode)
 	if !ok {
 		panic("expected STTypedBindingPatternNode")
 	}
-	qualifiedNameRef := this.createQualifiedNameReferenceNode(identifier, colon, secondIdentifier)
-	newTypeDesc := this.mergeQualifiedNameWithTypeDesc(qualifiedNameRef, typedBP.TypeDescriptor)
+	qualifiedNameRef := b.createQualifiedNameReferenceNode(identifier, colon, secondIdentifier)
+	newTypeDesc := b.mergeQualifiedNameWithTypeDesc(qualifiedNameRef, typedBP.TypeDescriptor)
 	newTypeBP := tree.CreateTypedBindingPatternNode(newTypeDesc, typedBP.BindingPattern)
 	publicQualifier := tree.CreateEmptyNode()
-	res, _ := this.parseVarDeclRhsInner(annots, publicQualifier, varDeclQualifiers, newTypeBP, false)
+	res, _ := b.parseVarDeclRhsInner(annots, publicQualifier, varDeclQualifiers, newTypeBP, false)
 	return res
 }
 
-func (this *BallerinaParser) parseMemberWithExprInRhs(identifier tree.STNode, colon tree.STNode, secondIdentifier tree.STNode, memberAccessExpr tree.STNode) tree.STNode {
-	expr := this.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, memberAccessExpr, false, true)
-	switch this.peek().Kind() {
+func (b *BallerinaParser) parseMemberWithExprInRhs(identifier tree.STNode, colon tree.STNode, secondIdentifier tree.STNode, memberAccessExpr tree.STNode) tree.STNode {
+	expr := b.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, memberAccessExpr, false, true)
+	switch b.peek().Kind() {
 	case common.COMMA_TOKEN, common.CLOSE_BRACE_TOKEN:
-		this.switchContext(common.PARSER_RULE_CONTEXT_EXPRESSION_STATEMENT)
+		b.switchContext(common.PARSER_RULE_CONTEXT_EXPRESSION_STATEMENT)
 		readonlyKeyword := tree.CreateEmptyNode()
 		return tree.CreateSpecificFieldNode(readonlyKeyword, identifier, colon, expr)
 	case common.EQUAL_TOKEN, common.SEMICOLON_TOKEN:
 		fallthrough
 	default:
-		this.switchContext(common.PARSER_RULE_CONTEXT_BLOCK_STMT)
-		this.startContext(common.PARSER_RULE_CONTEXT_EXPRESSION_STATEMENT)
-		qualifiedName := this.createQualifiedNameReferenceNode(identifier, colon, secondIdentifier)
-		updatedExpr := this.mergeQualifiedNameWithExpr(qualifiedName, expr)
-		return this.parseStatementStartWithExprRhs(updatedExpr)
+		b.switchContext(common.PARSER_RULE_CONTEXT_BLOCK_STMT)
+		b.startContext(common.PARSER_RULE_CONTEXT_EXPRESSION_STATEMENT)
+		qualifiedName := b.createQualifiedNameReferenceNode(identifier, colon, secondIdentifier)
+		updatedExpr := b.mergeQualifiedNameWithExpr(qualifiedName, expr)
+		return b.parseStatementStartWithExprRhs(updatedExpr)
 	}
 }
 
-func (this *BallerinaParser) parseInferredTypeDescDefaultOrExpression() tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseInferredTypeDescDefaultOrExpression() tree.STNode {
+	nextToken := b.peek()
 	nextTokenKind := nextToken.Kind()
 	if nextTokenKind == common.LT_TOKEN {
-		return this.parseInferredTypeDescDefaultOrExpressionInner(this.consume())
+		return b.parseInferredTypeDescDefaultOrExpressionInner(b.consume())
 	}
-	if this.isValidExprStart(nextTokenKind) {
-		return this.parseExpression()
+	if b.isValidExprStart(nextTokenKind) {
+		return b.parseExpression()
 	}
-	this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_EXPR_START_OR_INFERRED_TYPEDESC_DEFAULT_START)
-	return this.parseInferredTypeDescDefaultOrExpression()
+	b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_EXPR_START_OR_INFERRED_TYPEDESC_DEFAULT_START)
+	return b.parseInferredTypeDescDefaultOrExpression()
 }
 
-func (this *BallerinaParser) parseInferredTypeDescDefaultOrExpressionInner(ltToken tree.STToken) tree.STNode {
-	nextToken := this.peek()
+func (b *BallerinaParser) parseInferredTypeDescDefaultOrExpressionInner(ltToken tree.STToken) tree.STNode {
+	nextToken := b.peek()
 	if nextToken.Kind() == common.GT_TOKEN {
-		return tree.CreateInferredTypedescDefaultNode(ltToken, this.consume())
+		return tree.CreateInferredTypedescDefaultNode(ltToken, b.consume())
 	}
-	if this.isTypeStartingToken(nextToken.Kind()) || (nextToken.Kind() == common.AT_TOKEN) {
-		this.startContext(common.PARSER_RULE_CONTEXT_TYPE_CAST)
-		expr := this.parseTypeCastExprInner(ltToken, true, false, false)
-		return this.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, expr, true, false)
+	if b.isTypeStartingToken(nextToken.Kind()) || (nextToken.Kind() == common.AT_TOKEN) {
+		b.startContext(common.PARSER_RULE_CONTEXT_TYPE_CAST)
+		expr := b.parseTypeCastExprInner(ltToken, true, false, false)
+		return b.parseExpressionRhs(DEFAULT_OP_PRECEDENCE, expr, true, false)
 	}
-	this.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_TYPE_CAST_PARAM_START_OR_INFERRED_TYPEDESC_DEFAULT_END)
-	return this.parseInferredTypeDescDefaultOrExpressionInner(ltToken)
+	b.recoverWithBlockContext(nextToken, common.PARSER_RULE_CONTEXT_TYPE_CAST_PARAM_START_OR_INFERRED_TYPEDESC_DEFAULT_END)
+	return b.parseInferredTypeDescDefaultOrExpressionInner(ltToken)
 }
 
-func (this *BallerinaParser) mergeQualifiedNameWithExpr(qualifiedName tree.STNode, exprOrAction tree.STNode) tree.STNode {
+func (b *BallerinaParser) mergeQualifiedNameWithExpr(qualifiedName tree.STNode, exprOrAction tree.STNode) tree.STNode {
 	switch exprOrAction.Kind() {
 	case common.SIMPLE_NAME_REFERENCE:
 		return qualifiedName
@@ -14157,7 +14157,7 @@ func (this *BallerinaParser) mergeQualifiedNameWithExpr(qualifiedName tree.STNod
 		if !ok {
 			panic("expected STBinaryExpressionNode")
 		}
-		newLhsExpr := this.mergeQualifiedNameWithExpr(qualifiedName, binaryExpr.LhsExpr)
+		newLhsExpr := b.mergeQualifiedNameWithExpr(qualifiedName, binaryExpr.LhsExpr)
 		return tree.CreateBinaryExpressionNode(binaryExpr.Kind(), newLhsExpr, binaryExpr.Operator,
 			binaryExpr.RhsExpr)
 	case common.FIELD_ACCESS:
@@ -14165,7 +14165,7 @@ func (this *BallerinaParser) mergeQualifiedNameWithExpr(qualifiedName tree.STNod
 		if !ok {
 			panic("expected STFieldAccessExpressionNode")
 		}
-		newLhsExpr := this.mergeQualifiedNameWithExpr(qualifiedName, fieldAccess.Expression)
+		newLhsExpr := b.mergeQualifiedNameWithExpr(qualifiedName, fieldAccess.Expression)
 		return tree.CreateFieldAccessExpressionNode(newLhsExpr, fieldAccess.DotToken,
 			fieldAccess.FieldName)
 	case common.INDEXED_EXPRESSION:
@@ -14173,7 +14173,7 @@ func (this *BallerinaParser) mergeQualifiedNameWithExpr(qualifiedName tree.STNod
 		if !ok {
 			panic("expected STIndexedExpressionNode")
 		}
-		newLhsExpr := this.mergeQualifiedNameWithExpr(qualifiedName, memberAccess.ContainerExpression)
+		newLhsExpr := b.mergeQualifiedNameWithExpr(qualifiedName, memberAccess.ContainerExpression)
 		return tree.CreateIndexedExpressionNode(newLhsExpr, memberAccess.OpenBracket,
 			memberAccess.KeyExpression, memberAccess.CloseBracket)
 	case common.TYPE_TEST_EXPRESSION:
@@ -14181,7 +14181,7 @@ func (this *BallerinaParser) mergeQualifiedNameWithExpr(qualifiedName tree.STNod
 		if !ok {
 			panic("expected STTypeTestExpressionNode")
 		}
-		newLhsExpr := this.mergeQualifiedNameWithExpr(qualifiedName, typeTest.Expression)
+		newLhsExpr := b.mergeQualifiedNameWithExpr(qualifiedName, typeTest.Expression)
 		return tree.CreateTypeTestExpressionNode(newLhsExpr, typeTest.IsKeyword,
 			typeTest.TypeDescriptor)
 	case common.ANNOT_ACCESS:
@@ -14189,7 +14189,7 @@ func (this *BallerinaParser) mergeQualifiedNameWithExpr(qualifiedName tree.STNod
 		if !ok {
 			panic("expected STAnnotAccessExpressionNode")
 		}
-		newLhsExpr := this.mergeQualifiedNameWithExpr(qualifiedName, annotAccess.Expression)
+		newLhsExpr := b.mergeQualifiedNameWithExpr(qualifiedName, annotAccess.Expression)
 		return tree.CreateFieldAccessExpressionNode(newLhsExpr, annotAccess.AnnotChainingToken,
 			annotAccess.AnnotTagReference)
 	case common.OPTIONAL_FIELD_ACCESS:
@@ -14197,7 +14197,7 @@ func (this *BallerinaParser) mergeQualifiedNameWithExpr(qualifiedName tree.STNod
 		if !ok {
 			panic("expected STOptionalFieldAccessExpressionNode")
 		}
-		newLhsExpr := this.mergeQualifiedNameWithExpr(qualifiedName, optionalFieldAccess.Expression)
+		newLhsExpr := b.mergeQualifiedNameWithExpr(qualifiedName, optionalFieldAccess.Expression)
 		return tree.CreateFieldAccessExpressionNode(newLhsExpr,
 			optionalFieldAccess.OptionalChainingToken, optionalFieldAccess.FieldName)
 	case common.CONDITIONAL_EXPRESSION:
@@ -14205,7 +14205,7 @@ func (this *BallerinaParser) mergeQualifiedNameWithExpr(qualifiedName tree.STNod
 		if !ok {
 			panic("expected STConditionalExpressionNode")
 		}
-		newLhsExpr := this.mergeQualifiedNameWithExpr(qualifiedName, conditionalExpr.LhsExpression)
+		newLhsExpr := b.mergeQualifiedNameWithExpr(qualifiedName, conditionalExpr.LhsExpression)
 		return tree.CreateConditionalExpressionNode(newLhsExpr, conditionalExpr.QuestionMarkToken,
 			conditionalExpr.MiddleExpression, conditionalExpr.ColonToken, conditionalExpr.EndExpression)
 	case common.REMOTE_METHOD_CALL_ACTION:
@@ -14213,7 +14213,7 @@ func (this *BallerinaParser) mergeQualifiedNameWithExpr(qualifiedName tree.STNod
 		if !ok {
 			panic("expected STRemoteMethodCallActionNode")
 		}
-		newLhsExpr := this.mergeQualifiedNameWithExpr(qualifiedName, remoteCall.Expression)
+		newLhsExpr := b.mergeQualifiedNameWithExpr(qualifiedName, remoteCall.Expression)
 		return tree.CreateRemoteMethodCallActionNode(newLhsExpr, remoteCall.RightArrowToken,
 			remoteCall.MethodName, remoteCall.OpenParenToken, remoteCall.Arguments,
 			remoteCall.CloseParenToken)
@@ -14222,7 +14222,7 @@ func (this *BallerinaParser) mergeQualifiedNameWithExpr(qualifiedName tree.STNod
 		if !ok {
 			panic("expected STAsyncSendActionNode")
 		}
-		newLhsExpr := this.mergeQualifiedNameWithExpr(qualifiedName, asyncSend.Expression)
+		newLhsExpr := b.mergeQualifiedNameWithExpr(qualifiedName, asyncSend.Expression)
 		return tree.CreateAsyncSendActionNode(newLhsExpr, asyncSend.RightArrowToken,
 			asyncSend.PeerWorker)
 	case common.SYNC_SEND_ACTION:
@@ -14230,7 +14230,7 @@ func (this *BallerinaParser) mergeQualifiedNameWithExpr(qualifiedName tree.STNod
 		if !ok {
 			panic("expected STSyncSendActionNode")
 		}
-		newLhsExpr := this.mergeQualifiedNameWithExpr(qualifiedName, syncSend.Expression)
+		newLhsExpr := b.mergeQualifiedNameWithExpr(qualifiedName, syncSend.Expression)
 		return tree.CreateAsyncSendActionNode(newLhsExpr, syncSend.SyncSendToken, syncSend.PeerWorker)
 	case common.FUNCTION_CALL:
 		funcCall, ok := exprOrAction.(*tree.STFunctionCallExpressionNode)
@@ -14244,7 +14244,7 @@ func (this *BallerinaParser) mergeQualifiedNameWithExpr(qualifiedName tree.STNod
 	}
 }
 
-func (this *BallerinaParser) mergeQualifiedNameWithTypeDesc(qualifiedName tree.STNode, typeDesc tree.STNode) tree.STNode {
+func (b *BallerinaParser) mergeQualifiedNameWithTypeDesc(qualifiedName tree.STNode, typeDesc tree.STNode) tree.STNode {
 	switch typeDesc.Kind() {
 	case common.SIMPLE_NAME_REFERENCE:
 		return qualifiedName
@@ -14253,36 +14253,36 @@ func (this *BallerinaParser) mergeQualifiedNameWithTypeDesc(qualifiedName tree.S
 		if !ok {
 			panic("expected STArrayTypeDescriptorNode")
 		}
-		newMemberType := this.mergeQualifiedNameWithTypeDesc(qualifiedName, arrayTypeDesc.MemberTypeDesc)
+		newMemberType := b.mergeQualifiedNameWithTypeDesc(qualifiedName, arrayTypeDesc.MemberTypeDesc)
 		return tree.CreateArrayTypeDescriptorNode(newMemberType, arrayTypeDesc.Dimensions)
 	case common.UNION_TYPE_DESC:
 		unionTypeDesc, ok := typeDesc.(*tree.STUnionTypeDescriptorNode)
 		if !ok {
 			panic("expected *tree.STUnionTypeDescriptorNode")
 		}
-		newlhsType := this.mergeQualifiedNameWithTypeDesc(qualifiedName, unionTypeDesc.LeftTypeDesc)
-		return this.mergeTypesWithUnion(newlhsType, unionTypeDesc.PipeToken, unionTypeDesc.RightTypeDesc)
+		newlhsType := b.mergeQualifiedNameWithTypeDesc(qualifiedName, unionTypeDesc.LeftTypeDesc)
+		return b.mergeTypesWithUnion(newlhsType, unionTypeDesc.PipeToken, unionTypeDesc.RightTypeDesc)
 	case common.INTERSECTION_TYPE_DESC:
 		intersectionTypeDesc, ok := typeDesc.(*tree.STIntersectionTypeDescriptorNode)
 		if !ok {
 			panic("expected *tree.STIntersectionTypeDescriptorNode")
 		}
-		newlhsType := this.mergeQualifiedNameWithTypeDesc(qualifiedName, intersectionTypeDesc.LeftTypeDesc)
-		return this.mergeTypesWithIntersection(newlhsType, intersectionTypeDesc.BitwiseAndToken,
+		newlhsType := b.mergeQualifiedNameWithTypeDesc(qualifiedName, intersectionTypeDesc.LeftTypeDesc)
+		return b.mergeTypesWithIntersection(newlhsType, intersectionTypeDesc.BitwiseAndToken,
 			intersectionTypeDesc.RightTypeDesc)
 	case common.OPTIONAL_TYPE_DESC:
 		optionalType, ok := typeDesc.(*tree.STOptionalTypeDescriptorNode)
 		if !ok {
 			panic("expected STOptionalTypeDescriptorNode")
 		}
-		newMemberType := this.mergeQualifiedNameWithTypeDesc(qualifiedName, optionalType.TypeDescriptor)
+		newMemberType := b.mergeQualifiedNameWithTypeDesc(qualifiedName, optionalType.TypeDescriptor)
 		return tree.CreateOptionalTypeDescriptorNode(newMemberType, optionalType.QuestionMarkToken)
 	default:
 		return typeDesc
 	}
 }
 
-func (this *BallerinaParser) getTupleMemberList(ambiguousList []tree.STNode) []tree.STNode {
+func (b *BallerinaParser) getTupleMemberList(ambiguousList []tree.STNode) []tree.STNode {
 	var tupleMemberList []tree.STNode
 	for _, item := range ambiguousList {
 		if item.Kind() == common.COMMA_TOKEN {
@@ -14290,14 +14290,14 @@ func (this *BallerinaParser) getTupleMemberList(ambiguousList []tree.STNode) []t
 		} else {
 			tupleMemberList = append(tupleMemberList,
 				tree.CreateMemberTypeDescriptorNode(tree.CreateEmptyNodeList(),
-					this.getTypeDescFromExpr(item)))
+					b.getTypeDescFromExpr(item)))
 		}
 	}
 	return tupleMemberList
 }
 
-func (this *BallerinaParser) getTypeDescFromExpr(expression tree.STNode) tree.STNode {
-	if this.isDefiniteTypeDesc(expression.Kind()) || (expression.Kind() == common.COMMA_TOKEN) {
+func (b *BallerinaParser) getTypeDescFromExpr(expression tree.STNode) tree.STNode {
+	if b.isDefiniteTypeDesc(expression.Kind()) || (expression.Kind() == common.COMMA_TOKEN) {
 		return expression
 	}
 	switch expression.Kind() {
@@ -14306,7 +14306,7 @@ func (this *BallerinaParser) getTypeDescFromExpr(expression tree.STNode) tree.ST
 		if !ok {
 			panic("getTypeDescFromExpr: expected STIndexedExpressionNode")
 		}
-		return this.parseArrayTypeDescriptorNode(*indexedExpr)
+		return b.parseArrayTypeDescriptorNode(*indexedExpr)
 	case common.NUMERIC_LITERAL,
 		common.BOOLEAN_LITERAL,
 		common.STRING_LITERAL,
@@ -14324,7 +14324,7 @@ func (this *BallerinaParser) getTypeDescFromExpr(expression tree.STNode) tree.ST
 		if !ok {
 			panic("expected STBracedExpressionNode")
 		}
-		typeDesc := this.getTypeDescFromExpr(bracedExpr.Expression)
+		typeDesc := b.getTypeDescFromExpr(bracedExpr.Expression)
 		return tree.CreateParenthesisedTypeDescriptorNode(bracedExpr.OpenParen, typeDesc,
 			bracedExpr.CloseParen)
 	case common.NIL_LITERAL:
@@ -14340,7 +14340,7 @@ func (this *BallerinaParser) getTypeDescFromExpr(expression tree.STNode) tree.ST
 		if !ok {
 			panic("expected STAmbiguousCollectionNode")
 		}
-		memberTypeDescs := tree.CreateNodeList(this.getTupleMemberList(innerList.Members)...)
+		memberTypeDescs := tree.CreateNodeList(b.getTupleMemberList(innerList.Members)...)
 		return tree.CreateTupleTypeDescriptorNode(innerList.CollectionStartToken, memberTypeDescs,
 			innerList.CollectionEndToken)
 	case common.BINARY_EXPRESSION:
@@ -14351,9 +14351,9 @@ func (this *BallerinaParser) getTypeDescFromExpr(expression tree.STNode) tree.ST
 		switch binaryExpr.Operator.Kind() {
 		case common.PIPE_TOKEN,
 			common.BITWISE_AND_TOKEN:
-			lhsTypeDesc := this.getTypeDescFromExpr(binaryExpr.LhsExpr)
-			rhsTypeDesc := this.getTypeDescFromExpr(binaryExpr.RhsExpr)
-			return this.mergeTypes(lhsTypeDesc, binaryExpr.Operator, rhsTypeDesc)
+			lhsTypeDesc := b.getTypeDescFromExpr(binaryExpr.LhsExpr)
+			rhsTypeDesc := b.getTypeDescFromExpr(binaryExpr.RhsExpr)
+			return b.mergeTypes(lhsTypeDesc, binaryExpr.Operator, rhsTypeDesc)
 		default:
 			break
 		}
@@ -14371,17 +14371,17 @@ func (this *BallerinaParser) getTypeDescFromExpr(expression tree.STNode) tree.ST
 	}
 }
 
-func (this *BallerinaParser) getBindingPatternsList(ambibuousList []tree.STNode, isListBP bool) []tree.STNode {
+func (b *BallerinaParser) getBindingPatternsList(ambibuousList []tree.STNode, isListBP bool) []tree.STNode {
 	var bindingPatterns []tree.STNode
 	for _, item := range ambibuousList {
-		bindingPatterns = append(bindingPatterns, this.getBindingPattern(item, isListBP))
+		bindingPatterns = append(bindingPatterns, b.getBindingPattern(item, isListBP))
 	}
 	return bindingPatterns
 }
 
-func (this *BallerinaParser) getBindingPattern(ambiguousNode tree.STNode, isListBP bool) tree.STNode {
+func (b *BallerinaParser) getBindingPattern(ambiguousNode tree.STNode, isListBP bool) tree.STNode {
 	errorCode := common.ERROR_INVALID_BINDING_PATTERN
-	if this.isEmpty(ambiguousNode) {
+	if b.isEmpty(ambiguousNode) {
 		return nil
 	}
 	switch ambiguousNode.Kind() {
@@ -14401,7 +14401,7 @@ func (this *BallerinaParser) getBindingPattern(ambiguousNode tree.STNode, isList
 			panic("getBindingPattern: expected STSimpleNameReferenceNode")
 		}
 		varName := simpleNameNode.Name
-		return this.createCaptureOrWildcardBP(varName)
+		return b.createCaptureOrWildcardBP(varName)
 	case common.QUALIFIED_NAME_REFERENCE:
 		if isListBP {
 			errorCode = common.ERROR_FIELD_BP_INSIDE_LIST_BP
@@ -14413,14 +14413,14 @@ func (this *BallerinaParser) getBindingPattern(ambiguousNode tree.STNode, isList
 		}
 		fieldName := tree.CreateSimpleNameReferenceNode(qualifiedName.ModulePrefix)
 		return tree.CreateFieldBindingPatternFullNode(fieldName, qualifiedName.Colon,
-			this.createCaptureOrWildcardBP(qualifiedName.Identifier))
+			b.createCaptureOrWildcardBP(qualifiedName.Identifier))
 	case common.BRACKETED_LIST,
 		common.LIST_BP_OR_LIST_CONSTRUCTOR:
 		innerList, ok := ambiguousNode.(*tree.STAmbiguousCollectionNode)
 		if !ok {
 			panic("expected STAmbiguousCollectionNode")
 		}
-		memberBindingPatterns := tree.CreateNodeList(this.getBindingPatternsList(innerList.Members, true)...)
+		memberBindingPatterns := tree.CreateNodeList(b.getBindingPatternsList(innerList.Members, true)...)
 		return tree.CreateListBindingPatternNode(innerList.CollectionStartToken, memberBindingPatterns,
 			innerList.CollectionEndToken)
 	case common.MAPPING_BP_OR_MAPPING_CONSTRUCTOR:
@@ -14431,7 +14431,7 @@ func (this *BallerinaParser) getBindingPattern(ambiguousNode tree.STNode, isList
 		var bindingPatterns []tree.STNode
 		i := 0
 		for ; i < len(innerList.Members); i++ {
-			bp := this.getBindingPattern(innerList.Members[i], false)
+			bp := b.getBindingPattern(innerList.Members[i], false)
 			bindingPatterns = append(bindingPatterns, bp)
 			if bp.Kind() == common.REST_BINDING_PATTERN {
 				break
@@ -14450,7 +14450,7 @@ func (this *BallerinaParser) getBindingPattern(ambiguousNode tree.STNode, isList
 			return tree.CreateFieldBindingPatternVarnameNode(fieldName)
 		}
 		return tree.CreateFieldBindingPatternFullNode(fieldName, field.Colon,
-			this.getBindingPattern(field.ValueExpr, false))
+			b.getBindingPattern(field.ValueExpr, false))
 	case common.ERROR_CONSTRUCTOR:
 		errorCons, ok := ambiguousNode.(*tree.STErrorConstructorExpressionNode)
 		if !ok {
@@ -14462,7 +14462,7 @@ func (this *BallerinaParser) getBindingPattern(ambiguousNode tree.STNode, isList
 		i := 0
 		for ; i < size; i++ {
 			arg := args.ChildInBucket(i)
-			bindingPatterns = append(bindingPatterns, this.getBindingPattern(arg, false))
+			bindingPatterns = append(bindingPatterns, b.getBindingPattern(arg, false))
 		}
 		argListBindingPatterns := tree.CreateNodeList(bindingPatterns...)
 		return tree.CreateErrorBindingPatternNode(errorCons.ErrorKeyword, errorCons.TypeReference,
@@ -14472,7 +14472,7 @@ func (this *BallerinaParser) getBindingPattern(ambiguousNode tree.STNode, isList
 		if !ok {
 			panic("expected STPositionalArgumentNode")
 		}
-		return this.getBindingPattern(positionalArg.Expression, false)
+		return b.getBindingPattern(positionalArg.Expression, false)
 	case common.NAMED_ARG:
 		namedArg, nameOk := ambiguousNode.(*tree.STNamedArgumentNode)
 		if !nameOk {
@@ -14484,7 +14484,7 @@ func (this *BallerinaParser) getBindingPattern(ambiguousNode tree.STNode, isList
 		}
 		bindingPatternArgName := argNameNode.Name
 		return tree.CreateNamedArgBindingPatternNode(bindingPatternArgName, namedArg.EqualsToken,
-			this.getBindingPattern(namedArg.Expression, false))
+			b.getBindingPattern(namedArg.Expression, false))
 	case common.REST_ARG:
 		restArg, ok := ambiguousNode.(*tree.STRestArgumentNode)
 		if !ok {
@@ -14498,20 +14498,20 @@ func (this *BallerinaParser) getBindingPattern(ambiguousNode tree.STNode, isList
 	return tree.CreateCaptureBindingPatternNode(identifier)
 }
 
-func (this *BallerinaParser) getExpressionList(ambibuousList []tree.STNode, isMappingConstructor bool) []tree.STNode {
+func (b *BallerinaParser) getExpressionList(ambibuousList []tree.STNode, isMappingConstructor bool) []tree.STNode {
 	var exprList []tree.STNode
 	for _, item := range ambibuousList {
-		exprList = append(exprList, this.getExpressionInner(item, isMappingConstructor))
+		exprList = append(exprList, b.getExpressionInner(item, isMappingConstructor))
 	}
 	return exprList
 }
 
-func (this *BallerinaParser) getExpression(ambiguousNode tree.STNode) tree.STNode {
-	return this.getExpressionInner(ambiguousNode, false)
+func (b *BallerinaParser) getExpression(ambiguousNode tree.STNode) tree.STNode {
+	return b.getExpressionInner(ambiguousNode, false)
 }
 
-func (this *BallerinaParser) getExpressionInner(ambiguousNode tree.STNode, isInMappingConstructor bool) tree.STNode {
-	if ((this.isEmpty(ambiguousNode) || (this.isDefiniteExpr(ambiguousNode.Kind()) && (ambiguousNode.Kind() != common.INDEXED_EXPRESSION))) || this.isDefiniteAction(ambiguousNode.Kind())) || (ambiguousNode.Kind() == common.COMMA_TOKEN) {
+func (b *BallerinaParser) getExpressionInner(ambiguousNode tree.STNode, isInMappingConstructor bool) tree.STNode {
+	if ((b.isEmpty(ambiguousNode) || (b.isDefiniteExpr(ambiguousNode.Kind()) && (ambiguousNode.Kind() != common.INDEXED_EXPRESSION))) || b.isDefiniteAction(ambiguousNode.Kind())) || (ambiguousNode.Kind() == common.COMMA_TOKEN) {
 		return ambiguousNode
 	}
 	switch ambiguousNode.Kind() {
@@ -14520,7 +14520,7 @@ func (this *BallerinaParser) getExpressionInner(ambiguousNode tree.STNode, isInM
 		if !ok {
 			panic("getExpressionInner: expected STAmbiguousCollectionNode")
 		}
-		memberExprs := tree.CreateNodeList(this.getExpressionList(innerList.Members, false)...)
+		memberExprs := tree.CreateNodeList(b.getExpressionList(innerList.Members, false)...)
 		return tree.CreateListConstructorExpressionNode(innerList.CollectionStartToken, memberExprs,
 			innerList.CollectionEndToken)
 
@@ -14542,10 +14542,10 @@ func (this *BallerinaParser) getExpressionInner(ambiguousNode tree.STNode, isInM
 				readOnlyKeyword := tree.CreateEmptyNode()
 				fieldName := qualifiedNameRefNode.ModulePrefix
 				colon := qualifiedNameRefNode.Colon
-				valueExpr := this.getExpression(qualifiedNameRefNode.Identifier)
+				valueExpr := b.getExpression(qualifiedNameRefNode.Identifier)
 				fieldNode = tree.CreateSpecificFieldNode(readOnlyKeyword, fieldName, colon, valueExpr)
 			} else {
-				fieldNode = this.getExpressionInner(field, true)
+				fieldNode = b.getExpressionInner(field, true)
 			}
 			fieldList = append(fieldList, fieldNode)
 		}
@@ -14575,14 +14575,14 @@ func (this *BallerinaParser) getExpressionInner(ambiguousNode tree.STNode, isInM
 		}
 		return tree.CreateSpecificFieldNode(field.ReadonlyKeyword, field.FieldName, field.Colon,
 
-			this.getExpression(field.ValueExpr))
+			b.getExpression(field.ValueExpr))
 
 	case common.ERROR_CONSTRUCTOR:
 		errorCons, ok := ambiguousNode.(*tree.STErrorConstructorExpressionNode)
 		if !ok {
 			panic("getExpressionInner: expected STErrorConstructorExpressionNode")
 		}
-		errorArgs := this.getErrorArgList(errorCons.Arguments)
+		errorArgs := b.getErrorArgList(errorCons.Arguments)
 		return tree.CreateErrorConstructorExpressionNode(errorCons.ErrorKeyword,
 			errorCons.TypeReference, errorCons.OpenParenToken, errorArgs, errorCons.CloseParenToken)
 
@@ -14619,7 +14619,7 @@ func (this *BallerinaParser) getExpressionInner(ambiguousNode tree.STNode, isInM
 	}
 }
 
-func (this *BallerinaParser) getMappingField(identifier tree.STNode, colon tree.STNode, bindingPatternOrExpr tree.STNode) tree.STNode {
+func (b *BallerinaParser) getMappingField(identifier tree.STNode, colon tree.STNode, bindingPatternOrExpr tree.STNode) tree.STNode {
 	simpleNameRef := tree.CreateSimpleNameReferenceNode(identifier)
 	switch bindingPatternOrExpr.Kind() {
 	case common.LIST_BINDING_PATTERN,
@@ -14634,22 +14634,22 @@ func (this *BallerinaParser) getMappingField(identifier tree.STNode, colon tree.
 	}
 }
 
-func (this *BallerinaParser) recoverWithBlockContext(nextToken tree.STToken, currentCtx common.ParserRuleContext) *Solution {
-	if this.isInsideABlock(nextToken) {
-		return this.recover(nextToken, currentCtx, true)
+func (b *BallerinaParser) recoverWithBlockContext(nextToken tree.STToken, currentCtx common.ParserRuleContext) *Solution {
+	if b.isInsideABlock(nextToken) {
+		return b.recover(nextToken, currentCtx, true)
 	} else {
-		return this.recover(nextToken, currentCtx, false)
+		return b.recover(nextToken, currentCtx, false)
 	}
 }
 
-func (this *BallerinaParser) isInsideABlock(nextToken tree.STToken) bool {
+func (b *BallerinaParser) isInsideABlock(nextToken tree.STToken) bool {
 	if nextToken.Kind() != common.CLOSE_BRACE_TOKEN {
 		return false
 	}
-	return slices.ContainsFunc(this.errorHandler.GetContextStack(), this.isBlockContext)
+	return slices.ContainsFunc(b.errorHandler.GetContextStack(), b.isBlockContext)
 }
 
-func (this *BallerinaParser) isBlockContext(ctx common.ParserRuleContext) bool {
+func (b *BallerinaParser) isBlockContext(ctx common.ParserRuleContext) bool {
 	switch ctx {
 	case common.PARSER_RULE_CONTEXT_FUNC_BODY_BLOCK,
 		common.PARSER_RULE_CONTEXT_CLASS_MEMBER,
@@ -14670,7 +14670,7 @@ func (this *BallerinaParser) isBlockContext(ctx common.ParserRuleContext) bool {
 	}
 }
 
-func (this *BallerinaParser) isSpecialMethodName(token tree.STToken) bool {
+func (b *BallerinaParser) isSpecialMethodName(token tree.STToken) bool {
 	return (((token.Kind() == common.MAP_KEYWORD) || (token.Kind() == common.START_KEYWORD)) || (token.Kind() == common.JOIN_KEYWORD))
 }
 

--- a/parser/tree/syntax_tree.go
+++ b/parser/tree/syntax_tree.go
@@ -38,43 +38,43 @@ func NewSyntaxTreeFromNodeTextDocument(rootNode Node, textDocument text.TextDocu
 	return this
 }
 
-func (this *SyntaxTree) TextDocument() text.TextDocument {
-	return this.textDocument
+func (s *SyntaxTree) TextDocument() text.TextDocument {
+	return s.textDocument
 }
 
-func (this *SyntaxTree) ContainsModulePart() bool {
+func (s *SyntaxTree) ContainsModulePart() bool {
 	// migrated from SyntaxTree.java:76:5
-	return this.RootNode.Kind() == common.MODULE_PART
+	return s.RootNode.Kind() == common.MODULE_PART
 }
 
-func (this *SyntaxTree) FilePath() string {
+func (s *SyntaxTree) FilePath() string {
 	// migrated from SyntaxTree.java:85:5
-	return this.filePath
+	return s.filePath
 }
 
-func (this *SyntaxTree) ModifyWith(rootNode Node) SyntaxTree {
+func (s *SyntaxTree) ModifyWith(rootNode Node) SyntaxTree {
 	// migrated from SyntaxTree.java:91:5
 	panic("not implemented")
 }
 
-func (this *SyntaxTree) ReplaceNode(target Node, replacement Node) SyntaxTree {
+func (s *SyntaxTree) ReplaceNode(target Node, replacement Node) SyntaxTree {
 	// migrated from SyntaxTree.java:95:5
 	panic("not implemented")
 }
 
-func (this *SyntaxTree) Diagnostics() iter.Seq[Diagnostic] {
+func (s *SyntaxTree) Diagnostics() iter.Seq[Diagnostic] {
 	// migrated from SyntaxTree.java:105:5
-	return this.RootNode.Diagnostics()
+	return s.RootNode.Diagnostics()
 }
 
-func (this *SyntaxTree) HasDiagnostics() bool {
+func (s *SyntaxTree) HasDiagnostics() bool {
 	// migrated from SyntaxTree.java:109:5
-	return this.RootNode.HasDiagnostics()
+	return s.RootNode.HasDiagnostics()
 }
 
-func (this *SyntaxTree) ToSourceCode() string {
+func (s *SyntaxTree) ToSourceCode() string {
 	// migrated from SyntaxTree.java:123:5
-	return this.RootNode.ToSourceCode()
+	return s.RootNode.ToSourceCode()
 }
 
 func modifyWithSyntaxTree[T Node](node T, clone bool, syntaxTree *SyntaxTree) T {

--- a/semtypes/all_or_nothing_subtype.go
+++ b/semtypes/all_or_nothing_subtype.go
@@ -41,24 +41,24 @@ func createNothing() allOrNothingSubtype {
 	return allOrNothingSubtypeNothing
 }
 
-func (this *allOrNothingSubtype) IsAllSubtype() bool {
-	return this.isAll
+func (a *allOrNothingSubtype) IsAllSubtype() bool {
+	return a.isAll
 }
 
-func (this *allOrNothingSubtype) IsNothingSubtype() bool {
-	return (!this.isAll)
+func (a *allOrNothingSubtype) IsNothingSubtype() bool {
+	return (!a.isAll)
 }
 
-func (this *allOrNothingSubtype) canonicalKey() string {
-	if this.isAll {
+func (a *allOrNothingSubtype) canonicalKey() string {
+	if a.isAll {
 		return "true"
 	} else {
 		return "false"
 	}
 }
 
-func (this *allOrNothingSubtype) String() string {
-	if this.isAll {
+func (a *allOrNothingSubtype) String() string {
+	if a.isAll {
 		return "all"
 	} else {
 		return "nothing"

--- a/semtypes/basic_type_ops_panic_impl.go
+++ b/semtypes/basic_type_ops_panic_impl.go
@@ -26,22 +26,22 @@ func newBasicTypeOpsPanicImpl() basicTypeOpsPanicImpl {
 	return this
 }
 
-func (this *basicTypeOpsPanicImpl) Union(t1 SubtypeData, t2 SubtypeData) SubtypeData {
+func (b *basicTypeOpsPanicImpl) Union(t1 SubtypeData, t2 SubtypeData) SubtypeData {
 	panic("Binary operation should not be called")
 }
 
-func (this *basicTypeOpsPanicImpl) Intersect(t1 SubtypeData, t2 SubtypeData) SubtypeData {
+func (b *basicTypeOpsPanicImpl) Intersect(t1 SubtypeData, t2 SubtypeData) SubtypeData {
 	panic("Binary operation should not be called")
 }
 
-func (this *basicTypeOpsPanicImpl) Diff(t1 SubtypeData, t2 SubtypeData) SubtypeData {
+func (b *basicTypeOpsPanicImpl) Diff(t1 SubtypeData, t2 SubtypeData) SubtypeData {
 	panic("Binary operation should not be called")
 }
 
-func (this *basicTypeOpsPanicImpl) complement(t SubtypeData) SubtypeData {
+func (b *basicTypeOpsPanicImpl) complement(t SubtypeData) SubtypeData {
 	panic("Unary operation should not be called")
 }
 
-func (this *basicTypeOpsPanicImpl) IsEmpty(cx Context, t SubtypeData) bool {
+func (b *basicTypeOpsPanicImpl) IsEmpty(cx Context, t SubtypeData) bool {
 	panic("Unary boolean operation should not be called")
 }

--- a/semtypes/bdd_all_or_nothing.go
+++ b/semtypes/bdd_all_or_nothing.go
@@ -40,31 +40,31 @@ func bddNothing() *bddAllOrNothing {
 	return &nothing
 }
 
-func (this *bddAllOrNothing) IsAll() bool {
-	return this.isAll
+func (b *bddAllOrNothing) IsAll() bool {
+	return b.isAll
 }
 
-func (this *bddAllOrNothing) IsNothing() bool {
-	return (!this.isAll)
+func (b *bddAllOrNothing) IsNothing() bool {
+	return (!b.isAll)
 }
 
-func (this *bddAllOrNothing) complement() *bddAllOrNothing {
-	if this.isAll {
+func (b *bddAllOrNothing) complement() *bddAllOrNothing {
+	if b.isAll {
 		return &nothing
 	}
 	return &all
 }
 
-func (this *bddAllOrNothing) canonicalKey() string {
-	if this.isAll {
+func (b *bddAllOrNothing) canonicalKey() string {
+	if b.isAll {
 		return "true"
 	} else {
 		return "false"
 	}
 }
 
-func (this *bddAllOrNothing) String() string {
-	if this.isAll {
+func (b *bddAllOrNothing) String() string {
+	if b.isAll {
 		return "all"
 	} else {
 		return "nothing"

--- a/semtypes/bdd_common_ops.go
+++ b/semtypes/bdd_common_ops.go
@@ -226,7 +226,7 @@ func atomCmp(a1 atom, a2 atom) int {
 	return a1.index() - a2.index()
 }
 
-func (this *bddCommonOpsMethods) BddToString(b Bdd, inner bool) string {
+func (c *bddCommonOpsMethods) BddToString(b Bdd, inner bool) string {
 	if allOrNothing, ok := b.(*bddAllOrNothing); ok {
 		if allOrNothing.IsAll() {
 			return "1"
@@ -242,7 +242,7 @@ func (this *bddCommonOpsMethods) BddToString(b Bdd, inner bool) string {
 	} else {
 		str = "a" + string(rune(a.index()))
 	}
-	str = str + "?" + this.BddToString(bdd.left(), true) + ":" + this.BddToString(bdd.middle(), true) + ":" + this.BddToString(bdd.right(), true)
+	str = str + "?" + c.BddToString(bdd.left(), true) + ":" + c.BddToString(bdd.middle(), true) + ":" + c.BddToString(bdd.right(), true)
 	if inner {
 		str = "(" + str + ")"
 	}

--- a/semtypes/bdd_memo.go
+++ b/semtypes/bdd_memo.go
@@ -37,14 +37,14 @@ func newBddMemo() bddMemo {
 	return this
 }
 
-func (this *bddMemo) SetIsEmpty(isEmpty bool) {
+func (b *bddMemo) SetIsEmpty(isEmpty bool) {
 	if isEmpty {
-		this.isEmpty = MemoStatus_TRUE
+		b.isEmpty = MemoStatus_TRUE
 	} else {
-		this.isEmpty = MemoStatus_FALSE
+		b.isEmpty = MemoStatus_FALSE
 	}
 }
 
-func (this *bddMemo) IsEmpty() bool {
-	return (this.isEmpty == MemoStatus_TRUE)
+func (b *bddMemo) IsEmpty() bool {
+	return (b.isEmpty == MemoStatus_TRUE)
 }

--- a/semtypes/bdd_node_impl.go
+++ b/semtypes/bdd_node_impl.go
@@ -28,20 +28,20 @@ type bddNodeImpl struct {
 
 var _ bddNode = &bddNodeImpl{}
 
-func (this *bddNodeImpl) atom() atom {
-	return this._atom
+func (b *bddNodeImpl) atom() atom {
+	return b._atom
 }
 
-func (this *bddNodeImpl) left() Bdd {
-	return this._left
+func (b *bddNodeImpl) left() Bdd {
+	return b._left
 }
 
-func (this *bddNodeImpl) middle() Bdd {
-	return this._middle
+func (b *bddNodeImpl) middle() Bdd {
+	return b._middle
 }
 
-func (this *bddNodeImpl) right() Bdd {
-	return this._right
+func (b *bddNodeImpl) right() Bdd {
+	return b._right
 }
 
 func newBddNodeImpl(atom atom, left, middle, right Bdd) *bddNodeImpl {
@@ -54,6 +54,6 @@ func newBddNodeImpl(atom atom, left, middle, right Bdd) *bddNodeImpl {
 	}
 }
 
-func (this *bddNodeImpl) canonicalKey() string {
-	return this.canonical
+func (b *bddNodeImpl) canonicalKey() string {
+	return b.canonical
 }

--- a/semtypes/bdd_node_simple.go
+++ b/semtypes/bdd_node_simple.go
@@ -25,20 +25,20 @@ type bddNodeSimple struct {
 
 var _ bddNode = &bddNodeSimple{}
 
-func (this *bddNodeSimple) left() Bdd {
+func (b *bddNodeSimple) left() Bdd {
 	return bddAll()
 }
 
-func (this *bddNodeSimple) middle() Bdd {
+func (b *bddNodeSimple) middle() Bdd {
 	return bddNothing()
 }
 
-func (this *bddNodeSimple) right() Bdd {
+func (b *bddNodeSimple) right() Bdd {
 	return bddNothing()
 }
 
-func (this *bddNodeSimple) atom() atom {
-	return this._atom
+func (b *bddNodeSimple) atom() atom {
+	return b._atom
 }
 
 func newBddNodeSimple(atom atom) *bddNodeSimple {
@@ -48,6 +48,6 @@ func newBddNodeSimple(atom atom) *bddNodeSimple {
 	}
 }
 
-func (this *bddNodeSimple) canonicalKey() string {
-	return this.canonical
+func (b *bddNodeSimple) canonicalKey() string {
+	return b.canonical
 }

--- a/semtypes/boolean_ops.go
+++ b/semtypes/boolean_ops.go
@@ -20,7 +20,7 @@ type booleanOps struct{}
 
 var _ BasicTypeOps = &booleanOps{}
 
-func (this *booleanOps) Union(d1 SubtypeData, d2 SubtypeData) SubtypeData {
+func (b *booleanOps) Union(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	v1 := d1.(booleanSubtype)
 	v2 := d2.(booleanSubtype)
 	if v1.Value == v2.Value {
@@ -30,7 +30,7 @@ func (this *booleanOps) Union(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	}
 }
 
-func (this *booleanOps) Intersect(d1 SubtypeData, d2 SubtypeData) SubtypeData {
+func (b *booleanOps) Intersect(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	v1 := d1.(booleanSubtype)
 	v2 := d2.(booleanSubtype)
 	if v1.Value == v2.Value {
@@ -40,7 +40,7 @@ func (this *booleanOps) Intersect(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	}
 }
 
-func (this *booleanOps) Diff(d1 SubtypeData, d2 SubtypeData) SubtypeData {
+func (b *booleanOps) Diff(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	v1 := d1.(booleanSubtype)
 	v2 := d2.(booleanSubtype)
 	if v1.Value == v2.Value {
@@ -50,12 +50,12 @@ func (this *booleanOps) Diff(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	}
 }
 
-func (this *booleanOps) complement(d SubtypeData) SubtypeData {
+func (b *booleanOps) complement(d SubtypeData) SubtypeData {
 	v := d.(booleanSubtype)
 	t := booleanSubtypeFrom(!v.Value)
 	return t
 }
 
-func (this *booleanOps) IsEmpty(cx Context, t SubtypeData) bool {
+func (b *booleanOps) IsEmpty(cx Context, t SubtypeData) bool {
 	return notIsEmpty(cx, t)
 }

--- a/semtypes/cell_atomic_type.go
+++ b/semtypes/cell_atomic_type.go
@@ -33,9 +33,9 @@ const (
 	CellMutability_CELL_MUT_UNLIMITED
 )
 
-func (this *cellAtomicType) equals(other atomicType) bool {
+func (c *cellAtomicType) equals(other atomicType) bool {
 	if other, ok := other.(*cellAtomicType); ok {
-		return other.Ty == this.Ty && other.Mut == this.Mut
+		return other.Ty == c.Ty && other.Mut == c.Mut
 	}
 	return false
 }
@@ -55,6 +55,6 @@ func cellAtomicTypeFrom(ty SemType, mut CellMutability) cellAtomicType {
 	return newCellAtomicTypeFromTyMut(ty, mut)
 }
 
-func (this *cellAtomicType) atomKind() kind {
+func (c *cellAtomicType) atomKind() kind {
 	return kind_CELL_ATOM
 }

--- a/semtypes/cell_ops.go
+++ b/semtypes/cell_ops.go
@@ -151,23 +151,23 @@ func newCellOps() cellOps {
 	return this
 }
 
-func (this *cellOps) Union(t1 SubtypeData, t2 SubtypeData) SubtypeData {
+func (c *cellOps) Union(t1 SubtypeData, t2 SubtypeData) SubtypeData {
 	return cellSubtypeUnion(t1, t2)
 }
 
-func (this *cellOps) Intersect(t1 SubtypeData, t2 SubtypeData) SubtypeData {
+func (c *cellOps) Intersect(t1 SubtypeData, t2 SubtypeData) SubtypeData {
 	return cellSubtypeIntersect(t1, t2)
 }
 
-func (this *cellOps) Diff(t1 SubtypeData, t2 SubtypeData) SubtypeData {
+func (c *cellOps) Diff(t1 SubtypeData, t2 SubtypeData) SubtypeData {
 	return cellSubtypeDiff(t1, t2)
 }
 
-func (this *cellOps) complement(t SubtypeData) SubtypeData {
+func (c *cellOps) complement(t SubtypeData) SubtypeData {
 	return cellSubtypeComplement(t)
 }
 
-func (this *cellOps) IsEmpty(cx Context, t SubtypeData) bool {
+func (c *cellOps) IsEmpty(cx Context, t SubtypeData) bool {
 	return cellFormulaIsEmpty(cx, t)
 }
 

--- a/semtypes/char_string_subtype.go
+++ b/semtypes/char_string_subtype.go
@@ -30,10 +30,10 @@ func charStringSubtypeFrom(allowed bool, values []enumerableType[string]) charSt
 	}
 }
 
-func (this *charStringSubtype) Allowed() bool {
-	return this.allowed
+func (c *charStringSubtype) Allowed() bool {
+	return c.allowed
 }
 
-func (this *charStringSubtype) Values() []enumerableType[string] {
-	return this.values
+func (c *charStringSubtype) Values() []enumerableType[string] {
+	return c.values
 }

--- a/semtypes/complex_sem_type_impl.go
+++ b/semtypes/complex_sem_type_impl.go
@@ -26,19 +26,19 @@ type ComplexSemType struct {
 
 var _ SemType = &ComplexSemType{}
 
-func (this *ComplexSemType) all() BasicTypeBitSet {
-	return this.allBitSet
+func (c *ComplexSemType) all() BasicTypeBitSet {
+	return c.allBitSet
 }
 
-func (this *ComplexSemType) some() BasicTypeBitSet {
-	return this.someBitSet
+func (c *ComplexSemType) some() BasicTypeBitSet {
+	return c.someBitSet
 }
 
-func (this *ComplexSemType) subtypeDataList() []ProperSubtypeData {
-	return this.dataList
+func (c *ComplexSemType) subtypeDataList() []ProperSubtypeData {
+	return c.dataList
 }
 
-func (this *ComplexSemType) equals(other *ComplexSemType) bool {
-	return this == other || (this.allBitSet == other.allBitSet && this.someBitSet == other.someBitSet &&
-		slices.Equal(this.dataList, other.dataList))
+func (c *ComplexSemType) equals(other *ComplexSemType) bool {
+	return c == other || (c.allBitSet == other.allBitSet && c.someBitSet == other.someBitSet &&
+		slices.Equal(c.dataList, other.dataList))
 }

--- a/semtypes/context.go
+++ b/semtypes/context.go
@@ -50,113 +50,113 @@ type comparableMemoKey struct {
 	semType2 SemType
 }
 
-func (this *context) pushToMemoStack(m *bddMemo) {
-	this._memoStack = append(this._memoStack, m)
+func (c *context) pushToMemoStack(m *bddMemo) {
+	c._memoStack = append(c._memoStack, m)
 }
 
-func (this *context) getMemoStackDepth() int {
-	return len(this._memoStack)
+func (c *context) getMemoStackDepth() int {
+	return len(c._memoStack)
 }
 
-func (this *context) getMemoStack(i int) *bddMemo {
-	return this._memoStack[i]
+func (c *context) getMemoStack(i int) *bddMemo {
+	return c._memoStack[i]
 }
 
-func (this *context) popFromMemoStack() *bddMemo {
-	lastIndex := len(this._memoStack) - 1
-	memo := this._memoStack[lastIndex]
-	this._memoStack = this._memoStack[:lastIndex]
+func (c *context) popFromMemoStack() *bddMemo {
+	lastIndex := len(c._memoStack) - 1
+	memo := c._memoStack[lastIndex]
+	c._memoStack = c._memoStack[:lastIndex]
 	return memo
 }
 
-func (this *context) Env() Env {
-	return this._env
+func (c *context) Env() Env {
+	return c._env
 }
 
-func (this *context) jsonMemo() SemType {
-	return this._jsonMemo
+func (c *context) jsonMemo() SemType {
+	return c._jsonMemo
 }
 
-func (this *context) setJsonMemo(t SemType) {
-	this._jsonMemo = t
+func (c *context) setJsonMemo(t SemType) {
+	c._jsonMemo = t
 }
 
-func (this *context) anydataMemo() SemType {
-	return this._anydataMemo
+func (c *context) anydataMemo() SemType {
+	return c._anydataMemo
 }
 
-func (this *context) setAnydataMemo(t SemType) {
-	this._anydataMemo = t
+func (c *context) setAnydataMemo(t SemType) {
+	c._anydataMemo = t
 }
 
-func (this *context) cloneableMemo() SemType {
-	return this._cloneableMemo
+func (c *context) cloneableMemo() SemType {
+	return c._cloneableMemo
 }
 
-func (this *context) setCloneableMemo(t SemType) {
-	this._cloneableMemo = t
+func (c *context) setCloneableMemo(t SemType) {
+	c._cloneableMemo = t
 }
 
-func (this *context) isolatedObjectMemo() SemType {
-	return this._isolatedObjectMemo
+func (c *context) isolatedObjectMemo() SemType {
+	return c._isolatedObjectMemo
 }
 
-func (this *context) setIsolatedObjectMemo(t SemType) {
-	this._isolatedObjectMemo = t
+func (c *context) setIsolatedObjectMemo(t SemType) {
+	c._isolatedObjectMemo = t
 }
 
-func (this *context) serviceObjectMemo() SemType {
-	return this._serviceObjectMemo
+func (c *context) serviceObjectMemo() SemType {
+	return c._serviceObjectMemo
 }
 
-func (this *context) setServiceObjectMemo(t SemType) {
-	this._serviceObjectMemo = t
+func (c *context) setServiceObjectMemo(t SemType) {
+	c._serviceObjectMemo = t
 }
 
-func (this *context) mappingMemo() map[string]*bddMemo {
-	return this._mappingMemo
+func (c *context) mappingMemo() map[string]*bddMemo {
+	return c._mappingMemo
 }
 
-func (this *context) functionMemo() map[string]*bddMemo {
-	return this._functionMemo
+func (c *context) functionMemo() map[string]*bddMemo {
+	return c._functionMemo
 }
 
-func (this *context) listMemo() map[string]*bddMemo {
-	return this._listMemo
+func (c *context) listMemo() map[string]*bddMemo {
+	return c._listMemo
 }
 
-func (this *context) FunctionAtomType(atom atom) *functionAtomicType {
-	return this._env.functionAtomType(atom)
+func (c *context) FunctionAtomType(atom atom) *functionAtomicType {
+	return c._env.functionAtomType(atom)
 }
 
-func (this *context) ListAtomType(atom atom) *ListAtomicType {
-	return this._env.listAtomType(atom)
+func (c *context) ListAtomType(atom atom) *ListAtomicType {
+	return c._env.listAtomType(atom)
 }
 
-func (this *context) MappingAtomType(atom atom) *MappingAtomicType {
-	return this._env.mappingAtomType(atom)
+func (c *context) MappingAtomType(atom atom) *MappingAtomicType {
+	return c._env.mappingAtomType(atom)
 }
 
-func (this *context) pushConjunction(atom atom, next conjunctionHandle) conjunctionHandle {
-	idx := conjunctionHandle(len(this._conjunctions) + 1)
-	this._conjunctions = append(this._conjunctions, conjunction{atom: atom, Next: next})
+func (c *context) pushConjunction(atom atom, next conjunctionHandle) conjunctionHandle {
+	idx := conjunctionHandle(len(c._conjunctions) + 1)
+	c._conjunctions = append(c._conjunctions, conjunction{atom: atom, Next: next})
 	return idx
 }
 
-func (this *context) conjunctionAtom(h conjunctionHandle) atom {
-	return this._conjunctions[h-1].atom
+func (c *context) conjunctionAtom(h conjunctionHandle) atom {
+	return c._conjunctions[h-1].atom
 }
 
-func (this *context) conjunctionNext(h conjunctionHandle) conjunctionHandle {
-	return this._conjunctions[h-1].Next
+func (c *context) conjunctionNext(h conjunctionHandle) conjunctionHandle {
+	return c._conjunctions[h-1].Next
 }
 
-func (this *context) conjunctionStackDepth() int32 {
-	return int32(len(this._conjunctions))
+func (c *context) conjunctionStackDepth() int32 {
+	return int32(len(c._conjunctions))
 }
 
-func (this *context) resetConjunctionStack(depth int32) {
-	this._conjunctions = this._conjunctions[:depth]
+func (c *context) resetConjunctionStack(depth int32) {
+	c._conjunctions = c._conjunctions[:depth]
 }
 
 func ContextFrom(env Env) Context {
@@ -170,10 +170,10 @@ func ContextFrom(env Env) Context {
 	}
 }
 
-func (this *context) comparableMemo(t1, t2 SemType) *comparableMemo {
-	return this._comparableMemo[comparableMemoKey{semType1: t1, semType2: t2}]
+func (c *context) comparableMemo(t1, t2 SemType) *comparableMemo {
+	return c._comparableMemo[comparableMemoKey{semType1: t1, semType2: t2}]
 }
 
-func (this *context) setComparableMemo(t1, t2 SemType, memo *comparableMemo) {
-	this._comparableMemo[comparableMemoKey{semType1: t1, semType2: t2}] = memo
+func (c *context) setComparableMemo(t1, t2 SemType, memo *comparableMemo) {
+	c._comparableMemo[comparableMemoKey{semType1: t1, semType2: t2}] = memo
 }

--- a/semtypes/core.go
+++ b/semtypes/core.go
@@ -810,7 +810,7 @@ func containsConstFloat(t SemType, n float64) bool {
 		return (b.all() & (1 << BTFloat.Code())) != 0
 	} else {
 		return floatSubtypeContains(
-			getComplexSubtypeData(t.(*ComplexSemType), BTFloat), enumerableFloatFrom(n))
+			getComplexSubtypeData(t.(*ComplexSemType), BTFloat), newEnumerableFloatFromFloat64(n))
 	}
 }
 

--- a/semtypes/decimal_ops.go
+++ b/semtypes/decimal_ops.go
@@ -31,7 +31,7 @@ func newDecimalOps() decimalOps {
 	return this
 }
 
-func (this *decimalOps) Union(t1 SubtypeData, t2 SubtypeData) SubtypeData {
+func (d *decimalOps) Union(t1 SubtypeData, t2 SubtypeData) SubtypeData {
 	var values []enumerableType[big.Rat]
 	var v1 enumerableSubtype[big.Rat] = new(t1.(decimalSubtype))
 	var v2 enumerableSubtype[big.Rat] = new(t2.(decimalSubtype))
@@ -39,7 +39,7 @@ func (this *decimalOps) Union(t1 SubtypeData, t2 SubtypeData) SubtypeData {
 	return createDecimalSubtype(allowed, values)
 }
 
-func (this *decimalOps) Intersect(t1 SubtypeData, t2 SubtypeData) SubtypeData {
+func (d *decimalOps) Intersect(t1 SubtypeData, t2 SubtypeData) SubtypeData {
 	var values []enumerableType[big.Rat]
 	var v1 enumerableSubtype[big.Rat] = new(t1.(decimalSubtype))
 	var v2 enumerableSubtype[big.Rat] = new(t2.(decimalSubtype))
@@ -47,15 +47,15 @@ func (this *decimalOps) Intersect(t1 SubtypeData, t2 SubtypeData) SubtypeData {
 	return createDecimalSubtype(allowed, values)
 }
 
-func (this *decimalOps) Diff(t1 SubtypeData, t2 SubtypeData) SubtypeData {
-	return this.Intersect(t1, this.complement(t2))
+func (d *decimalOps) Diff(t1 SubtypeData, t2 SubtypeData) SubtypeData {
+	return d.Intersect(t1, d.complement(t2))
 }
 
-func (this *decimalOps) complement(t SubtypeData) SubtypeData {
+func (d *decimalOps) complement(t SubtypeData) SubtypeData {
 	s := t.(decimalSubtype)
 	return createDecimalSubtype((!s.allowed), s.Values())
 }
 
-func (this *decimalOps) IsEmpty(tc Context, t SubtypeData) bool {
+func (d *decimalOps) IsEmpty(tc Context, t SubtypeData) bool {
 	return notIsEmpty(tc, t)
 }

--- a/semtypes/decimal_subtype.go
+++ b/semtypes/decimal_subtype.go
@@ -89,13 +89,13 @@ func createDecimalSubtype(allowed bool, values []enumerableType[big.Rat]) Proper
 	return newDecimalSubtypeFromBoolEnumerableDecimals(allowed, values)
 }
 
-func (this *decimalSubtype) Allowed() bool {
-	return this.allowed
+func (d *decimalSubtype) Allowed() bool {
+	return d.allowed
 }
 
-func (this *decimalSubtype) Values() []enumerableType[big.Rat] {
+func (d *decimalSubtype) Values() []enumerableType[big.Rat] {
 	var values []enumerableType[big.Rat]
-	for _, value := range this.values {
+	for _, value := range d.values {
 		values = append(values, &value)
 	}
 	return values

--- a/semtypes/enumerable_char_string.go
+++ b/semtypes/enumerable_char_string.go
@@ -40,9 +40,9 @@ func (t1 *enumerableCharString) Compare(t2 enumerableType[string]) int {
 }
 
 func newEnumerableCharStringFromString(value string) enumerableCharString {
-	this := enumerableCharString{}
-	this.value = value
-	return this
+	e := enumerableCharString{}
+	e.value = value
+	return e
 }
 
 func enumerableCharStringFrom(v string) enumerableType[string] {

--- a/semtypes/enumerable_char_string.go
+++ b/semtypes/enumerable_char_string.go
@@ -22,8 +22,8 @@ type enumerableCharString struct {
 
 var _ enumerableType[string] = &enumerableCharString{}
 
-func (this *enumerableCharString) Value() string {
-	return this.value
+func (e *enumerableCharString) Value() string {
+	return e.value
 }
 
 func (t1 *enumerableCharString) Compare(t2 enumerableType[string]) int {

--- a/semtypes/enumerable_decimal.go
+++ b/semtypes/enumerable_decimal.go
@@ -26,8 +26,8 @@ type enumerableDecimal struct {
 
 var _ enumerableType[big.Rat] = &enumerableDecimal{}
 
-func (this *enumerableDecimal) Value() big.Rat {
-	return this.value
+func (e *enumerableDecimal) Value() big.Rat {
+	return e.value
 }
 
 func (t1 *enumerableDecimal) Compare(t2 enumerableType[big.Rat]) int {

--- a/semtypes/enumerable_float.go
+++ b/semtypes/enumerable_float.go
@@ -44,11 +44,5 @@ func (t1 *enumerableFloat) Compare(t2 enumerableType[float64]) int {
 }
 
 func newEnumerableFloatFromFloat64(value float64) enumerableFloat {
-	this := enumerableFloat{}
-	this.value = value
-	return this
-}
-
-func enumerableFloatFrom(d float64) enumerableFloat {
-	return newEnumerableFloatFromFloat64(d)
+	return enumerableFloat{value: value}
 }

--- a/semtypes/enumerable_float.go
+++ b/semtypes/enumerable_float.go
@@ -24,8 +24,8 @@ type enumerableFloat struct {
 
 var _ enumerableType[float64] = &enumerableFloat{}
 
-func (this *enumerableFloat) Value() float64 {
-	return this.value
+func (e *enumerableFloat) Value() float64 {
+	return e.value
 }
 
 func (t1 *enumerableFloat) Compare(t2 enumerableType[float64]) int {

--- a/semtypes/enumerable_string.go
+++ b/semtypes/enumerable_string.go
@@ -22,8 +22,8 @@ type enumerableString struct {
 
 var _ enumerableType[string] = &enumerableString{}
 
-func (this *enumerableString) Value() string {
-	return this.value
+func (e *enumerableString) Value() string {
+	return e.value
 }
 
 func (t1 *enumerableString) Compare(t2 enumerableType[string]) int {

--- a/semtypes/env.go
+++ b/semtypes/env.go
@@ -57,154 +57,154 @@ type env struct {
 	types map[string]SemType
 }
 
-func (this *env) recListAtomCount() int {
-	return len(this.recListAtoms)
+func (e *env) recListAtomCount() int {
+	return len(e.recListAtoms)
 }
 
-func (this *env) recMappingAtomCount() int {
-	return len(this.recMappingAtoms)
+func (e *env) recMappingAtomCount() int {
+	return len(e.recMappingAtoms)
 }
 
-func (this *env) recFunctionAtomCount() int {
-	return len(this.recFunctionAtoms)
+func (e *env) recFunctionAtomCount() int {
+	return len(e.recFunctionAtoms)
 }
 
-func (this *env) distinctAtomCount() int {
-	this.distinctAtomMutex.Lock()
-	defer this.distinctAtomMutex.Unlock()
-	return this.distinctAtoms
+func (e *env) distinctAtomCount() int {
+	e.distinctAtomMutex.Lock()
+	defer e.distinctAtomMutex.Unlock()
+	return e.distinctAtoms
 }
 
-func (this *env) distinctAtomCountGetAndIncrement() int {
-	this.distinctAtomMutex.Lock()
-	defer this.distinctAtomMutex.Unlock()
-	this.distinctAtoms++
-	return this.distinctAtoms
+func (e *env) distinctAtomCountGetAndIncrement() int {
+	e.distinctAtomMutex.Lock()
+	defer e.distinctAtomMutex.Unlock()
+	e.distinctAtoms++
+	return e.distinctAtoms
 }
 
-func (this *env) recFunctionAtom() recAtom {
-	this.recFunctionAtomsMutex.Lock()
-	defer this.recFunctionAtomsMutex.Unlock()
-	result := len(this.recFunctionAtoms)
-	this.recFunctionAtoms = append(this.recFunctionAtoms, nil)
+func (e *env) recFunctionAtom() recAtom {
+	e.recFunctionAtomsMutex.Lock()
+	defer e.recFunctionAtomsMutex.Unlock()
+	result := len(e.recFunctionAtoms)
+	e.recFunctionAtoms = append(e.recFunctionAtoms, nil)
 	return createRecAtom(result)
 }
 
-func (this *env) setRecFunctionAtomType(rec recAtom, atomicType *functionAtomicType) {
-	this.recFunctionAtomsMutex.Lock()
-	defer this.recFunctionAtomsMutex.Unlock()
-	this.recFunctionAtoms[rec.index()] = atomicType
+func (e *env) setRecFunctionAtomType(rec recAtom, atomicType *functionAtomicType) {
+	e.recFunctionAtomsMutex.Lock()
+	defer e.recFunctionAtomsMutex.Unlock()
+	e.recFunctionAtoms[rec.index()] = atomicType
 }
 
-func (this *env) getRecFunctionAtomType(rec recAtom) *functionAtomicType {
-	this.recFunctionAtomsMutex.Lock()
-	defer this.recFunctionAtomsMutex.Unlock()
-	return this.recFunctionAtoms[rec.index()]
+func (e *env) getRecFunctionAtomType(rec recAtom) *functionAtomicType {
+	e.recFunctionAtomsMutex.Lock()
+	defer e.recFunctionAtomsMutex.Unlock()
+	return e.recFunctionAtoms[rec.index()]
 }
 
-func (this *env) listAtom(atomicType *ListAtomicType) typeAtom {
-	return this.typeAtom(atomicType)
+func (e *env) listAtom(atomicType *ListAtomicType) typeAtom {
+	return e.typeAtom(atomicType)
 }
 
-func (this *env) mappingAtom(atomicType *MappingAtomicType) typeAtom {
-	return this.typeAtom(atomicType)
+func (e *env) mappingAtom(atomicType *MappingAtomicType) typeAtom {
+	return e.typeAtom(atomicType)
 }
 
-func (this *env) functionAtom(atomicType *functionAtomicType) typeAtom {
-	return this.typeAtom(atomicType)
+func (e *env) functionAtom(atomicType *functionAtomicType) typeAtom {
+	return e.typeAtom(atomicType)
 }
 
-func (this *env) cellAtom(atomicType *cellAtomicType) typeAtom {
-	return this.typeAtom(atomicType)
+func (e *env) cellAtom(atomicType *cellAtomicType) typeAtom {
+	return e.typeAtom(atomicType)
 }
 
-func (this *env) typeAtom(atomicType atomicType) typeAtom {
-	this.atomTableMutex.Lock()
-	defer this.atomTableMutex.Unlock()
-	ta, ok := this.atomTable[atomicType]
+func (e *env) typeAtom(atomicType atomicType) typeAtom {
+	e.atomTableMutex.Lock()
+	defer e.atomTableMutex.Unlock()
+	ta, ok := e.atomTable[atomicType]
 	if ok {
 		return ta
 	}
-	ta = createTypeAtom(len(this.atomTable), atomicType)
-	this.atomTable[atomicType] = ta
+	ta = createTypeAtom(len(e.atomTable), atomicType)
+	e.atomTable[atomicType] = ta
 	return ta
 }
 
-func (this *env) listAtomType(atom atom) *ListAtomicType {
+func (e *env) listAtomType(atom atom) *ListAtomicType {
 	if recAtom, ok := atom.(*recAtom); ok {
-		return this.getRecListAtomType(*recAtom)
+		return e.getRecListAtomType(*recAtom)
 	}
 	return atom.(*typeAtom).AtomicType.(*ListAtomicType)
 }
 
-func (this *env) functionAtomType(atom atom) *functionAtomicType {
+func (e *env) functionAtomType(atom atom) *functionAtomicType {
 	if recAtom, ok := atom.(*recAtom); ok {
-		return this.getRecFunctionAtomType(*recAtom)
+		return e.getRecFunctionAtomType(*recAtom)
 	}
 	return atom.(*typeAtom).AtomicType.(*functionAtomicType)
 }
 
-func (this *env) mappingAtomType(atom atom) *MappingAtomicType {
+func (e *env) mappingAtomType(atom atom) *MappingAtomicType {
 	if recAtom, ok := atom.(*recAtom); ok {
-		return this.getRecMappingAtomType(*recAtom)
+		return e.getRecMappingAtomType(*recAtom)
 	}
 	return atom.(*typeAtom).AtomicType.(*MappingAtomicType)
 }
 
-func (this *env) recListAtom() recAtom {
-	this.recListAtomsMutex.Lock()
-	defer this.recListAtomsMutex.Unlock()
-	result := len(this.recListAtoms)
-	this.recListAtoms = append(this.recListAtoms, nil)
+func (e *env) recListAtom() recAtom {
+	e.recListAtomsMutex.Lock()
+	defer e.recListAtomsMutex.Unlock()
+	result := len(e.recListAtoms)
+	e.recListAtoms = append(e.recListAtoms, nil)
 	return createRecAtom(result)
 }
 
-func (this *env) recMappingAtom() recAtom {
-	this.recMappingAtomsMutex.Lock()
-	defer this.recMappingAtomsMutex.Unlock()
-	result := len(this.recMappingAtoms)
-	this.recMappingAtoms = append(this.recMappingAtoms, nil)
+func (e *env) recMappingAtom() recAtom {
+	e.recMappingAtomsMutex.Lock()
+	defer e.recMappingAtomsMutex.Unlock()
+	result := len(e.recMappingAtoms)
+	e.recMappingAtoms = append(e.recMappingAtoms, nil)
 	return createRecAtom(result)
 }
 
-func (this *env) setRecListAtomType(rec recAtom, atomicType *ListAtomicType) {
-	this.recListAtomsMutex.Lock()
-	defer this.recListAtomsMutex.Unlock()
-	this.recListAtoms[rec.index()] = atomicType
+func (e *env) setRecListAtomType(rec recAtom, atomicType *ListAtomicType) {
+	e.recListAtomsMutex.Lock()
+	defer e.recListAtomsMutex.Unlock()
+	e.recListAtoms[rec.index()] = atomicType
 }
 
-func (this *env) setRecMappingAtomType(rec recAtom, atomicType *MappingAtomicType) {
-	this.recMappingAtomsMutex.Lock()
-	defer this.recMappingAtomsMutex.Unlock()
-	this.recMappingAtoms[rec.index()] = atomicType
+func (e *env) setRecMappingAtomType(rec recAtom, atomicType *MappingAtomicType) {
+	e.recMappingAtomsMutex.Lock()
+	defer e.recMappingAtomsMutex.Unlock()
+	e.recMappingAtoms[rec.index()] = atomicType
 }
 
-func (this *env) getRecListAtomType(rec recAtom) *ListAtomicType {
-	this.recListAtomsMutex.Lock()
-	defer this.recListAtomsMutex.Unlock()
-	return this.recListAtoms[rec.index()]
+func (e *env) getRecListAtomType(rec recAtom) *ListAtomicType {
+	e.recListAtomsMutex.Lock()
+	defer e.recListAtomsMutex.Unlock()
+	return e.recListAtoms[rec.index()]
 }
 
-func (this *env) getRecMappingAtomType(rec recAtom) *MappingAtomicType {
-	this.recMappingAtomsMutex.Lock()
-	defer this.recMappingAtomsMutex.Unlock()
-	return this.recMappingAtoms[rec.index()]
+func (e *env) getRecMappingAtomType(rec recAtom) *MappingAtomicType {
+	e.recMappingAtomsMutex.Lock()
+	defer e.recMappingAtomsMutex.Unlock()
+	return e.recMappingAtoms[rec.index()]
 }
 
-func (this *env) cellAtomType(atom atom) *cellAtomicType {
+func (e *env) cellAtomType(atom atom) *cellAtomicType {
 	return atom.(*typeAtom).AtomicType.(*cellAtomicType)
 }
 
 // Public/package methods
 
 // initializeEnv populates the environment with predefined atoms
-// func (this *predefinedTypeEnv) initializeEnv(env Env) {
-// 	fillRecAtoms(this, &env.recListAtoms, this.initializedRecListAtoms)
-// 	fillRecAtoms(this, &env.recMappingAtoms, this.initializedRecMappingAtoms)
-// 	for _, each := range this.initializedCellAtoms {
+// func (p *predefinedTypeEnv) initializeEnv(env Env) {
+// 	fillRecAtoms(p, &env.recListAtoms, p.initializedRecListAtoms)
+// 	fillRecAtoms(p, &env.recMappingAtoms, p.initializedRecMappingAtoms)
+// 	for _, each := range p.initializedCellAtoms {
 // 		env.cellAtom(each.atomicType)
 // 	}
-// 	for _, each := range this.initializedListAtoms {
+// 	for _, each := range p.initializedListAtoms {
 // 		env.listAtom(each.atomicType)
 // 	}
 // }

--- a/semtypes/error_ops.go
+++ b/semtypes/error_ops.go
@@ -36,22 +36,22 @@ func errorBddIsEmpty(cx Context, b Bdd) bool {
 	return bddEveryPositive(cx, b, conjunctionNil, conjunctionNil, mappingFormulaIsEmpty)
 }
 
-func (this *errorOps) complement(d SubtypeData) SubtypeData {
+func (e *errorOps) complement(d SubtypeData) SubtypeData {
 	return errorSubtypeComplement(d)
 }
 
-func (this *errorOps) IsEmpty(cx Context, t SubtypeData) bool {
+func (e *errorOps) IsEmpty(cx Context, t SubtypeData) bool {
 	return errorSubtypeIsEmpty(cx, t)
 }
 
-func (this *errorOps) Union(d1 SubtypeData, d2 SubtypeData) SubtypeData {
+func (e *errorOps) Union(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	return bddSubtypeUnion(d1, d2)
 }
 
-func (this *errorOps) Intersect(d1 SubtypeData, d2 SubtypeData) SubtypeData {
+func (e *errorOps) Intersect(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	return bddSubtypeIntersect(d1, d2)
 }
 
-func (this *errorOps) Diff(d1 SubtypeData, d2 SubtypeData) SubtypeData {
+func (e *errorOps) Diff(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	return bddSubtypeDiff(d1, d2)
 }

--- a/semtypes/float_ops.go
+++ b/semtypes/float_ops.go
@@ -27,7 +27,7 @@ func newFloatOps() floatOps {
 	return this
 }
 
-func (this *floatOps) Union(t1 SubtypeData, t2 SubtypeData) SubtypeData {
+func (f *floatOps) Union(t1 SubtypeData, t2 SubtypeData) SubtypeData {
 	var values []enumerableType[float64]
 	var v1 enumerableSubtype[float64] = new(t1.(floatSubtype))
 	var v2 enumerableSubtype[float64] = new(t2.(floatSubtype))
@@ -35,7 +35,7 @@ func (this *floatOps) Union(t1 SubtypeData, t2 SubtypeData) SubtypeData {
 	return createFloatSubtype(allowed, values)
 }
 
-func (this *floatOps) Intersect(t1 SubtypeData, t2 SubtypeData) SubtypeData {
+func (f *floatOps) Intersect(t1 SubtypeData, t2 SubtypeData) SubtypeData {
 	var values []enumerableType[float64]
 	var v1 enumerableSubtype[float64] = new(t1.(floatSubtype))
 	var v2 enumerableSubtype[float64] = new(t2.(floatSubtype))
@@ -43,15 +43,15 @@ func (this *floatOps) Intersect(t1 SubtypeData, t2 SubtypeData) SubtypeData {
 	return createFloatSubtype(allowed, values)
 }
 
-func (this *floatOps) Diff(t1 SubtypeData, t2 SubtypeData) SubtypeData {
-	return this.Intersect(t1, this.complement(t2))
+func (f *floatOps) Diff(t1 SubtypeData, t2 SubtypeData) SubtypeData {
+	return f.Intersect(t1, f.complement(t2))
 }
 
-func (this *floatOps) complement(t SubtypeData) SubtypeData {
+func (f *floatOps) complement(t SubtypeData) SubtypeData {
 	s := t.(floatSubtype)
 	return createFloatSubtype((!s.allowed), s.Values())
 }
 
-func (this *floatOps) IsEmpty(cx Context, t SubtypeData) bool {
+func (f *floatOps) IsEmpty(cx Context, t SubtypeData) bool {
 	return notIsEmpty(cx, t)
 }

--- a/semtypes/float_subtype.go
+++ b/semtypes/float_subtype.go
@@ -87,13 +87,13 @@ func createFloatSubtype(allowed bool, values []enumerableType[float64]) ProperSu
 	return newFloatSubtypeFromBoolEnumerableFloats(allowed, values)
 }
 
-func (this *floatSubtype) Allowed() bool {
-	return this.allowed
+func (f *floatSubtype) Allowed() bool {
+	return f.allowed
 }
 
-func (this *floatSubtype) Values() []enumerableType[float64] {
+func (f *floatSubtype) Values() []enumerableType[float64] {
 	var values []enumerableType[float64]
-	for _, value := range this.values {
+	for _, value := range f.values {
 		values = append(values, &value)
 	}
 	return values

--- a/semtypes/float_subtype.go
+++ b/semtypes/float_subtype.go
@@ -41,14 +41,14 @@ func newFloatSubtypeFromBoolEnumerableFloats(allowed bool, values []enumerableTy
 	this.allowed = allowed
 	var floats []enumerableFloat
 	for _, value := range values {
-		floats = append(floats, enumerableFloatFrom(value.Value()))
+		floats = append(floats, newEnumerableFloatFromFloat64(value.Value()))
 	}
 	this.values = floats
 	return this
 }
 
 func FloatConst(value float64) SemType {
-	return getBasicSubtype(BTFloat, newFloatSubtypeFromBoolEnumerableFloat(true, enumerableFloatFrom(value)))
+	return getBasicSubtype(BTFloat, newFloatSubtypeFromBoolEnumerableFloat(true, newEnumerableFloatFromFloat64(value)))
 }
 
 func floatSubtypeSingleValue(d SubtypeData) common.Optional[float64] {

--- a/semtypes/function_atomic_type.go
+++ b/semtypes/function_atomic_type.go
@@ -25,10 +25,10 @@ type functionAtomicType struct {
 
 var _ atomicType = &functionAtomicType{}
 
-func (this *functionAtomicType) equals(other atomicType) bool {
+func (f *functionAtomicType) equals(other atomicType) bool {
 	if other, ok := other.(*functionAtomicType); ok {
-		return other.ParamType == this.ParamType && other.RetType == this.RetType &&
-			other.Qualifiers == this.Qualifiers && other.IsGeneric == this.IsGeneric
+		return other.ParamType == f.ParamType && other.RetType == f.RetType &&
+			other.Qualifiers == f.Qualifiers && other.IsGeneric == f.IsGeneric
 	}
 	return false
 }
@@ -52,6 +52,6 @@ func newFunctionAtomicType(paramType SemType, retType SemType, qualifiers SemTyp
 	return this
 }
 
-func (this *functionAtomicType) atomKind() kind {
+func (f *functionAtomicType) atomKind() kind {
 	return kind_FUNCTION_ATOM
 }

--- a/semtypes/function_definition.go
+++ b/semtypes/function_definition.go
@@ -28,40 +28,40 @@ func NewFunctionDefinition() FunctionDefinition {
 	return this
 }
 
-func (this *FunctionDefinition) GetSemType(env Env) SemType {
-	if this.semType != nil {
-		return this.semType
+func (f *FunctionDefinition) GetSemType(env Env) SemType {
+	if f.semType != nil {
+		return f.semType
 	}
 	rec := env.recFunctionAtom()
-	this.rec = &rec
-	return this.createSemType(&rec)
+	f.rec = &rec
+	return f.createSemType(&rec)
 }
 
-func (this *FunctionDefinition) createSemType(rec atom) SemType {
+func (f *FunctionDefinition) createSemType(rec atom) SemType {
 	bdd := bddAtom(rec)
 	s := getBasicSubtype(BTFunction, bdd)
-	this.semType = s
+	f.semType = s
 	return s
 }
 
-func (this *FunctionDefinition) Define(env Env, args SemType, ret SemType, qualifiers FunctionQualifiers) SemType {
+func (f *FunctionDefinition) Define(env Env, args SemType, ret SemType, qualifiers FunctionQualifiers) SemType {
 	atomicType := functionAtomicTypeFrom(args, ret, qualifiers.semType)
-	return this.defineInternal(env, atomicType)
+	return f.defineInternal(env, atomicType)
 }
 
-func (this *FunctionDefinition) DefineGeneric(env Env, args SemType, ret SemType, qualifiers FunctionQualifiers) SemType {
+func (f *FunctionDefinition) DefineGeneric(env Env, args SemType, ret SemType, qualifiers FunctionQualifiers) SemType {
 	atomicType := functionAtomicTypeGenericFrom(args, ret, qualifiers.semType)
-	return this.defineInternal(env, atomicType)
+	return f.defineInternal(env, atomicType)
 }
 
-func (this *FunctionDefinition) defineInternal(env Env, atomicType functionAtomicType) SemType {
+func (f *FunctionDefinition) defineInternal(env Env, atomicType functionAtomicType) SemType {
 	var a atom
-	rec := this.rec
+	rec := f.rec
 	if rec != nil {
 		a = rec
 		env.setRecFunctionAtomType(*rec, &atomicType)
 	} else {
 		a = new(env.functionAtom(&atomicType))
 	}
-	return this.createSemType(a)
+	return f.createSemType(a)
 }

--- a/semtypes/function_ops.go
+++ b/semtypes/function_ops.go
@@ -20,25 +20,25 @@ type functionOps struct{}
 
 var _ BasicTypeOps = &functionOps{}
 
-func (this *functionOps) IsEmpty(cx Context, t SubtypeData) bool {
+func (f *functionOps) IsEmpty(cx Context, t SubtypeData) bool {
 	return memoSubtypeIsEmpty(cx, cx.functionMemo(), func(cx Context, b Bdd) bool {
 		return bddEvery(cx, b, conjunctionNil, conjunctionNil, functionFormulaIsEmpty)
 	}, t.(Bdd))
 }
 
-func (this *functionOps) complement(t SubtypeData) SubtypeData {
+func (f *functionOps) complement(t SubtypeData) SubtypeData {
 	return bddComplement(t.(Bdd))
 }
 
-func (this *functionOps) Diff(t1 SubtypeData, t2 SubtypeData) SubtypeData {
+func (f *functionOps) Diff(t1 SubtypeData, t2 SubtypeData) SubtypeData {
 	return bddDiff(t1.(Bdd), t2.(Bdd))
 }
 
-func (this *functionOps) Intersect(t1 SubtypeData, t2 SubtypeData) SubtypeData {
+func (f *functionOps) Intersect(t1 SubtypeData, t2 SubtypeData) SubtypeData {
 	return bddIntersect(t1.(Bdd), t2.(Bdd))
 }
 
-func (this *functionOps) Union(t1 SubtypeData, t2 SubtypeData) SubtypeData {
+func (f *functionOps) Union(t1 SubtypeData, t2 SubtypeData) SubtypeData {
 	return bddUnion(t1.(Bdd), t2.(Bdd))
 }
 
@@ -107,7 +107,7 @@ func NewFunctionOps() functionOps {
 	return this
 }
 
-func (this *functionOps) functionTheta(cx Context, t0 SemType, t1 SemType, pos conjunctionHandle) bool {
+func (f *functionOps) functionTheta(cx Context, t0 SemType, t1 SemType, pos conjunctionHandle) bool {
 	if pos == conjunctionNil {
 		return (IsEmpty(cx, t0) || IsEmpty(cx, t1))
 	} else {
@@ -115,7 +115,7 @@ func (this *functionOps) functionTheta(cx Context, t0 SemType, t1 SemType, pos c
 		posNext := cx.conjunctionNext(pos)
 		s0 := s.ParamType
 		s1 := s.RetType
-		return ((IsSubtype(cx, t0, s0) || this.functionTheta(cx, Diff(s0, t0), s1, posNext)) && (IsSubtype(cx, t1, complement(s1)) || this.functionTheta(cx, s0, Intersect(s1, t1), posNext)))
+		return ((IsSubtype(cx, t0, s0) || f.functionTheta(cx, Diff(s0, t0), s1, posNext)) && (IsSubtype(cx, t1, complement(s1)) || f.functionTheta(cx, s0, Intersect(s1, t1), posNext)))
 	}
 }
 

--- a/semtypes/future_ops.go
+++ b/semtypes/future_ops.go
@@ -27,6 +27,6 @@ func newFutureOps() futureOps {
 	return this
 }
 
-func (this *futureOps) IsEmpty(cx Context, t SubtypeData) bool {
+func (f *futureOps) IsEmpty(cx Context, t SubtypeData) bool {
 	return mappingSubtypeIsEmpty(cx, t)
 }

--- a/semtypes/int_ops.go
+++ b/semtypes/int_ops.go
@@ -27,7 +27,7 @@ func newIntOps() intOps {
 
 var intOpsInstance = newIntOps()
 
-func (this *intOps) Union(d1 SubtypeData, d2 SubtypeData) SubtypeData {
+func (i *intOps) Union(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	v1 := d1.(intSubtype)
 	v2 := d2.(intSubtype)
 	v := rangeListUnion(v1.Ranges, v2.Ranges)
@@ -37,7 +37,7 @@ func (this *intOps) Union(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	return createIntSubtype(v...)
 }
 
-func (this *intOps) Intersect(d1 SubtypeData, d2 SubtypeData) SubtypeData {
+func (i *intOps) Intersect(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	v1 := d1.(intSubtype)
 	v2 := d2.(intSubtype)
 	v := rangeListIntersect(v1.Ranges, v2.Ranges)
@@ -47,7 +47,7 @@ func (this *intOps) Intersect(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	return createIntSubtype(v...)
 }
 
-func (this *intOps) Diff(d1 SubtypeData, d2 SubtypeData) SubtypeData {
+func (i *intOps) Diff(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	v1 := d1.(intSubtype)
 	v2 := d2.(intSubtype)
 	v := rangeListIntersect(v1.Ranges, rangeListComplement(v2.Ranges))
@@ -57,7 +57,7 @@ func (this *intOps) Diff(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	return createIntSubtype(v...)
 }
 
-func (this *intOps) complement(d SubtypeData) SubtypeData {
+func (i *intOps) complement(d SubtypeData) SubtypeData {
 	v := d.(intSubtype)
 	return createIntSubtype(rangeListComplement(v.Ranges)...)
 }
@@ -78,7 +78,7 @@ func intSubtypeMin(subtype intSubtype) int64 {
 	return subtype.Ranges[0].Min
 }
 
-func (this *intOps) IsEmpty(cx Context, t SubtypeData) bool {
+func (i *intOps) IsEmpty(cx Context, t SubtypeData) bool {
 	return notIsEmpty(cx, t)
 }
 

--- a/semtypes/int_subtype.go
+++ b/semtypes/int_subtype.go
@@ -127,10 +127,10 @@ func intSubtypeSingleValue(d SubtypeData) common.Optional[int64] {
 	return common.OptionalOf(min)
 }
 
-func (this intSubtype) String() string {
+func (i intSubtype) String() string {
 	var builder strings.Builder
 	builder.WriteString("(int")
-	for _, r := range this.Ranges {
+	for _, r := range i.Ranges {
 		builder.WriteString(" ")
 		if r.Min == r.Max {
 			fmt.Fprintf(&builder, "%d", r.Min)

--- a/semtypes/list_atomic_type.go
+++ b/semtypes/list_atomic_type.go
@@ -27,13 +27,13 @@ type ListAtomicType struct {
 
 var _ atomicType = &ListAtomicType{}
 
-func (this *ListAtomicType) equals(other atomicType) bool {
+func (l *ListAtomicType) equals(other atomicType) bool {
 	if other, ok := other.(*ListAtomicType); ok {
-		if !this.rest.equals(other.rest) {
+		if !l.rest.equals(other.rest) {
 			return false
 		}
-		return other.Members.FixedLength == this.Members.FixedLength &&
-			slices.EqualFunc(other.Members.initial, this.Members.initial, func(a, b ComplexSemType) bool { return a.equals(&b) })
+		return other.Members.FixedLength == l.Members.FixedLength &&
+			slices.EqualFunc(other.Members.initial, l.Members.initial, func(a, b ComplexSemType) bool { return a.equals(&b) })
 	}
 	return false
 }
@@ -49,7 +49,7 @@ func listAtomicTypeFrom(members fixedLengthArray, rest *ComplexSemType) ListAtom
 	return newListAtomicTypeFromMembersRest(members, rest)
 }
 
-func (this *ListAtomicType) atomKind() kind {
+func (l *ListAtomicType) atomKind() kind {
 	return kind_LIST_ATOM
 }
 

--- a/semtypes/list_definition.go
+++ b/semtypes/list_definition.go
@@ -34,26 +34,26 @@ func NewListDefinition() ListDefinition {
 	return this
 }
 
-func (this *ListDefinition) GetSemType(env Env) SemType {
-	s := this.semType
+func (l *ListDefinition) GetSemType(env Env) SemType {
+	s := l.semType
 	if s == nil {
 		rec := env.recListAtom()
-		this.rec = &rec
-		return this.createSemType(env, &rec)
+		l.rec = &rec
+		return l.createSemType(env, &rec)
 	} else {
 		return s
 	}
 }
 
-func (this *ListDefinition) TupleTypeWrapped(env Env, members ...SemType) SemType {
-	return this.DefineListTypeWrappedWithEnvSemTypesInt(env, members, len(members))
+func (l *ListDefinition) TupleTypeWrapped(env Env, members ...SemType) SemType {
+	return l.DefineListTypeWrappedWithEnvSemTypesInt(env, members, len(members))
 }
 
-func (this *ListDefinition) TupleTypeWrappedRo(env Env, members ...SemType) SemType {
-	return this.DefineListTypeWrapped(env, members, len(members), NEVER, CellMutability_CELL_MUT_NONE)
+func (l *ListDefinition) TupleTypeWrappedRo(env Env, members ...SemType) SemType {
+	return l.DefineListTypeWrapped(env, members, len(members), NEVER, CellMutability_CELL_MUT_NONE)
 }
 
-func (this *ListDefinition) DefineListTypeWrapped(env Env, initial []SemType, fixedLength int, rest SemType, mut CellMutability) SemType {
+func (l *ListDefinition) DefineListTypeWrapped(env Env, initial []SemType, fixedLength int, rest SemType, mut CellMutability) SemType {
 	common.Assert(rest != nil)
 	var initialCells []ComplexSemType
 	for _, member := range initial {
@@ -66,44 +66,44 @@ func (this *ListDefinition) DefineListTypeWrapped(env Env, initial []SemType, fi
 		restMut = mut
 	}
 	restCell := cellContainingWithEnvSemTypeCellMutability(env, Union(rest, UNDEF), restMut)
-	return this.define(env, initialCells, fixedLength, restCell)
+	return l.define(env, initialCells, fixedLength, restCell)
 }
 
-func (this *ListDefinition) DefineListTypeWrappedWithEnvSemTypesInt(env Env, initial []SemType, size int) SemType {
-	return this.DefineListTypeWrapped(env, initial, size, NEVER, CellMutability_CELL_MUT_LIMITED)
+func (l *ListDefinition) DefineListTypeWrappedWithEnvSemTypesInt(env Env, initial []SemType, size int) SemType {
+	return l.DefineListTypeWrapped(env, initial, size, NEVER, CellMutability_CELL_MUT_LIMITED)
 }
 
-func (this *ListDefinition) DefineListTypeWrappedWithEnvSemTypesIntSemType(env Env, initial []SemType, fixedLength int, rest SemType) SemType {
-	return this.DefineListTypeWrapped(env, initial, fixedLength, rest, CellMutability_CELL_MUT_LIMITED)
+func (l *ListDefinition) DefineListTypeWrappedWithEnvSemTypesIntSemType(env Env, initial []SemType, fixedLength int, rest SemType) SemType {
+	return l.DefineListTypeWrapped(env, initial, fixedLength, rest, CellMutability_CELL_MUT_LIMITED)
 }
 
-func (this *ListDefinition) DefineListTypeWrappedWithEnvSemType(env Env, rest SemType) SemType {
-	return this.DefineListTypeWrappedWithEnvSemTypesIntSemType(env, nil, 0, rest)
+func (l *ListDefinition) DefineListTypeWrappedWithEnvSemType(env Env, rest SemType) SemType {
+	return l.DefineListTypeWrappedWithEnvSemTypesIntSemType(env, nil, 0, rest)
 }
 
-func (this *ListDefinition) DefineListTypeWrappedWithEnvSemTypeCellMutability(env Env, rest SemType, mut CellMutability) SemType {
-	return this.DefineListTypeWrapped(env, nil, 0, rest, mut)
+func (l *ListDefinition) DefineListTypeWrappedWithEnvSemTypeCellMutability(env Env, rest SemType, mut CellMutability) SemType {
+	return l.DefineListTypeWrapped(env, nil, 0, rest, mut)
 }
 
-func (this *ListDefinition) DefineListTypeWrappedWithEnvSemTypesSemType(env Env, initial []SemType, rest SemType) SemType {
-	return this.DefineListTypeWrapped(env, initial, len(initial), rest, CellMutability_CELL_MUT_LIMITED)
+func (l *ListDefinition) DefineListTypeWrappedWithEnvSemTypesSemType(env Env, initial []SemType, rest SemType) SemType {
+	return l.DefineListTypeWrapped(env, initial, len(initial), rest, CellMutability_CELL_MUT_LIMITED)
 }
 
-func (this *ListDefinition) define(env Env, initial []ComplexSemType, fixedLength int, rest *ComplexSemType) *ComplexSemType {
-	members := this.fixedLengthNormalize(fixedLengthArrayFrom(initial, fixedLength))
+func (l *ListDefinition) define(env Env, initial []ComplexSemType, fixedLength int, rest *ComplexSemType) *ComplexSemType {
+	members := l.fixedLengthNormalize(fixedLengthArrayFrom(initial, fixedLength))
 	atomicType := listAtomicTypeFrom(members, rest)
 	var atom atom
-	rec := this.rec
+	rec := l.rec
 	if rec != nil {
 		atom = rec
 		env.setRecListAtomType(*rec, &atomicType)
 	} else {
 		atom = new(env.listAtom(&atomicType))
 	}
-	return this.createSemType(env, atom)
+	return l.createSemType(env, atom)
 }
 
-func (this *ListDefinition) fixedLengthNormalize(array fixedLengthArray) fixedLengthArray {
+func (l *ListDefinition) fixedLengthNormalize(array fixedLengthArray) fixedLengthArray {
 	initial := array.initial
 	i := (len(initial) - 1)
 	if i <= 0 {
@@ -120,9 +120,9 @@ func (this *ListDefinition) fixedLengthNormalize(array fixedLengthArray) fixedLe
 	return fixedLengthArrayFrom(initial[:i+2], array.FixedLength)
 }
 
-func (this *ListDefinition) createSemType(env Env, atom atom) *ComplexSemType {
+func (l *ListDefinition) createSemType(env Env, atom atom) *ComplexSemType {
 	bdd := bddAtom(atom)
 	complexSemType := getBasicSubtype(BTList, bdd)
-	this.semType = complexSemType
+	l.semType = complexSemType
 	return complexSemType
 }

--- a/semtypes/list_ops.go
+++ b/semtypes/list_ops.go
@@ -372,22 +372,22 @@ func newListOps() listOps {
 	return this
 }
 
-func (this *listOps) Union(d1 SubtypeData, d2 SubtypeData) SubtypeData {
+func (l *listOps) Union(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	return bddSubtypeUnion(d1, d2)
 }
 
-func (this *listOps) Intersect(d1 SubtypeData, d2 SubtypeData) SubtypeData {
+func (l *listOps) Intersect(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	return bddSubtypeIntersect(d1, d2)
 }
 
-func (this *listOps) Diff(d1 SubtypeData, d2 SubtypeData) SubtypeData {
+func (l *listOps) Diff(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	return bddSubtypeDiff(d1, d2)
 }
 
-func (this *listOps) complement(d SubtypeData) SubtypeData {
+func (l *listOps) complement(d SubtypeData) SubtypeData {
 	return bddSubtypeComplement(d)
 }
 
-func (this *listOps) IsEmpty(cx Context, d SubtypeData) bool {
+func (l *listOps) IsEmpty(cx Context, d SubtypeData) bool {
 	return listSubtypeIsEmpty(cx, d)
 }

--- a/semtypes/mapping_atomic_type.go
+++ b/semtypes/mapping_atomic_type.go
@@ -28,12 +28,12 @@ type MappingAtomicType struct {
 
 var _ atomicType = &MappingAtomicType{}
 
-func (this *MappingAtomicType) equals(other atomicType) bool {
+func (m *MappingAtomicType) equals(other atomicType) bool {
 	if other, ok := other.(*MappingAtomicType); ok {
-		if !this.Rest.equals(other.Rest) {
+		if !m.Rest.equals(other.Rest) {
 			return false
 		}
-		return slices.Equal(other.Names, this.Names) && slices.EqualFunc(other.Types, this.Types, func(a, b ComplexSemType) bool { return a.equals(&b) })
+		return slices.Equal(other.Names, m.Names) && slices.EqualFunc(other.Types, m.Types, func(a, b ComplexSemType) bool { return a.equals(&b) })
 	}
 	return false
 }
@@ -46,23 +46,23 @@ func mappingAtomicTypeFrom(names []string, types []ComplexSemType, rest *Complex
 	}
 }
 
-func (this *MappingAtomicType) atomKind() kind {
+func (m *MappingAtomicType) atomKind() kind {
 	return kind_MAPPING_ATOM
 }
 
-func (this *MappingAtomicType) FieldInnerVal(name string) SemType {
-	for i, n := range this.Names {
+func (m *MappingAtomicType) FieldInnerVal(name string) SemType {
+	for i, n := range m.Names {
 		if n == name {
-			return cellInnerVal(&this.Types[i])
+			return cellInnerVal(&m.Types[i])
 		}
 	}
-	return cellInnerVal(this.Rest)
+	return cellInnerVal(m.Rest)
 }
 
-func (this *MappingAtomicType) IsOptional(cx Context, name string) bool {
-	for i, n := range this.Names {
+func (m *MappingAtomicType) IsOptional(cx Context, name string) bool {
+	for i, n := range m.Names {
 		if n == name {
-			return IsSubtype(cx, UNDEF, cellInnerVal(&this.Types[i]))
+			return IsSubtype(cx, UNDEF, cellInnerVal(&m.Types[i]))
 		}
 	}
 	return true

--- a/semtypes/mapping_definition.go
+++ b/semtypes/mapping_definition.go
@@ -40,40 +40,40 @@ func NewMappingDefinition() MappingDefinition {
 	return this
 }
 
-func (this *MappingDefinition) GetSemType(env Env) SemType {
-	s := this.semType
+func (m *MappingDefinition) GetSemType(env Env) SemType {
+	s := m.semType
 	if s == nil {
 		rec := env.recMappingAtom()
-		this.rec = &rec
-		return this.createSemType(env, &rec)
+		m.rec = &rec
+		return m.createSemType(env, &rec)
 	} else {
 		return s
 	}
 }
 
-func (this *MappingDefinition) SetSemTypeToNever() {
-	this.semType = NEVER
+func (m *MappingDefinition) SetSemTypeToNever() {
+	m.semType = NEVER
 }
 
-func (this *MappingDefinition) Define(env Env, fields []CellField, rest *ComplexSemType) SemType {
-	sfh := this.splitFields(fields)
+func (m *MappingDefinition) Define(env Env, fields []CellField, rest *ComplexSemType) SemType {
+	sfh := m.splitFields(fields)
 	atomicType := mappingAtomicTypeFrom(sfh.Names, sfh.Types, rest)
 	var a atom
-	rec := this.rec
+	rec := m.rec
 	if rec != nil {
 		a = rec
 		env.setRecMappingAtomType(*rec, &atomicType)
 	} else {
 		a = new(env.mappingAtom(&atomicType))
 	}
-	return this.createSemType(env, a)
+	return m.createSemType(env, a)
 }
 
-func (this *MappingDefinition) DefineMappingTypeWrapped(env Env, fields []Field, rest SemType) SemType {
-	return this.DefineMappingTypeWrappedWithEnvFieldsSemTypeCellMutability(env, fields, rest, CellMutability_CELL_MUT_LIMITED)
+func (m *MappingDefinition) DefineMappingTypeWrapped(env Env, fields []Field, rest SemType) SemType {
+	return m.DefineMappingTypeWrappedWithEnvFieldsSemTypeCellMutability(env, fields, rest, CellMutability_CELL_MUT_LIMITED)
 }
 
-func (this *MappingDefinition) DefineMappingTypeWrappedWithEnvFieldsSemTypeCellMutability(env Env, fields []Field, rest SemType, mut CellMutability) SemType {
+func (m *MappingDefinition) DefineMappingTypeWrappedWithEnvFieldsSemTypeCellMutability(env Env, fields []Field, rest SemType, mut CellMutability) SemType {
 	var cellFields []CellField
 	for _, field := range fields {
 		ty := field.Ty
@@ -98,17 +98,17 @@ func (this *MappingDefinition) DefineMappingTypeWrappedWithEnvFieldsSemTypeCellM
 		restMut = mut
 	}
 	restCell := cellContainingWithEnvSemTypeCellMutability(env, Union(rest, UNDEF), restMut)
-	return this.Define(env, cellFields, restCell)
+	return m.Define(env, cellFields, restCell)
 }
 
-func (this *MappingDefinition) createSemType(env Env, atom atom) SemType {
+func (m *MappingDefinition) createSemType(env Env, atom atom) SemType {
 	bdd := bddAtom(atom)
 	s := getBasicSubtype(BTMapping, bdd)
-	this.semType = s
+	m.semType = s
 	return s
 }
 
-func (this *MappingDefinition) splitFields(fields []CellField) splitField {
+func (m *MappingDefinition) splitFields(fields []CellField) splitField {
 	sortedFields := make([]CellField, len(fields))
 	copy(sortedFields, fields)
 	// Arrays.sort(sortedFields, Comparator.comparing(MappingDefinition::fieldName))

--- a/semtypes/mapping_ops.go
+++ b/semtypes/mapping_ops.go
@@ -205,22 +205,22 @@ func newMappingOps() mappingOps {
 	return mappingOps{}
 }
 
-func (this *mappingOps) Union(d1 SubtypeData, d2 SubtypeData) SubtypeData {
+func (m *mappingOps) Union(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	return bddSubtypeUnion(d1, d2)
 }
 
-func (this *mappingOps) Intersect(d1 SubtypeData, d2 SubtypeData) SubtypeData {
+func (m *mappingOps) Intersect(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	return bddSubtypeIntersect(d1, d2)
 }
 
-func (this *mappingOps) Diff(d1 SubtypeData, d2 SubtypeData) SubtypeData {
+func (m *mappingOps) Diff(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	return bddSubtypeDiff(d1, d2)
 }
 
-func (this *mappingOps) complement(d SubtypeData) SubtypeData {
+func (m *mappingOps) complement(d SubtypeData) SubtypeData {
 	return bddSubtypeComplement(d)
 }
 
-func (this *mappingOps) IsEmpty(cx Context, d SubtypeData) bool {
+func (m *mappingOps) IsEmpty(cx Context, d SubtypeData) bool {
 	return mappingSubtypeIsEmpty(cx, d)
 }

--- a/semtypes/non_char_string_subtype.go
+++ b/semtypes/non_char_string_subtype.go
@@ -34,10 +34,10 @@ func nonCharStringSubtypeFrom(allowed bool, values []enumerableType[string]) non
 	return newNonCharStringSubtypeFromBoolEnumerableStrings(allowed, values)
 }
 
-func (this *nonCharStringSubtype) Allowed() bool {
-	return this.allowed
+func (n *nonCharStringSubtype) Allowed() bool {
+	return n.allowed
 }
 
-func (this *nonCharStringSubtype) Values() []enumerableType[string] {
-	return this.values
+func (n *nonCharStringSubtype) Values() []enumerableType[string] {
+	return n.values
 }

--- a/semtypes/object_definition.go
+++ b/semtypes/object_definition.go
@@ -59,7 +59,7 @@ func objectDefinitionDistinct(distinctId int) SemType {
 //	      FUNCTION value;
 //	   }
 //	}
-func (this *ObjectDefinition) Define(env Env, qualifiers ObjectQualifiers, members []Member) SemType {
+func (o *ObjectDefinition) Define(env Env, qualifiers ObjectQualifiers, members []Member) SemType {
 	common.Assert(objectDefinitionValidateMembers(members))
 	var mut CellMutability
 	if qualifiers.readonly {
@@ -75,8 +75,8 @@ func (this *ObjectDefinition) Define(env Env, qualifiers ObjectQualifiers, membe
 	var cellFields []CellField
 	cellFields = append(cellFields, memberStream...)
 	cellFields = append(cellFields, qualifierStream...)
-	mappingType := this.mappingDefinition.Define(env, cellFields, this.restMemberType(env, mut, qualifiers.readonly))
-	return this.objectContaining(mappingType)
+	mappingType := o.mappingDefinition.Define(env, cellFields, o.restMemberType(env, mut, qualifiers.readonly))
+	return o.objectContaining(mappingType)
 }
 
 func objectDefinitionValidateMembers(members []Member) bool {
@@ -91,12 +91,12 @@ func objectDefinitionValidateMembers(members []Member) bool {
 	return len(nameMap) == len(members)
 }
 
-func (this *ObjectDefinition) objectContaining(mappingType SemType) SemType {
+func (o *ObjectDefinition) objectContaining(mappingType SemType) SemType {
 	bdd := subtypeData(mappingType, BTMapping)
 	return createBasicSemType(BTObject, bdd)
 }
 
-func (this *ObjectDefinition) restMemberType(env Env, mut CellMutability, immutable bool) *ComplexSemType {
+func (o *ObjectDefinition) restMemberType(env Env, mut CellMutability, immutable bool) *ComplexSemType {
 	fieldDefn := NewMappingDefinition()
 	var fieldValueTy SemType
 	if immutable {
@@ -144,6 +144,6 @@ func memberField(env Env, member *Member, mut CellMutability) CellField {
 	return cellFieldFrom(member.Name, *cellContainingWithEnvSemTypeCellMutability(env, semtype, fieldMut))
 }
 
-func (this *ObjectDefinition) GetSemType(env Env) SemType {
-	return this.objectContaining(this.mappingDefinition.GetSemType(env))
+func (o *ObjectDefinition) GetSemType(env Env) SemType {
+	return o.objectContaining(o.mappingDefinition.GetSemType(env))
 }

--- a/semtypes/object_ops.go
+++ b/semtypes/object_ops.go
@@ -21,15 +21,15 @@ type objectOps struct {
 
 var _ BasicTypeOps = &objectOps{}
 
-func (this *objectOps) Diff(t1 SubtypeData, t2 SubtypeData) SubtypeData {
+func (o *objectOps) Diff(t1 SubtypeData, t2 SubtypeData) SubtypeData {
 	return bddSubtypeDiff(t1, t2)
 }
 
-func (this *objectOps) Intersect(t1 SubtypeData, t2 SubtypeData) SubtypeData {
+func (o *objectOps) Intersect(t1 SubtypeData, t2 SubtypeData) SubtypeData {
 	return bddSubtypeIntersect(t1, t2)
 }
 
-func (this *objectOps) Union(t1 SubtypeData, t2 SubtypeData) SubtypeData {
+func (o *objectOps) Union(t1 SubtypeData, t2 SubtypeData) SubtypeData {
 	return bddSubtypeUnion(t1, t2)
 }
 
@@ -46,14 +46,14 @@ func newObjectOps() objectOps {
 	return this
 }
 
-func (this *objectOps) complement(t SubtypeData) SubtypeData {
-	return this.objectSubTypeComplement(t)
+func (o *objectOps) complement(t SubtypeData) SubtypeData {
+	return o.objectSubTypeComplement(t)
 }
 
-func (this *objectOps) IsEmpty(cx Context, t SubtypeData) bool {
+func (o *objectOps) IsEmpty(cx Context, t SubtypeData) bool {
 	return objectSubTypeIsEmpty(cx, t)
 }
 
-func (this *objectOps) objectSubTypeComplement(t SubtypeData) SubtypeData {
+func (o *objectOps) objectSubTypeComplement(t SubtypeData) SubtypeData {
 	return bddSubtypeDiff(MAPPING_SUBTYPE_OBJECT, t)
 }

--- a/semtypes/predefined_type_env.go
+++ b/semtypes/predefined_type_env.go
@@ -116,18 +116,18 @@ func predefinedTypeEnvGetInstance() *predefinedTypeEnv {
 // Helper methods
 
 // addInitializedCellAtom adds a cellAtomicType to the initialized atoms list
-func (this *predefinedTypeEnv) addInitializedCellAtom(atom *cellAtomicType) {
-	addInitializedAtom(this, &this.initializedCellAtoms, atom)
+func (p *predefinedTypeEnv) addInitializedCellAtom(atom *cellAtomicType) {
+	addInitializedAtom(p, &p.initializedCellAtoms, atom)
 }
 
 // addInitializedListAtom adds a ListAtomicType to the initialized atoms list
-func (this *predefinedTypeEnv) addInitializedListAtom(atom *ListAtomicType) {
-	addInitializedAtom(this, &this.initializedListAtoms, atom)
+func (p *predefinedTypeEnv) addInitializedListAtom(atom *ListAtomicType) {
+	addInitializedAtom(p, &p.initializedListAtoms, atom)
 }
 
 // addInitializedMapAtom adds a MappingAtomicType to the initialized atoms list
-func (this *predefinedTypeEnv) addInitializedMapAtom(atom *MappingAtomicType) {
-	addInitializedAtom(this, &this.initializedMappingAtoms, atom)
+func (p *predefinedTypeEnv) addInitializedMapAtom(atom *MappingAtomicType) {
+	addInitializedAtom(p, &p.initializedMappingAtoms, atom)
 }
 
 // addInitializedAtom is a generic function to add an atom to the atoms list with an index
@@ -137,18 +137,18 @@ func addInitializedAtom[E atomicType](env *predefinedTypeEnv, atoms *[]initializ
 }
 
 // cellAtomIndex returns the index of a cellAtomicType in the initialized atoms list
-func (this *predefinedTypeEnv) cellAtomIndex(atom *cellAtomicType) int {
-	return atomIndex(this.initializedCellAtoms, atom)
+func (p *predefinedTypeEnv) cellAtomIndex(atom *cellAtomicType) int {
+	return atomIndex(p.initializedCellAtoms, atom)
 }
 
 // listAtomIndex returns the index of a ListAtomicType in the initialized atoms list
-func (this *predefinedTypeEnv) listAtomIndex(atom *ListAtomicType) int {
-	return atomIndex(this.initializedListAtoms, atom)
+func (p *predefinedTypeEnv) listAtomIndex(atom *ListAtomicType) int {
+	return atomIndex(p.initializedListAtoms, atom)
 }
 
 // mappingAtomIndex returns the index of a MappingAtomicType in the initialized atoms list
-func (this *predefinedTypeEnv) mappingAtomIndex(atom *MappingAtomicType) int {
-	return atomIndex(this.initializedMappingAtoms, atom)
+func (p *predefinedTypeEnv) mappingAtomIndex(atom *MappingAtomicType) int {
+	return atomIndex(p.initializedMappingAtoms, atom)
 }
 
 // atomIndex is a generic function to find the index of an atom in the atoms list
@@ -165,502 +165,502 @@ func atomIndex[E atomicType](initializedAtoms []initializedTypeAtom[E], atom E) 
 // Getter methods
 
 // cellAtomicVal returns the cellAtomicType for VAL with limited mutability
-func (this *predefinedTypeEnv) cellAtomicVal() *cellAtomicType {
-	if this._cellAtomicVal == nil {
+func (p *predefinedTypeEnv) cellAtomicVal() *cellAtomicType {
+	if p._cellAtomicVal == nil {
 		val := cellAtomicTypeFrom(VAL, CellMutability_CELL_MUT_LIMITED)
-		this._cellAtomicVal = &val
-		this.addInitializedCellAtom(&val)
+		p._cellAtomicVal = &val
+		p.addInitializedCellAtom(&val)
 	}
-	return this._cellAtomicVal
+	return p._cellAtomicVal
 }
 
 // atomCellVal returns the typeAtom for cell val
-func (this *predefinedTypeEnv) atomCellVal() *typeAtom {
-	if this._atomCellVal == nil {
-		cellAtomicVal := this.cellAtomicVal()
-		atomCellVal := createTypeAtom(this.cellAtomIndex(cellAtomicVal), cellAtomicVal)
-		this._atomCellVal = &atomCellVal
+func (p *predefinedTypeEnv) atomCellVal() *typeAtom {
+	if p._atomCellVal == nil {
+		cellAtomicVal := p.cellAtomicVal()
+		atomCellVal := createTypeAtom(p.cellAtomIndex(cellAtomicVal), cellAtomicVal)
+		p._atomCellVal = &atomCellVal
 	}
-	return this._atomCellVal
+	return p._atomCellVal
 }
 
 // cellAtomicNever returns the cellAtomicType for NEVER with limited mutability
-func (this *predefinedTypeEnv) cellAtomicNever() *cellAtomicType {
-	if this._cellAtomicNever == nil {
+func (p *predefinedTypeEnv) cellAtomicNever() *cellAtomicType {
+	if p._cellAtomicNever == nil {
 		val := cellAtomicTypeFrom(NEVER, CellMutability_CELL_MUT_LIMITED)
-		this._cellAtomicNever = &val
-		this.addInitializedCellAtom(&val)
+		p._cellAtomicNever = &val
+		p.addInitializedCellAtom(&val)
 	}
-	return this._cellAtomicNever
+	return p._cellAtomicNever
 }
 
 // atomCellNever returns the typeAtom for cell never
-func (this *predefinedTypeEnv) atomCellNever() *typeAtom {
-	if this._atomCellNever == nil {
-		cellAtomicNever := this.cellAtomicNever()
-		atomCellNever := createTypeAtom(this.cellAtomIndex(cellAtomicNever), cellAtomicNever)
-		this._atomCellNever = &atomCellNever
+func (p *predefinedTypeEnv) atomCellNever() *typeAtom {
+	if p._atomCellNever == nil {
+		cellAtomicNever := p.cellAtomicNever()
+		atomCellNever := createTypeAtom(p.cellAtomIndex(cellAtomicNever), cellAtomicNever)
+		p._atomCellNever = &atomCellNever
 	}
-	return this._atomCellNever
+	return p._atomCellNever
 }
 
 // cellAtomicInner returns the cellAtomicType for INNER with limited mutability
-func (this *predefinedTypeEnv) cellAtomicInner() *cellAtomicType {
-	if this._callAtomicInner == nil {
+func (p *predefinedTypeEnv) cellAtomicInner() *cellAtomicType {
+	if p._callAtomicInner == nil {
 		val := cellAtomicTypeFrom(INNER, CellMutability_CELL_MUT_LIMITED)
-		this._callAtomicInner = &val
-		this.addInitializedCellAtom(&val)
+		p._callAtomicInner = &val
+		p.addInitializedCellAtom(&val)
 	}
-	return this._callAtomicInner
+	return p._callAtomicInner
 }
 
 // atomCellInner returns the typeAtom for cell inner
-func (this *predefinedTypeEnv) atomCellInner() *typeAtom {
-	if this._atomCellInner == nil {
-		cellAtomicInner := this.cellAtomicInner()
-		atomCellInner := createTypeAtom(this.cellAtomIndex(cellAtomicInner), cellAtomicInner)
-		this._atomCellInner = &atomCellInner
+func (p *predefinedTypeEnv) atomCellInner() *typeAtom {
+	if p._atomCellInner == nil {
+		cellAtomicInner := p.cellAtomicInner()
+		atomCellInner := createTypeAtom(p.cellAtomIndex(cellAtomicInner), cellAtomicInner)
+		p._atomCellInner = &atomCellInner
 	}
-	return this._atomCellInner
+	return p._atomCellInner
 }
 
 // cellAtomicInnerMapping returns the cellAtomicType for union(MAPPING, UNDEF) with limited mutability
-func (this *predefinedTypeEnv) cellAtomicInnerMapping() *cellAtomicType {
-	if this._cellAtomicInnerMapping == nil {
+func (p *predefinedTypeEnv) cellAtomicInnerMapping() *cellAtomicType {
+	if p._cellAtomicInnerMapping == nil {
 		val := cellAtomicTypeFrom(Union(MAPPING, UNDEF), CellMutability_CELL_MUT_LIMITED)
-		this._cellAtomicInnerMapping = &val
-		this.addInitializedCellAtom(&val)
+		p._cellAtomicInnerMapping = &val
+		p.addInitializedCellAtom(&val)
 	}
-	return this._cellAtomicInnerMapping
+	return p._cellAtomicInnerMapping
 }
 
 // atomCellInnerMapping returns the typeAtom for cell inner mapping
-func (this *predefinedTypeEnv) atomCellInnerMapping() *typeAtom {
-	if this._atomCellInnerMapping == nil {
-		cellAtomicInnerMapping := this.cellAtomicInnerMapping()
-		atomCellInnerMapping := createTypeAtom(this.cellAtomIndex(cellAtomicInnerMapping), cellAtomicInnerMapping)
-		this._atomCellInnerMapping = &atomCellInnerMapping
+func (p *predefinedTypeEnv) atomCellInnerMapping() *typeAtom {
+	if p._atomCellInnerMapping == nil {
+		cellAtomicInnerMapping := p.cellAtomicInnerMapping()
+		atomCellInnerMapping := createTypeAtom(p.cellAtomIndex(cellAtomicInnerMapping), cellAtomicInnerMapping)
+		p._atomCellInnerMapping = &atomCellInnerMapping
 	}
-	return this._atomCellInnerMapping
+	return p._atomCellInnerMapping
 }
 
 // cellAtomicInnerMappingRO returns the cellAtomicType for union(MAPPING_RO, UNDEF) with limited mutability
-func (this *predefinedTypeEnv) cellAtomicInnerMappingRO() *cellAtomicType {
-	if this._cellAtomicInnerMappingRO == nil {
+func (p *predefinedTypeEnv) cellAtomicInnerMappingRO() *cellAtomicType {
+	if p._cellAtomicInnerMappingRO == nil {
 		val := cellAtomicTypeFrom(Union(MAPPING_RO, UNDEF), CellMutability_CELL_MUT_LIMITED)
-		this._cellAtomicInnerMappingRO = &val
-		this.addInitializedCellAtom(&val)
+		p._cellAtomicInnerMappingRO = &val
+		p.addInitializedCellAtom(&val)
 	}
-	return this._cellAtomicInnerMappingRO
+	return p._cellAtomicInnerMappingRO
 }
 
 // atomCellInnerMappingRO returns the typeAtom for cell inner mapping RO
-func (this *predefinedTypeEnv) atomCellInnerMappingRO() *typeAtom {
-	if this._atomCellInnerMappingRO == nil {
-		cellAtomicInnerMappingRO := this.cellAtomicInnerMappingRO()
-		atomCellInnerMappingRO := createTypeAtom(this.cellAtomIndex(cellAtomicInnerMappingRO), cellAtomicInnerMappingRO)
-		this._atomCellInnerMappingRO = &atomCellInnerMappingRO
+func (p *predefinedTypeEnv) atomCellInnerMappingRO() *typeAtom {
+	if p._atomCellInnerMappingRO == nil {
+		cellAtomicInnerMappingRO := p.cellAtomicInnerMappingRO()
+		atomCellInnerMappingRO := createTypeAtom(p.cellAtomIndex(cellAtomicInnerMappingRO), cellAtomicInnerMappingRO)
+		p._atomCellInnerMappingRO = &atomCellInnerMappingRO
 	}
-	return this._atomCellInnerMappingRO
+	return p._atomCellInnerMappingRO
 }
 
 // listAtomicMapping returns the ListAtomicType for empty fixed length array with CELL_SEMTYPE_INNER_MAPPING
-func (this *predefinedTypeEnv) listAtomicMapping() *ListAtomicType {
-	if this._listAtomicMapping == nil {
+func (p *predefinedTypeEnv) listAtomicMapping() *ListAtomicType {
+	if p._listAtomicMapping == nil {
 		val := listAtomicTypeFrom(fixedLengthArrayEmpty(), CELL_SEMTYPE_INNER_MAPPING)
-		this._listAtomicMapping = &val
-		this.addInitializedListAtom(&val)
+		p._listAtomicMapping = &val
+		p.addInitializedListAtom(&val)
 	}
-	return this._listAtomicMapping
+	return p._listAtomicMapping
 }
 
 // atomListMapping returns the typeAtom for list mapping
-func (this *predefinedTypeEnv) atomListMapping() *typeAtom {
-	if this._atomListMapping == nil {
-		listAtomicMapping := this.listAtomicMapping()
-		atomListMapping := createTypeAtom(this.listAtomIndex(listAtomicMapping), listAtomicMapping)
-		this._atomListMapping = &atomListMapping
+func (p *predefinedTypeEnv) atomListMapping() *typeAtom {
+	if p._atomListMapping == nil {
+		listAtomicMapping := p.listAtomicMapping()
+		atomListMapping := createTypeAtom(p.listAtomIndex(listAtomicMapping), listAtomicMapping)
+		p._atomListMapping = &atomListMapping
 	}
-	return this._atomListMapping
+	return p._atomListMapping
 }
 
 // listAtomicMappingRO returns the ListAtomicType for empty fixed length array with CELL_SEMTYPE_INNER_MAPPING_RO
-func (this *predefinedTypeEnv) listAtomicMappingRO() *ListAtomicType {
-	if this._listAtomicMappingRO == nil {
+func (p *predefinedTypeEnv) listAtomicMappingRO() *ListAtomicType {
+	if p._listAtomicMappingRO == nil {
 		val := listAtomicTypeFrom(fixedLengthArrayEmpty(), CELL_SEMTYPE_INNER_MAPPING_RO)
-		this._listAtomicMappingRO = &val
-		this.addInitializedListAtom(&val)
+		p._listAtomicMappingRO = &val
+		p.addInitializedListAtom(&val)
 	}
-	return this._listAtomicMappingRO
+	return p._listAtomicMappingRO
 }
 
 // atomListMappingRO returns the typeAtom for list mapping RO
-func (this *predefinedTypeEnv) atomListMappingRO() *typeAtom {
-	if this._atomListMappingRO == nil {
-		listAtomicMappingRO := this.listAtomicMappingRO()
-		atomListMappingRO := createTypeAtom(this.listAtomIndex(listAtomicMappingRO), listAtomicMappingRO)
-		this._atomListMappingRO = &atomListMappingRO
+func (p *predefinedTypeEnv) atomListMappingRO() *typeAtom {
+	if p._atomListMappingRO == nil {
+		listAtomicMappingRO := p.listAtomicMappingRO()
+		atomListMappingRO := createTypeAtom(p.listAtomIndex(listAtomicMappingRO), listAtomicMappingRO)
+		p._atomListMappingRO = &atomListMappingRO
 	}
-	return this._atomListMappingRO
+	return p._atomListMappingRO
 }
 
 // cellAtomicInnerRO returns the cellAtomicType for INNER_READONLY with no mutability
-func (this *predefinedTypeEnv) cellAtomicInnerRO() *cellAtomicType {
-	if this._cellAtomicInnerRO == nil {
+func (p *predefinedTypeEnv) cellAtomicInnerRO() *cellAtomicType {
+	if p._cellAtomicInnerRO == nil {
 		val := cellAtomicTypeFrom(INNER_READONLY, CellMutability_CELL_MUT_NONE)
-		this._cellAtomicInnerRO = &val
-		this.addInitializedCellAtom(&val)
+		p._cellAtomicInnerRO = &val
+		p.addInitializedCellAtom(&val)
 	}
-	return this._cellAtomicInnerRO
+	return p._cellAtomicInnerRO
 }
 
 // atomCellInnerRO returns the typeAtom for cell inner RO
-func (this *predefinedTypeEnv) atomCellInnerRO() *typeAtom {
-	if this._atomCellInnerRO == nil {
-		cellAtomicInnerRO := this.cellAtomicInnerRO()
-		atomCellInnerRO := createTypeAtom(this.cellAtomIndex(cellAtomicInnerRO), cellAtomicInnerRO)
-		this._atomCellInnerRO = &atomCellInnerRO
+func (p *predefinedTypeEnv) atomCellInnerRO() *typeAtom {
+	if p._atomCellInnerRO == nil {
+		cellAtomicInnerRO := p.cellAtomicInnerRO()
+		atomCellInnerRO := createTypeAtom(p.cellAtomIndex(cellAtomicInnerRO), cellAtomicInnerRO)
+		p._atomCellInnerRO = &atomCellInnerRO
 	}
-	return this._atomCellInnerRO
+	return p._atomCellInnerRO
 }
 
 // cellAtomicUndef returns the cellAtomicType for UNDEF with no mutability
-func (this *predefinedTypeEnv) cellAtomicUndef() *cellAtomicType {
-	if this._cellAtomicUndef == nil {
+func (p *predefinedTypeEnv) cellAtomicUndef() *cellAtomicType {
+	if p._cellAtomicUndef == nil {
 		val := cellAtomicTypeFrom(UNDEF, CellMutability_CELL_MUT_NONE)
-		this._cellAtomicUndef = &val
-		this.addInitializedCellAtom(&val)
+		p._cellAtomicUndef = &val
+		p.addInitializedCellAtom(&val)
 	}
-	return this._cellAtomicUndef
+	return p._cellAtomicUndef
 }
 
 // atomCellUndef returns the typeAtom for cell undef
-func (this *predefinedTypeEnv) atomCellUndef() *typeAtom {
-	if this._atomCellUndef == nil {
-		cellAtomicUndef := this.cellAtomicUndef()
-		atomCellUndef := createTypeAtom(this.cellAtomIndex(cellAtomicUndef), cellAtomicUndef)
-		this._atomCellUndef = &atomCellUndef
+func (p *predefinedTypeEnv) atomCellUndef() *typeAtom {
+	if p._atomCellUndef == nil {
+		cellAtomicUndef := p.cellAtomicUndef()
+		atomCellUndef := createTypeAtom(p.cellAtomIndex(cellAtomicUndef), cellAtomicUndef)
+		p._atomCellUndef = &atomCellUndef
 	}
-	return this._atomCellUndef
+	return p._atomCellUndef
 }
 
 // listAtomicTwoElement returns the ListAtomicType for two-element list with CELL_SEMTYPE_VAL and CELL_SEMTYPE_UNDEF
-func (this *predefinedTypeEnv) listAtomicTwoElement() *ListAtomicType {
-	if this._listAtomicTwoElement == nil {
+func (p *predefinedTypeEnv) listAtomicTwoElement() *ListAtomicType {
+	if p._listAtomicTwoElement == nil {
 		val := listAtomicTypeFrom(fixedLengthArrayFrom([]ComplexSemType{*CELL_SEMTYPE_VAL}, 2), CELL_SEMTYPE_UNDEF)
-		this._listAtomicTwoElement = &val
-		this.addInitializedListAtom(&val)
+		p._listAtomicTwoElement = &val
+		p.addInitializedListAtom(&val)
 	}
-	return this._listAtomicTwoElement
+	return p._listAtomicTwoElement
 }
 
 // atomListTwoElement returns the typeAtom for list two element
-func (this *predefinedTypeEnv) atomListTwoElement() *typeAtom {
-	if this._atomListTwoElement == nil {
-		listAtomicTwoElement := this.listAtomicTwoElement()
-		atomListTwoElement := createTypeAtom(this.listAtomIndex(listAtomicTwoElement), listAtomicTwoElement)
-		this._atomListTwoElement = &atomListTwoElement
+func (p *predefinedTypeEnv) atomListTwoElement() *typeAtom {
+	if p._atomListTwoElement == nil {
+		listAtomicTwoElement := p.listAtomicTwoElement()
+		atomListTwoElement := createTypeAtom(p.listAtomIndex(listAtomicTwoElement), listAtomicTwoElement)
+		p._atomListTwoElement = &atomListTwoElement
 	}
-	return this._atomListTwoElement
+	return p._atomListTwoElement
 }
 
 // cellAtomicValRO returns the cellAtomicType for VAL_READONLY with no mutability
-func (this *predefinedTypeEnv) cellAtomicValRO() *cellAtomicType {
-	if this._cellAtomicValRO == nil {
+func (p *predefinedTypeEnv) cellAtomicValRO() *cellAtomicType {
+	if p._cellAtomicValRO == nil {
 		val := cellAtomicTypeFrom(VAL_READONLY, CellMutability_CELL_MUT_NONE)
-		this._cellAtomicValRO = &val
-		this.addInitializedCellAtom(&val)
+		p._cellAtomicValRO = &val
+		p.addInitializedCellAtom(&val)
 	}
-	return this._cellAtomicValRO
+	return p._cellAtomicValRO
 }
 
 // atomCellValRO returns the typeAtom for cell val RO
-func (this *predefinedTypeEnv) atomCellValRO() *typeAtom {
-	if this._atomCellValRO == nil {
-		cellAtomicValRO := this.cellAtomicValRO()
-		atomCellValRO := createTypeAtom(this.cellAtomIndex(cellAtomicValRO), cellAtomicValRO)
-		this._atomCellValRO = &atomCellValRO
+func (p *predefinedTypeEnv) atomCellValRO() *typeAtom {
+	if p._atomCellValRO == nil {
+		cellAtomicValRO := p.cellAtomicValRO()
+		atomCellValRO := createTypeAtom(p.cellAtomIndex(cellAtomicValRO), cellAtomicValRO)
+		p._atomCellValRO = &atomCellValRO
 	}
-	return this._atomCellValRO
+	return p._atomCellValRO
 }
 
 // mappingAtomicObjectMemberRO returns the MappingAtomicType for object member RO
-func (this *predefinedTypeEnv) mappingAtomicObjectMemberRO() *MappingAtomicType {
-	if this._mappingAtomicObjectMemberRO == nil {
+func (p *predefinedTypeEnv) mappingAtomicObjectMemberRO() *MappingAtomicType {
+	if p._mappingAtomicObjectMemberRO == nil {
 		val := mappingAtomicTypeFrom(
 			[]string{"kind", "value", "visibility"},
 			[]ComplexSemType{*CELL_SEMTYPE_OBJECT_MEMBER_KIND, *CELL_SEMTYPE_VAL_RO, *CELL_SEMTYPE_OBJECT_MEMBER_VISIBILITY},
 			CELL_SEMTYPE_UNDEF)
-		this._mappingAtomicObjectMemberRO = &val
-		this.addInitializedMapAtom(&val)
+		p._mappingAtomicObjectMemberRO = &val
+		p.addInitializedMapAtom(&val)
 	}
-	return this._mappingAtomicObjectMemberRO
+	return p._mappingAtomicObjectMemberRO
 }
 
 // atomMappingObjectMemberRO returns the typeAtom for mapping object member RO
-func (this *predefinedTypeEnv) atomMappingObjectMemberRO() *typeAtom {
-	if this._atomMappingObjectMemberRO == nil {
-		mappingAtomicObjectMemberRO := this.mappingAtomicObjectMemberRO()
-		atomMappingObjectMemberRO := createTypeAtom(this.mappingAtomIndex(mappingAtomicObjectMemberRO), mappingAtomicObjectMemberRO)
-		this._atomMappingObjectMemberRO = &atomMappingObjectMemberRO
+func (p *predefinedTypeEnv) atomMappingObjectMemberRO() *typeAtom {
+	if p._atomMappingObjectMemberRO == nil {
+		mappingAtomicObjectMemberRO := p.mappingAtomicObjectMemberRO()
+		atomMappingObjectMemberRO := createTypeAtom(p.mappingAtomIndex(mappingAtomicObjectMemberRO), mappingAtomicObjectMemberRO)
+		p._atomMappingObjectMemberRO = &atomMappingObjectMemberRO
 	}
-	return this._atomMappingObjectMemberRO
+	return p._atomMappingObjectMemberRO
 }
 
 // cellAtomicObjectMemberRO returns the cellAtomicType for object member RO
-func (this *predefinedTypeEnv) cellAtomicObjectMemberRO() *cellAtomicType {
-	if this._cellAtomicObjectMemberRO == nil {
+func (p *predefinedTypeEnv) cellAtomicObjectMemberRO() *cellAtomicType {
+	if p._cellAtomicObjectMemberRO == nil {
 		val := cellAtomicTypeFrom(MAPPING_SEMTYPE_OBJECT_MEMBER_RO, CellMutability_CELL_MUT_NONE)
-		this._cellAtomicObjectMemberRO = &val
-		this.addInitializedCellAtom(&val)
+		p._cellAtomicObjectMemberRO = &val
+		p.addInitializedCellAtom(&val)
 	}
-	return this._cellAtomicObjectMemberRO
+	return p._cellAtomicObjectMemberRO
 }
 
 // atomCellObjectMemberRO returns the typeAtom for cell object member RO
-func (this *predefinedTypeEnv) atomCellObjectMemberRO() *typeAtom {
-	if this._atomCellObjectMemberRO == nil {
-		cellAtomicObjectMemberRO := this.cellAtomicObjectMemberRO()
-		atomCellObjectMemberRO := createTypeAtom(this.cellAtomIndex(cellAtomicObjectMemberRO), cellAtomicObjectMemberRO)
-		this._atomCellObjectMemberRO = &atomCellObjectMemberRO
+func (p *predefinedTypeEnv) atomCellObjectMemberRO() *typeAtom {
+	if p._atomCellObjectMemberRO == nil {
+		cellAtomicObjectMemberRO := p.cellAtomicObjectMemberRO()
+		atomCellObjectMemberRO := createTypeAtom(p.cellAtomIndex(cellAtomicObjectMemberRO), cellAtomicObjectMemberRO)
+		p._atomCellObjectMemberRO = &atomCellObjectMemberRO
 	}
-	return this._atomCellObjectMemberRO
+	return p._atomCellObjectMemberRO
 }
 
 // cellAtomicObjectMemberKind returns the cellAtomicType for object member kind
-func (this *predefinedTypeEnv) cellAtomicObjectMemberKind() *cellAtomicType {
-	if this._cellAtomicObjectMemberKind == nil {
+func (p *predefinedTypeEnv) cellAtomicObjectMemberKind() *cellAtomicType {
+	if p._cellAtomicObjectMemberKind == nil {
 		val := cellAtomicTypeFrom(Union(StringConst("field"), StringConst("method")), CellMutability_CELL_MUT_NONE)
-		this._cellAtomicObjectMemberKind = &val
-		this.addInitializedCellAtom(&val)
+		p._cellAtomicObjectMemberKind = &val
+		p.addInitializedCellAtom(&val)
 	}
-	return this._cellAtomicObjectMemberKind
+	return p._cellAtomicObjectMemberKind
 }
 
 // atomCellObjectMemberKind returns the typeAtom for cell object member kind
-func (this *predefinedTypeEnv) atomCellObjectMemberKind() *typeAtom {
-	if this._atomCellObjectMemberKind == nil {
-		cellAtomicObjectMemberKind := this.cellAtomicObjectMemberKind()
-		atomCellObjectMemberKind := createTypeAtom(this.cellAtomIndex(cellAtomicObjectMemberKind), cellAtomicObjectMemberKind)
-		this._atomCellObjectMemberKind = &atomCellObjectMemberKind
+func (p *predefinedTypeEnv) atomCellObjectMemberKind() *typeAtom {
+	if p._atomCellObjectMemberKind == nil {
+		cellAtomicObjectMemberKind := p.cellAtomicObjectMemberKind()
+		atomCellObjectMemberKind := createTypeAtom(p.cellAtomIndex(cellAtomicObjectMemberKind), cellAtomicObjectMemberKind)
+		p._atomCellObjectMemberKind = &atomCellObjectMemberKind
 	}
-	return this._atomCellObjectMemberKind
+	return p._atomCellObjectMemberKind
 }
 
 // cellAtomicObjectMemberVisibility returns the cellAtomicType for object member visibility
-func (this *predefinedTypeEnv) cellAtomicObjectMemberVisibility() *cellAtomicType {
-	if this._cellAtomicObjectMemberVisibility == nil {
+func (p *predefinedTypeEnv) cellAtomicObjectMemberVisibility() *cellAtomicType {
+	if p._cellAtomicObjectMemberVisibility == nil {
 		val := cellAtomicTypeFrom(Union(StringConst("public"), StringConst("private")), CellMutability_CELL_MUT_NONE)
-		this._cellAtomicObjectMemberVisibility = &val
-		this.addInitializedCellAtom(&val)
+		p._cellAtomicObjectMemberVisibility = &val
+		p.addInitializedCellAtom(&val)
 	}
-	return this._cellAtomicObjectMemberVisibility
+	return p._cellAtomicObjectMemberVisibility
 }
 
 // atomCellObjectMemberVisibility returns the typeAtom for cell object member visibility
-func (this *predefinedTypeEnv) atomCellObjectMemberVisibility() *typeAtom {
-	if this._atomCellObjectMemberVisibility == nil {
-		cellAtomicObjectMemberVisibility := this.cellAtomicObjectMemberVisibility()
-		atomCellObjectMemberVisibility := createTypeAtom(this.cellAtomIndex(cellAtomicObjectMemberVisibility), cellAtomicObjectMemberVisibility)
-		this._atomCellObjectMemberVisibility = &atomCellObjectMemberVisibility
+func (p *predefinedTypeEnv) atomCellObjectMemberVisibility() *typeAtom {
+	if p._atomCellObjectMemberVisibility == nil {
+		cellAtomicObjectMemberVisibility := p.cellAtomicObjectMemberVisibility()
+		atomCellObjectMemberVisibility := createTypeAtom(p.cellAtomIndex(cellAtomicObjectMemberVisibility), cellAtomicObjectMemberVisibility)
+		p._atomCellObjectMemberVisibility = &atomCellObjectMemberVisibility
 	}
-	return this._atomCellObjectMemberVisibility
+	return p._atomCellObjectMemberVisibility
 }
 
 // mappingAtomicObjectMember returns the MappingAtomicType for object member
-func (this *predefinedTypeEnv) mappingAtomicObjectMember() *MappingAtomicType {
-	if this._mappingAtomicObjectMember == nil {
+func (p *predefinedTypeEnv) mappingAtomicObjectMember() *MappingAtomicType {
+	if p._mappingAtomicObjectMember == nil {
 		val := mappingAtomicTypeFrom(
 			[]string{"kind", "value", "visibility"},
 			[]ComplexSemType{*CELL_SEMTYPE_OBJECT_MEMBER_KIND, *CELL_SEMTYPE_VAL, *CELL_SEMTYPE_OBJECT_MEMBER_VISIBILITY},
 			CELL_SEMTYPE_UNDEF)
-		this._mappingAtomicObjectMember = &val
-		this.addInitializedMapAtom(&val)
+		p._mappingAtomicObjectMember = &val
+		p.addInitializedMapAtom(&val)
 	}
-	return this._mappingAtomicObjectMember
+	return p._mappingAtomicObjectMember
 }
 
 // atomMappingObjectMember returns the typeAtom for mapping object member
-func (this *predefinedTypeEnv) atomMappingObjectMember() *typeAtom {
-	if this._atomMappingObjectMember == nil {
-		mappingAtomicObjectMember := this.mappingAtomicObjectMember()
-		atomMappingObjectMember := createTypeAtom(this.mappingAtomIndex(mappingAtomicObjectMember), mappingAtomicObjectMember)
-		this._atomMappingObjectMember = &atomMappingObjectMember
+func (p *predefinedTypeEnv) atomMappingObjectMember() *typeAtom {
+	if p._atomMappingObjectMember == nil {
+		mappingAtomicObjectMember := p.mappingAtomicObjectMember()
+		atomMappingObjectMember := createTypeAtom(p.mappingAtomIndex(mappingAtomicObjectMember), mappingAtomicObjectMember)
+		p._atomMappingObjectMember = &atomMappingObjectMember
 	}
-	return this._atomMappingObjectMember
+	return p._atomMappingObjectMember
 }
 
 // cellAtomicObjectMember returns the cellAtomicType for object member
-func (this *predefinedTypeEnv) cellAtomicObjectMember() *cellAtomicType {
-	if this._cellAtomicObjectMember == nil {
+func (p *predefinedTypeEnv) cellAtomicObjectMember() *cellAtomicType {
+	if p._cellAtomicObjectMember == nil {
 		val := cellAtomicTypeFrom(MAPPING_SEMTYPE_OBJECT_MEMBER, CellMutability_CELL_MUT_UNLIMITED)
-		this._cellAtomicObjectMember = &val
-		this.addInitializedCellAtom(&val)
+		p._cellAtomicObjectMember = &val
+		p.addInitializedCellAtom(&val)
 	}
-	return this._cellAtomicObjectMember
+	return p._cellAtomicObjectMember
 }
 
 // atomCellObjectMember returns the typeAtom for cell object member
-func (this *predefinedTypeEnv) atomCellObjectMember() *typeAtom {
-	if this._atomCellObjectMember == nil {
-		cellAtomicObjectMember := this.cellAtomicObjectMember()
-		atomCellObjectMember := createTypeAtom(this.cellAtomIndex(cellAtomicObjectMember), cellAtomicObjectMember)
-		this._atomCellObjectMember = &atomCellObjectMember
+func (p *predefinedTypeEnv) atomCellObjectMember() *typeAtom {
+	if p._atomCellObjectMember == nil {
+		cellAtomicObjectMember := p.cellAtomicObjectMember()
+		atomCellObjectMember := createTypeAtom(p.cellAtomIndex(cellAtomicObjectMember), cellAtomicObjectMember)
+		p._atomCellObjectMember = &atomCellObjectMember
 	}
-	return this._atomCellObjectMember
+	return p._atomCellObjectMember
 }
 
 // mappingAtomicObject returns the MappingAtomicType for object
-func (this *predefinedTypeEnv) mappingAtomicObject() *MappingAtomicType {
-	if this._mappingAtomicObject == nil {
+func (p *predefinedTypeEnv) mappingAtomicObject() *MappingAtomicType {
+	if p._mappingAtomicObject == nil {
 		val := mappingAtomicTypeFrom(
 			[]string{"$qualifiers"},
 			[]ComplexSemType{*CELL_SEMTYPE_OBJECT_QUALIFIER},
 			CELL_SEMTYPE_OBJECT_MEMBER)
-		this._mappingAtomicObject = &val
-		this.addInitializedMapAtom(&val)
+		p._mappingAtomicObject = &val
+		p.addInitializedMapAtom(&val)
 	}
-	return this._mappingAtomicObject
+	return p._mappingAtomicObject
 }
 
 // atomMappingObject returns the typeAtom for mapping object
-func (this *predefinedTypeEnv) atomMappingObject() *typeAtom {
-	if this._atomMappingObject == nil {
-		mappingAtomicObject := this.mappingAtomicObject()
-		atomMappingObject := createTypeAtom(this.mappingAtomIndex(mappingAtomicObject), mappingAtomicObject)
-		this._atomMappingObject = &atomMappingObject
+func (p *predefinedTypeEnv) atomMappingObject() *typeAtom {
+	if p._atomMappingObject == nil {
+		mappingAtomicObject := p.mappingAtomicObject()
+		atomMappingObject := createTypeAtom(p.mappingAtomIndex(mappingAtomicObject), mappingAtomicObject)
+		p._atomMappingObject = &atomMappingObject
 	}
-	return this._atomMappingObject
+	return p._atomMappingObject
 }
 
 // listAtomicRO returns the ListAtomicType for read-only list
-func (this *predefinedTypeEnv) listAtomicRO() *ListAtomicType {
-	if this._listAtomicRO == nil {
+func (p *predefinedTypeEnv) listAtomicRO() *ListAtomicType {
+	if p._listAtomicRO == nil {
 		val := listAtomicTypeFrom(fixedLengthArrayEmpty(), CELL_SEMTYPE_INNER_RO)
-		this._listAtomicRO = &val
-		this.initializedRecListAtoms = append(this.initializedRecListAtoms, &val)
+		p._listAtomicRO = &val
+		p.initializedRecListAtoms = append(p.initializedRecListAtoms, &val)
 	}
-	return this._listAtomicRO
+	return p._listAtomicRO
 }
 
 // mappingAtomicRO returns the MappingAtomicType for read-only mapping
-func (this *predefinedTypeEnv) mappingAtomicRO() *MappingAtomicType {
-	if this._mappingAtomicRO == nil {
+func (p *predefinedTypeEnv) mappingAtomicRO() *MappingAtomicType {
+	if p._mappingAtomicRO == nil {
 		val := mappingAtomicTypeFrom([]string{}, []ComplexSemType{}, CELL_SEMTYPE_INNER_RO)
-		this._mappingAtomicRO = &val
-		this.initializedRecMappingAtoms = append(this.initializedRecMappingAtoms, &val)
+		p._mappingAtomicRO = &val
+		p.initializedRecMappingAtoms = append(p.initializedRecMappingAtoms, &val)
 	}
-	return this._mappingAtomicRO
+	return p._mappingAtomicRO
 }
 
 // getMappingAtomicObjectRO returns the MappingAtomicType for read-only object
-func (this *predefinedTypeEnv) getMappingAtomicObjectRO() *MappingAtomicType {
-	if this._mappingAtomicObjectRO == nil {
+func (p *predefinedTypeEnv) getMappingAtomicObjectRO() *MappingAtomicType {
+	if p._mappingAtomicObjectRO == nil {
 		val := mappingAtomicTypeFrom(
 			[]string{"$qualifiers"},
 			[]ComplexSemType{*CELL_SEMTYPE_OBJECT_QUALIFIER},
 			CELL_SEMTYPE_OBJECT_MEMBER_RO)
-		this._mappingAtomicObjectRO = &val
-		this.initializedRecMappingAtoms = append(this.initializedRecMappingAtoms, &val)
+		p._mappingAtomicObjectRO = &val
+		p.initializedRecMappingAtoms = append(p.initializedRecMappingAtoms, &val)
 	}
-	return this._mappingAtomicObjectRO
+	return p._mappingAtomicObjectRO
 }
 
 // cellAtomicMappingArray returns the cellAtomicType for mapping array
-func (this *predefinedTypeEnv) cellAtomicMappingArray() *cellAtomicType {
-	if this._cellAtomicMappingArray == nil {
+func (p *predefinedTypeEnv) cellAtomicMappingArray() *cellAtomicType {
+	if p._cellAtomicMappingArray == nil {
 		val := cellAtomicTypeFrom(MAPPING_ARRAY, CellMutability_CELL_MUT_LIMITED)
-		this._cellAtomicMappingArray = &val
-		this.addInitializedCellAtom(&val)
+		p._cellAtomicMappingArray = &val
+		p.addInitializedCellAtom(&val)
 	}
-	return this._cellAtomicMappingArray
+	return p._cellAtomicMappingArray
 }
 
 // atomCellMappingArray returns the typeAtom for cell mapping array
-func (this *predefinedTypeEnv) atomCellMappingArray() *typeAtom {
-	if this._atomCellMappingArray == nil {
-		cellAtomicMappingArray := this.cellAtomicMappingArray()
-		atomCellMappingArray := createTypeAtom(this.cellAtomIndex(cellAtomicMappingArray), cellAtomicMappingArray)
-		this._atomCellMappingArray = &atomCellMappingArray
+func (p *predefinedTypeEnv) atomCellMappingArray() *typeAtom {
+	if p._atomCellMappingArray == nil {
+		cellAtomicMappingArray := p.cellAtomicMappingArray()
+		atomCellMappingArray := createTypeAtom(p.cellAtomIndex(cellAtomicMappingArray), cellAtomicMappingArray)
+		p._atomCellMappingArray = &atomCellMappingArray
 	}
-	return this._atomCellMappingArray
+	return p._atomCellMappingArray
 }
 
 // cellAtomicMappingArrayRO returns the cellAtomicType for read-only mapping array
-func (this *predefinedTypeEnv) cellAtomicMappingArrayRO() *cellAtomicType {
-	if this._cellAtomicMappingArrayRO == nil {
+func (p *predefinedTypeEnv) cellAtomicMappingArrayRO() *cellAtomicType {
+	if p._cellAtomicMappingArrayRO == nil {
 		val := cellAtomicTypeFrom(MAPPING_ARRAY_RO, CellMutability_CELL_MUT_LIMITED)
-		this._cellAtomicMappingArrayRO = &val
-		this.addInitializedCellAtom(&val)
+		p._cellAtomicMappingArrayRO = &val
+		p.addInitializedCellAtom(&val)
 	}
-	return this._cellAtomicMappingArrayRO
+	return p._cellAtomicMappingArrayRO
 }
 
 // atomCellMappingArrayRO returns the typeAtom for cell mapping array RO
-func (this *predefinedTypeEnv) atomCellMappingArrayRO() *typeAtom {
-	if this._atomCellMappingArrayRO == nil {
-		cellAtomicMappingArrayRO := this.cellAtomicMappingArrayRO()
-		atomCellMappingArrayRO := createTypeAtom(this.cellAtomIndex(cellAtomicMappingArrayRO), cellAtomicMappingArrayRO)
-		this._atomCellMappingArrayRO = &atomCellMappingArrayRO
+func (p *predefinedTypeEnv) atomCellMappingArrayRO() *typeAtom {
+	if p._atomCellMappingArrayRO == nil {
+		cellAtomicMappingArrayRO := p.cellAtomicMappingArrayRO()
+		atomCellMappingArrayRO := createTypeAtom(p.cellAtomIndex(cellAtomicMappingArrayRO), cellAtomicMappingArrayRO)
+		p._atomCellMappingArrayRO = &atomCellMappingArrayRO
 	}
-	return this._atomCellMappingArrayRO
+	return p._atomCellMappingArrayRO
 }
 
 // listAtomicThreeElement returns the ListAtomicType for three-element list
-func (this *predefinedTypeEnv) listAtomicThreeElement() *ListAtomicType {
-	if this._listAtomicThreeElement == nil {
+func (p *predefinedTypeEnv) listAtomicThreeElement() *ListAtomicType {
+	if p._listAtomicThreeElement == nil {
 		val := listAtomicTypeFrom(
 			fixedLengthArrayFrom([]ComplexSemType{*CELL_SEMTYPE_LIST_SUBTYPE_MAPPING, *CELL_SEMTYPE_VAL}, 3),
 			CELL_SEMTYPE_UNDEF)
-		this._listAtomicThreeElement = &val
-		this.addInitializedListAtom(&val)
+		p._listAtomicThreeElement = &val
+		p.addInitializedListAtom(&val)
 	}
-	return this._listAtomicThreeElement
+	return p._listAtomicThreeElement
 }
 
 // atomListThreeElement returns the typeAtom for list three element
-func (this *predefinedTypeEnv) atomListThreeElement() *typeAtom {
-	if this._atomListThreeElement == nil {
-		listAtomicThreeElement := this.listAtomicThreeElement()
-		atomListThreeElement := createTypeAtom(this.listAtomIndex(listAtomicThreeElement), listAtomicThreeElement)
-		this._atomListThreeElement = &atomListThreeElement
+func (p *predefinedTypeEnv) atomListThreeElement() *typeAtom {
+	if p._atomListThreeElement == nil {
+		listAtomicThreeElement := p.listAtomicThreeElement()
+		atomListThreeElement := createTypeAtom(p.listAtomIndex(listAtomicThreeElement), listAtomicThreeElement)
+		p._atomListThreeElement = &atomListThreeElement
 	}
-	return this._atomListThreeElement
+	return p._atomListThreeElement
 }
 
 // listAtomicThreeElementRO returns the ListAtomicType for read-only three-element list
-func (this *predefinedTypeEnv) listAtomicThreeElementRO() *ListAtomicType {
-	if this._listAtomicThreeElementRO == nil {
+func (p *predefinedTypeEnv) listAtomicThreeElementRO() *ListAtomicType {
+	if p._listAtomicThreeElementRO == nil {
 		val := listAtomicTypeFrom(
 			fixedLengthArrayFrom([]ComplexSemType{*CELL_SEMTYPE_LIST_SUBTYPE_MAPPING_RO, *CELL_SEMTYPE_VAL}, 3),
 			CELL_SEMTYPE_UNDEF)
-		this._listAtomicThreeElementRO = &val
-		this.addInitializedListAtom(&val)
+		p._listAtomicThreeElementRO = &val
+		p.addInitializedListAtom(&val)
 	}
-	return this._listAtomicThreeElementRO
+	return p._listAtomicThreeElementRO
 }
 
 // atomListThreeElementRO returns the typeAtom for list three element RO
-func (this *predefinedTypeEnv) atomListThreeElementRO() *typeAtom {
-	if this._atomListThreeElementRO == nil {
-		listAtomicThreeElementRO := this.listAtomicThreeElementRO()
-		atomListThreeElementRO := createTypeAtom(this.listAtomIndex(listAtomicThreeElementRO), listAtomicThreeElementRO)
-		this._atomListThreeElementRO = &atomListThreeElementRO
+func (p *predefinedTypeEnv) atomListThreeElementRO() *typeAtom {
+	if p._atomListThreeElementRO == nil {
+		listAtomicThreeElementRO := p.listAtomicThreeElementRO()
+		atomListThreeElementRO := createTypeAtom(p.listAtomIndex(listAtomicThreeElementRO), listAtomicThreeElementRO)
+		p._atomListThreeElementRO = &atomListThreeElementRO
 	}
-	return this._atomListThreeElementRO
+	return p._atomListThreeElementRO
 }
 
 // ReservedRecAtomCount returns the maximum count of reserved rec atoms
-func (this *predefinedTypeEnv) ReservedRecAtomCount() int {
-	if len(this.initializedRecListAtoms) > len(this.initializedRecMappingAtoms) {
-		return len(this.initializedRecListAtoms)
+func (p *predefinedTypeEnv) ReservedRecAtomCount() int {
+	if len(p.initializedRecListAtoms) > len(p.initializedRecMappingAtoms) {
+		return len(p.initializedRecListAtoms)
 	}
-	return len(this.initializedRecMappingAtoms)
+	return len(p.initializedRecMappingAtoms)
 }
 
 // GetPredefinedRecAtom returns a predefined recAtom for the given index
-func (this *predefinedTypeEnv) GetPredefinedRecAtom(index int) common.Optional[*recAtom] {
-	if this.IsPredefinedRecAtom(index) {
+func (p *predefinedTypeEnv) GetPredefinedRecAtom(index int) common.Optional[*recAtom] {
+	if p.IsPredefinedRecAtom(index) {
 		recAtom := createRecAtom(index)
 		return common.OptionalOf(&recAtom)
 	}
@@ -668,6 +668,6 @@ func (this *predefinedTypeEnv) GetPredefinedRecAtom(index int) common.Optional[*
 }
 
 // IsPredefinedRecAtom checks if the given index is a predefined rec atom
-func (this *predefinedTypeEnv) IsPredefinedRecAtom(index int) bool {
-	return index >= 0 && index < this.ReservedRecAtomCount()
+func (p *predefinedTypeEnv) IsPredefinedRecAtom(index int) bool {
+	return index >= 0 && index < p.ReservedRecAtomCount()
 }

--- a/semtypes/rec_atom.go
+++ b/semtypes/rec_atom.go
@@ -47,14 +47,14 @@ func createDistinctRecAtom(index int) recAtom {
 	return newRecAtomFromInt(index)
 }
 
-func (this *recAtom) index() int {
-	return this.idx
+func (r *recAtom) index() int {
+	return r.idx
 }
 
-func (this *recAtom) canonicalKey() string {
-	return fmt.Sprintf("r%d", this.idx)
+func (r *recAtom) canonicalKey() string {
+	return fmt.Sprintf("r%d", r.idx)
 }
 
-func (this *recAtom) String() string {
-	return fmt.Sprintf("r%d", this.idx)
+func (r *recAtom) String() string {
+	return fmt.Sprintf("r%d", r.idx)
 }

--- a/semtypes/stream_definition.go
+++ b/semtypes/stream_definition.go
@@ -38,14 +38,14 @@ func streamContaining(tupleType SemType) SemType {
 	return createBasicSemType(BTStream, bdd)
 }
 
-func (this *streamDefinition) GetSemType(env Env) SemType {
-	return streamContaining(this.listDefinition.GetSemType(env))
+func (s *streamDefinition) GetSemType(env Env) SemType {
+	return streamContaining(s.listDefinition.GetSemType(env))
 }
 
-func (this *streamDefinition) Define(env Env, valueTy SemType, completionTy SemType) SemType {
+func (s *streamDefinition) Define(env Env, valueTy SemType, completionTy SemType) SemType {
 	if common.PointerEqualToValue(VAL, completionTy) && common.PointerEqualToValue(VAL, valueTy) {
 		return STREAM
 	}
-	tuple := this.listDefinition.TupleTypeWrapped(env, valueTy, completionTy)
+	tuple := s.listDefinition.TupleTypeWrapped(env, valueTy, completionTy)
 	return streamContaining(tuple)
 }

--- a/semtypes/stream_ops.go
+++ b/semtypes/stream_ops.go
@@ -39,10 +39,10 @@ func newStreamOps() streamOps {
 	return this
 }
 
-func (this *streamOps) complement(t SubtypeData) SubtypeData {
+func (s *streamOps) complement(t SubtypeData) SubtypeData {
 	return streamSubtypeComplement(t)
 }
 
-func (this *streamOps) IsEmpty(cx Context, t SubtypeData) bool {
+func (s *streamOps) IsEmpty(cx Context, t SubtypeData) bool {
 	return streamSubtypeIsEmpty(cx, t)
 }

--- a/semtypes/string_ops.go
+++ b/semtypes/string_ops.go
@@ -26,7 +26,7 @@ func newStringOps() stringOps {
 	return this
 }
 
-func (this *stringOps) Union(d1 SubtypeData, d2 SubtypeData) SubtypeData {
+func (s *stringOps) Union(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	sd1 := d1.(stringSubtype)
 	sd2 := d2.(stringSubtype)
 	var chars []enumerableType[string]
@@ -36,7 +36,7 @@ func (this *stringOps) Union(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	return createStringSubtype(charStringSubtypeFrom(charsAllowed, chars), nonCharStringSubtypeFrom(nonCharsAllowed, nonChars))
 }
 
-func (this *stringOps) Intersect(d1 SubtypeData, d2 SubtypeData) SubtypeData {
+func (s *stringOps) Intersect(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	if allOrNothing1, ok := d1.(*allOrNothingSubtype); ok {
 		if allOrNothing1.IsAllSubtype() {
 			return d2
@@ -60,11 +60,11 @@ func (this *stringOps) Intersect(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	return createStringSubtype(charStringSubtypeFrom(charsAllowed, chars), nonCharStringSubtypeFrom(nonCharsAllowed, nonChars))
 }
 
-func (this *stringOps) Diff(d1 SubtypeData, d2 SubtypeData) SubtypeData {
-	return this.Intersect(d1, this.complement(d2))
+func (s *stringOps) Diff(d1 SubtypeData, d2 SubtypeData) SubtypeData {
+	return s.Intersect(d1, s.complement(d2))
 }
 
-func (this *stringOps) complement(d SubtypeData) SubtypeData {
+func (s *stringOps) complement(d SubtypeData) SubtypeData {
 	st := d.(stringSubtype)
 	if len(st.GetChar().Values()) == 0 && len(st.GetNonChar().Values()) == 0 {
 		if st.GetChar().Allowed() && st.GetNonChar().Allowed() {
@@ -76,7 +76,7 @@ func (this *stringOps) complement(d SubtypeData) SubtypeData {
 	return createStringSubtype(charStringSubtypeFrom(!st.GetChar().Allowed(), st.GetChar().Values()), nonCharStringSubtypeFrom(!st.GetNonChar().Allowed(), st.GetNonChar().Values()))
 }
 
-func (this *stringOps) IsEmpty(cx Context, t SubtypeData) bool {
+func (s *stringOps) IsEmpty(cx Context, t SubtypeData) bool {
 	return notIsEmpty(cx, t)
 }
 

--- a/semtypes/string_subtype.go
+++ b/semtypes/string_subtype.go
@@ -137,12 +137,12 @@ func codePointCount(s string, start, end int) int {
 	return len([]rune(s[start:end]))
 }
 
-func (this *stringSubtype) GetChar() enumerableSubtype[string] {
-	return &this.charData
+func (s *stringSubtype) GetChar() enumerableSubtype[string] {
+	return &s.charData
 }
 
-func (this *stringSubtype) GetNonChar() enumerableSubtype[string] {
-	return &this.nonCharData
+func (s *stringSubtype) GetNonChar() enumerableSubtype[string] {
+	return &s.nonCharData
 }
 
 func stringChar() SemType {

--- a/semtypes/table_ops.go
+++ b/semtypes/table_ops.go
@@ -33,22 +33,22 @@ func tableSubtypeIsEmpty(cx Context, t SubtypeData) bool {
 	return listSubtypeIsEmpty(cx, b)
 }
 
-func (this *tableOps) complement(d SubtypeData) SubtypeData {
+func (t *tableOps) complement(d SubtypeData) SubtypeData {
 	return tableSubtypeComplement(d)
 }
 
-func (this *tableOps) IsEmpty(cx Context, d SubtypeData) bool {
+func (t *tableOps) IsEmpty(cx Context, d SubtypeData) bool {
 	return tableSubtypeIsEmpty(cx, d)
 }
 
-func (this *tableOps) Union(d1 SubtypeData, d2 SubtypeData) SubtypeData {
+func (t *tableOps) Union(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	return bddSubtypeUnion(d1, d2)
 }
 
-func (this *tableOps) Intersect(d1 SubtypeData, d2 SubtypeData) SubtypeData {
+func (t *tableOps) Intersect(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	return bddSubtypeIntersect(d1, d2)
 }
 
-func (this *tableOps) Diff(d1 SubtypeData, d2 SubtypeData) SubtypeData {
+func (t *tableOps) Diff(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	return bddSubtypeDiff(d1, d2)
 }

--- a/semtypes/type_atom.go
+++ b/semtypes/type_atom.go
@@ -38,10 +38,10 @@ func createTypeAtom(index int, atomicType atomicType) typeAtom {
 	}
 }
 
-func (this *typeAtom) index() int {
-	return this.idx
+func (t *typeAtom) index() int {
+	return t.idx
 }
 
-func (this *typeAtom) canonicalKey() string {
-	return fmt.Sprintf("t%d", this.idx)
+func (t *typeAtom) canonicalKey() string {
+	return fmt.Sprintf("t%d", t.idx)
 }

--- a/semtypes/type_pool.go
+++ b/semtypes/type_pool.go
@@ -544,7 +544,7 @@ func fromFloatSubtype(st *floatSubtype) floatSubtypeEntry {
 func toFloatSubtype(entry floatSubtypeEntry) ProperSubtypeData {
 	values := make([]enumerableType[float64], entry.nValues)
 	for i, v := range entry.values {
-		f := enumerableFloatFrom(v)
+		f := newEnumerableFloatFromFloat64(v)
 		values[i] = &f
 	}
 	return createFloatSubtype(entry.allowed, values)

--- a/semtypes/typedesc_ops.go
+++ b/semtypes/typedesc_ops.go
@@ -39,10 +39,10 @@ func newTypedescOps() typedescOps {
 	return this
 }
 
-func (this *typedescOps) complement(d SubtypeData) SubtypeData {
+func (t *typedescOps) complement(d SubtypeData) SubtypeData {
 	return typedescSubtypeComplement(d)
 }
 
-func (this *typedescOps) IsEmpty(cx Context, d SubtypeData) bool {
+func (t *typedescOps) IsEmpty(cx Context, d SubtypeData) bool {
 	return typedescSubtypeIsEmpty(cx, d)
 }

--- a/semtypes/xml_ops.go
+++ b/semtypes/xml_ops.go
@@ -29,40 +29,40 @@ func newXmlOps() xmlOps {
 	return this
 }
 
-func (this *xmlOps) Union(d1 SubtypeData, d2 SubtypeData) SubtypeData {
+func (x *xmlOps) Union(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	v1 := d1.(*xmlSubtype)
 	v2 := d2.(*xmlSubtype)
 	primitives := (v1.Primitives | v2.Primitives)
 	return createXmlSubtype(primitives, bddUnion(v1.Sequence, v2.Sequence))
 }
 
-func (this *xmlOps) Intersect(d1 SubtypeData, d2 SubtypeData) SubtypeData {
+func (x *xmlOps) Intersect(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	v1 := d1.(*xmlSubtype)
 	v2 := d2.(*xmlSubtype)
 	primitives := (v1.Primitives & v2.Primitives)
 	return createXmlSubtypeOrEmpty(primitives, bddIntersect(v1.Sequence, v2.Sequence))
 }
 
-func (this *xmlOps) Diff(d1 SubtypeData, d2 SubtypeData) SubtypeData {
+func (x *xmlOps) Diff(d1 SubtypeData, d2 SubtypeData) SubtypeData {
 	v1 := d1.(*xmlSubtype)
 	v2 := d2.(*xmlSubtype)
 	primitives := (v1.Primitives & (^v2.Primitives))
 	return createXmlSubtypeOrEmpty(primitives, bddDiff(v1.Sequence, v2.Sequence))
 }
 
-func (this *xmlOps) complement(d SubtypeData) SubtypeData {
-	return this.Diff(XML_SUBTYPE_TOP, d)
+func (x *xmlOps) complement(d SubtypeData) SubtypeData {
+	return x.Diff(XML_SUBTYPE_TOP, d)
 }
 
-func (this *xmlOps) IsEmpty(cx Context, t SubtypeData) bool {
+func (x *xmlOps) IsEmpty(cx Context, t SubtypeData) bool {
 	sd := t.(*xmlSubtype)
 	if sd.Primitives != 0 {
 		return false
 	}
-	return this.xmlBddEmpty(cx, sd.Sequence)
+	return x.xmlBddEmpty(cx, sd.Sequence)
 }
 
-func (this *xmlOps) xmlBddEmpty(cx Context, bdd Bdd) bool {
+func (x *xmlOps) xmlBddEmpty(cx Context, bdd Bdd) bool {
 	return bddEvery(cx, bdd, conjunctionNil, conjunctionNil, xmlFormulaIsEmpty)
 }
 


### PR DESCRIPTION
## Purpose
$Subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed method receiver variables across the codebase to use concise, idiomatic identifiers (e.g., b, c, s, m, f, etc.). No behavior, signatures, or public APIs changed.
* **Chores**
  * Re-enabled the receiver-naming static analysis check to enforce consistent naming conventions during linting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->