### PR TITLE
Fix worktree path in benchmark runner

### DIFF
--- a/compiler-tools/benchmark/runner.go
+++ b/compiler-tools/benchmark/runner.go
@@ -115,7 +115,7 @@ func (b *benchmark) run() error {
 }
 
 func (b *benchmark) checkoutWorktree(ref string) (string, error) {
-	path := filepath.Join(b.workRoot, "worktree"+sanitize(ref))
+	path := filepath.Join(b.workRoot, "worktree-"+sanitize(ref)+"-"+sanitize(filepath.Base(b.workRoot)))
 	b.removeWorktree(path)
 
 	if err := runCmd(".", "git", "worktree", "add", "--detach", path, ref); err != nil {


### PR DESCRIPTION
## Purpose
Fixes #481

The intermittent failure was caused by parallel benchmark tests creating Git worktrees with the same basename. Git stores worktree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the naming and organization scheme for temporary working directories in benchmark operations. The tool now implements an improved naming convention that enhances consistency and clarity when managing temporary resources, making it simpler to identify and track working directories created during benchmark execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ballerina-platform/ballerina-lang-go/pull/485?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->