### PR TITLE
Fix: Field access on a union type with an array type, is not narrowed in else/fall-through path

### DIFF
--- a/bir/bir_gen.go
+++ b/bir/bir_gen.go
@@ -446,7 +446,7 @@ func compoundAssignmentToMember(ctx *stmtContext, curBB *BIRBasicBlock, stmt *as
 	indexEffect := handleActionOrExpression(ctx, containerEffect.block, ref.IndexExpr)
 	curBB = indexEffect.block
 
-	loadKind, storeKind := memberAccessInstructionKinds(ref.Expr.GetDeterminedType())
+	loadKind, storeKind := memberAccessInstructionKinds(ctx.birCx.TypeContext(), ref.Expr.GetDeterminedType())
 
 	lhsValue := ctx.addTempVar(ref.GetDeterminedType())
 	load := NewFieldAccess(loadKind, lhsValue, indexEffect.result, containerEffect.result, pos)
@@ -469,12 +469,12 @@ func compoundAssignmentToMember(ctx *stmtContext, curBB *BIRBasicBlock, stmt *as
 	}
 }
 
-func memberAccessInstructionKinds(containerType semtypes.SemType) (loadKind, storeKind InstructionKind) {
+func memberAccessInstructionKinds(tyCtx semtypes.Context, containerType semtypes.SemType) (loadKind, storeKind InstructionKind) {
 	containerType = semtypes.Diff(containerType, semtypes.NIL)
 	switch {
-	case semtypes.IsSubtypeSimple(containerType, semtypes.LIST):
+	case semtypes.IsSubtype(tyCtx, containerType, semtypes.LIST):
 		return INSTRUCTION_KIND_ARRAY_LOAD, INSTRUCTION_KIND_ARRAY_STORE
-	case semtypes.IsSubtypeSimple(containerType, semtypes.OBJECT):
+	case semtypes.IsSubtype(tyCtx, containerType, semtypes.OBJECT):
 		return INSTRUCTION_KIND_OBJECT_LOAD, INSTRUCTION_KIND_OBJECT_STORE
 	default:
 		return INSTRUCTION_KIND_MAP_LOAD, INSTRUCTION_KIND_MAP_STORE
@@ -581,7 +581,7 @@ func assignToMemberStatement(ctx *stmtContext, bb *BIRBasicBlock, varRef *ast.BL
 	currBB = containerRefEffect.block
 	indexEffect := handleActionOrExpression(ctx, currBB, varRef.IndexExpr)
 	currBB = indexEffect.block
-	_, storeKind := memberAccessInstructionKinds(varRef.Expr.GetDeterminedType())
+	_, storeKind := memberAccessInstructionKinds(ctx.birCx.TypeContext(), varRef.Expr.GetDeterminedType())
 	fieldAccess := NewFieldAccess(storeKind, containerRefEffect.result, indexEffect.result, valueEffect.result, pos)
 	currBB.Instructions = append(currBB.Instructions, fieldAccess)
 	return statementEffect{
@@ -815,7 +815,7 @@ type expressionEffect struct {
 // of an expression dont' affect the other.
 func snapshotIfNeeded(ctx *stmtContext, effect expressionEffect, pos Location) expressionEffect {
 	op := effect.result
-	if _, isLocal := op.VariableDcl.(*BIRLocalVariableDcl); isLocal && hasNoStorageIdentity(op.VariableDcl.GetType()) {
+	if _, isLocal := op.VariableDcl.(*BIRLocalVariableDcl); isLocal && hasNoStorageIdentity(ctx.birCx.TypeContext(), op.VariableDcl.GetType()) {
 		tempOp := ctx.addTempVar(op.VariableDcl.GetType())
 		effect.block.Instructions = append(effect.block.Instructions, NewMove(op, tempOp, pos))
 		effect.result = tempOp
@@ -1196,12 +1196,13 @@ func assignmentContainerReference(ctx *stmtContext, bb *BIRBasicBlock, expr ast.
 	// inner lookup nominally yields `T?`). After filling, the container is
 	// guaranteed non-nil, so we strip `()` before classifying.
 	containerType := semtypes.Diff(inner.Expr.GetDeterminedType(), semtypes.NIL)
+	tyCtx := ctx.birCx.TypeContext()
 	var fillingKind InstructionKind
 	var filler values.FillerFactory
 	switch {
-	case semtypes.IsSubtypeSimple(containerType, semtypes.LIST):
+	case semtypes.IsSubtype(tyCtx, containerType, semtypes.LIST):
 		fillingKind = INSTRUCTION_KIND_ARRAY_FILLING_LOAD
-	case semtypes.IsSubtypeSimple(containerType, semtypes.MAPPING):
+	case semtypes.IsSubtype(tyCtx, containerType, semtypes.MAPPING):
 		fillingKind = INSTRUCTION_KIND_MAP_FILLING_LOAD
 		tyCx := semtypes.TypeCheckContext(ctx.birCx.CompilerContext.GetTypeEnv())
 		valueType := semtypes.MappingMemberTypeInnerVal(tyCx, containerType, semtypes.STRING)
@@ -1224,7 +1225,7 @@ func assignmentContainerReference(ctx *stmtContext, bb *BIRBasicBlock, expr ast.
 func indexBasedAccess(ctx *stmtContext, bb *BIRBasicBlock, expr *ast.BLangIndexBasedAccess) expressionEffect {
 	// Assignment is handled in assignmentStatement to this is always a load
 	resultOperand := ctx.addTempVar(expr.GetDeterminedType())
-	loadKind, _ := memberAccessInstructionKinds(expr.Expr.GetDeterminedType())
+	loadKind, _ := memberAccessInstructionKinds(ctx.birCx.TypeContext(), expr.Expr.GetDeterminedType())
 	indexEffect := handleActionOrExpression(ctx, bb, expr.IndexExpr)
 	containerRefEffect := handleActionOrExpression(ctx, indexEffect.block, expr.Expr)
 	currBB := containerRefEffect.block
@@ -1641,6 +1642,6 @@ func appendIfNotNil[T any](slice []T, item *T) []T {
 	return slice
 }
 
-func hasNoStorageIdentity(ty semtypes.SemType) bool {
-	return semtypes.IsSubtypeSimple(ty, semtypes.SIMPLE_BASIC)
+func hasNoStorageIdentity(tyCtx semtypes.Context, ty semtypes.SemType) bool {
+	return semtypes.IsSubtype(tyCtx, ty, semtypes.SIMPLE_BASIC)
 }

--- a/corpus/ast/subset9/09-bug/narrowed-field-access-v.txt
+++ b/corpus/ast/subset9/09-bug/narrowed-field-access-v.txt
@@ -1,0 +1,48 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (type-definition Rec
+    (record-type
+      (field a
+        (value-type string))
+      (field b
+        (value-type string))))
+  (function foo (
+    (variable input (type
+      (union-type
+        (array-type
+          (value-type string) dimensions: 1 ([]))
+        (user-defined-type Rec))))) (
+    (value-type null))
+    (block-function-body
+      (if
+        (type-test-expr is
+          (simple-var-ref input)
+          (array-type
+            (value-type string) dimensions: 1 ([])))
+        (block-stmt
+          (return
+            (literal <nil>))) ())
+      (block-stmt
+        (expression-stmt
+          (invocation io println (
+            (literal A is: )
+            (field-based-access a
+              (simple-var-ref input)))))
+        (expression-stmt
+          (invocation io println (
+            (literal B is: )
+            (field-based-access b
+              (simple-var-ref input))))))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (expression-stmt
+        (invocation foo (
+          (mapping-constructor-expr
+            (key-value
+              (literal a)
+              (literal Value A))
+            (key-value
+              (literal b)
+              (literal Value B)))))))))

--- a/corpus/bal/subset9/09-bug/narrowed-field-access-v.bal
+++ b/corpus/bal/subset9/09-bug/narrowed-field-access-v.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/io;
+
+type Rec record {|
+    string a;
+    string b;
+|};
+
+function foo(string[]|Rec input) {
+    if input is string[] {
+        return;
+    }
+    io:println("A is: ", input.a); // @output A is: Value A
+    io:println("B is: ", input.b); // @output B is: Value B
+}
+
+public function main() {
+    foo({a: "Value A", b: "Value B"});
+}

--- a/corpus/bir/subset9/09-bug/narrowed-field-access-v.txt
+++ b/corpus/bir/subset9/09-bug/narrowed-field-access-v.txt
@@ -1,0 +1,41 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+foo([string...]|{| a: string, b: string, never... |}) -> nil{
+  bb0 {
+    %2 = input is [string...]
+    %2 ? bb1 : bb2;
+  }
+  bb1 {
+    %3 = ConstantLoad <nil>
+    %0 = %3;
+    return;
+  }
+  bb2 {
+    %4 = ConstantLoad A is: 
+    %6 = ConstantLoad a
+    %5 = input[%6];
+    %7 = println(%4,%5) -> bb3;
+  }
+  bb3 {
+    %8 = ConstantLoad B is: 
+    %10 = ConstantLoad b
+    %9 = input[%10];
+    %11 = println(%8,%9) -> bb4;
+  }
+  bb4 {
+    return;
+  }
+}
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad a
+    %2 = ConstantLoad Value A
+    %3 = ConstantLoad b
+    %4 = ConstantLoad Value B
+    %5 = newMap {| a: string, b: string, never... |}{%1=%2, %3=%4}
+    %6 = foo(%5) -> bb1;
+  }
+  bb1 {
+    return;
+  }
+}

--- a/corpus/cfg/subset9/09-bug/narrowed-field-access-v.txt
+++ b/corpus/cfg/subset9/09-bug/narrowed-field-access-v.txt
@@ -1,0 +1,37 @@
+(foo
+  (bb0 () (bb1 bb2)
+    (type-test-expr is
+      (simple-var-ref input)
+      (array-type
+        (value-type string) dimensions: 1 ([])))
+  )
+  (bb1 (bb0) ()
+    (return
+      (literal <nil>))
+  )
+  (bb2 (bb0) ()
+    (expression-stmt
+      (invocation io println (
+        (literal A is: )
+        (field-based-access a
+          (simple-var-ref input)))))
+    (expression-stmt
+      (invocation io println (
+        (literal B is: )
+        (field-based-access b
+          (simple-var-ref input)))))
+  )
+)
+(main
+  (bb0 () ()
+    (expression-stmt
+      (invocation foo (
+        (mapping-constructor-expr
+          (key-value
+            (literal a)
+            (literal Value A))
+          (key-value
+            (literal b)
+            (literal Value B))))))
+  )
+)

--- a/corpus/desugared/subset9/09-bug/narrowed-field-access-v.txt
+++ b/corpus/desugared/subset9/09-bug/narrowed-field-access-v.txt
@@ -1,0 +1,49 @@
+(package
+  (import-package ballerina io (as io))
+  (type-definition Rec
+    (record-type
+      (field a
+        (value-type string))
+      (field b
+        (value-type string))))
+  (function foo (
+    (variable input (type
+      (union-type
+        (array-type
+          (value-type string) dimensions: 1 ([]))
+        (user-defined-type Rec))))) (
+    (value-type null))
+    (block-function-body
+      (if
+        (type-test-expr is
+          (simple-var-ref input)
+          (array-type
+            (value-type string) dimensions: 1 ([])))
+        (block-stmt
+          (return
+            (literal <nil>))) ())
+      (block-stmt
+        (expression-stmt
+          (invocation io println (
+            (literal A is: )
+            (index-based-access
+              (simple-var-ref input)
+              (literal a)))))
+        (expression-stmt
+          (invocation io println (
+            (literal B is: )
+            (index-based-access
+              (simple-var-ref input)
+              (literal b))))))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (expression-stmt
+        (invocation foo (
+          (mapping-constructor-expr
+            (key-value
+              (literal a)
+              (literal Value A))
+            (key-value
+              (literal b)
+              (literal Value B)))))))))

--- a/corpus/integration/subset9/09-bug/narrowed-field-access-v.txtar
+++ b/corpus/integration/subset9/09-bug/narrowed-field-access-v.txtar
@@ -1,0 +1,4 @@
+-- stdout --
+A is: Value A
+B is: Value B
+-- stderr --

--- a/desugar/query_expression.go
+++ b/desugar/query_expression.go
@@ -195,9 +195,10 @@ func createQueryCollectionSource(
 
 	lengthSource := ast.BLangExpression(collRef)
 	var keysRef *ast.BLangSimpleVarRef
+	tyCtx := semtypes.ContextFrom(cx.typeEnv())
 	switch {
-	case semtypes.IsSubtypeSimple(collTy, semtypes.LIST):
-	case semtypes.IsSubtypeSimple(collTy, semtypes.MAPPING):
+	case semtypes.IsSubtype(tyCtx, collTy, semtypes.LIST):
+	case semtypes.IsSubtype(tyCtx, collTy, semtypes.MAPPING):
 		keysInvocation := createKeysInvocation(cx, collRef)
 		if keysInvocation == nil {
 			return nil, nil, nil, nil, false

--- a/desugar/statement.go
+++ b/desugar/statement.go
@@ -354,10 +354,11 @@ func visitForEach(cx *functionContext, stmt *ast.BLangForeach) desugaredNode[ast
 		rangeExpr := stmt.Collection.(*ast.BLangBinaryExpr)
 		return desugarForEachOnRange(cx, rangeExpr, stmt.VariableDef, &stmt.Body, stmt.Scope())
 	}
-	if semtypes.IsSubtypeSimple(stmt.Collection.GetDeterminedType(), semtypes.LIST) {
+	tyCtx := semtypes.ContextFrom(cx.typeEnv())
+	if semtypes.IsSubtype(tyCtx, stmt.Collection.GetDeterminedType(), semtypes.LIST) {
 		return desugarForEachOnList(cx, stmt.Collection, stmt.VariableDef, &stmt.Body, stmt.Scope())
 	}
-	if semtypes.IsSubtypeSimple(stmt.Collection.GetDeterminedType(), semtypes.MAPPING) {
+	if semtypes.IsSubtype(tyCtx, stmt.Collection.GetDeterminedType(), semtypes.MAPPING) {
 		return desugarForEachOnMap(cx, stmt.Collection, stmt.VariableDef, &stmt.Body, stmt.Scope())
 	}
 	return desugarForEachOnIterable(cx, stmt.Collection, stmt.VariableDef, &stmt.Body, stmt.Scope())

--- a/semantics/control_flow_analyzer.go
+++ b/semantics/control_flow_analyzer.go
@@ -296,7 +296,7 @@ func (analyzer *functionControlFlowAnalyzer) analyzeStatement(curBB bbRef, stmt 
 		return analyzer.analyzePanic(curBB, s)
 	case *ast.BLangExpressionStmt:
 		analyzer.addNode(curBB, stmt)
-		if expr, ok := s.Expr.(ast.BLangExpression); ok && alwaysTerminatesViaCheck(expr) {
+		if expr, ok := s.Expr.(ast.BLangExpression); ok && alwaysTerminatesViaCheck(analyzer.tyCtx, expr) {
 			return terminatedEffect()
 		}
 		return continueEffect(curBB)
@@ -379,7 +379,7 @@ func (analyzer *functionControlFlowAnalyzer) analyzePanic(curBB bbRef, stmt *ast
 // `checkpanic` whose operand is statically a subtype of error. In that case the
 // `check` always returns from the enclosing function and the `checkpanic`
 // always panics, so following statements are unreachable.
-func alwaysTerminatesViaCheck(expr ast.BLangExpression) bool {
+func alwaysTerminatesViaCheck(tyCtx semtypes.Context, expr ast.BLangExpression) bool {
 	var inner ast.BLangExpression
 	switch e := expr.(type) {
 	case *ast.BLangCheckPanickedExpr:
@@ -394,7 +394,7 @@ func alwaysTerminatesViaCheck(expr ast.BLangExpression) bool {
 	if inner == nil {
 		return false
 	}
-	return semtypes.IsSubtypeSimple(inner.GetDeterminedType(), semtypes.ERROR)
+	return semtypes.IsSubtype(tyCtx, inner.GetDeterminedType(), semtypes.ERROR)
 }
 
 // Branching statement handlers

--- a/semantics/semantic_analyzer.go
+++ b/semantics/semantic_analyzer.go
@@ -99,7 +99,7 @@ func returnFound(a analyzer, returnStmt *ast.BLangReturn) bool {
 		return false
 	}
 	if returnStmt.Expr == nil {
-		if !semtypes.IsSubtypeSimple(retTy, semtypes.NIL) {
+		if !semtypes.IsSubtype(a.tyCtx(), retTy, semtypes.NIL) {
 			a.ctx().SemanticError("expect a return value", returnStmt.GetPosition())
 			return false
 		}
@@ -958,11 +958,11 @@ func analyzeIndexBasedAccess[A analyzer](a A, expr *ast.BLangIndexBasedAccess, e
 
 	var keyExprExpectedType semtypes.SemType
 	ctx := a.tyCtx()
-	if semtypes.IsSubtypeSimple(containerExprTy, semtypes.LIST) ||
-		semtypes.IsSubtypeSimple(containerExprTy, semtypes.STRING) ||
-		semtypes.IsSubtypeSimple(containerExprTy, semtypes.XML) {
+	if semtypes.IsSubtype(ctx, containerExprTy, semtypes.LIST) ||
+		semtypes.IsSubtype(ctx, containerExprTy, semtypes.STRING) ||
+		semtypes.IsSubtype(ctx, containerExprTy, semtypes.XML) {
 		keyExprExpectedType = semtypes.INT
-	} else if semtypes.IsSubtypeSimple(containerExprTy, semtypes.TABLE) {
+	} else if semtypes.IsSubtype(ctx, containerExprTy, semtypes.TABLE) {
 		a.unimplementedErr("table not supported", expr.GetPosition())
 		return false
 	} else if semtypes.IsSubtype(ctx, containerExprTy, semtypes.Union(semtypes.NIL, semtypes.MAPPING)) {
@@ -1114,12 +1114,12 @@ func analyzeUnaryExpr[A analyzer](a A, unaryExpr *ast.BLangUnaryExpr, expectedTy
 
 	switch unaryExpr.GetOperatorKind() {
 	case model.OperatorKind_ADD, model.OperatorKind_SUB, model.OperatorKind_BITWISE_COMPLEMENT:
-		if !isNumericType(underlyingTy) {
+		if !isNumericType(a.tyCtx(), underlyingTy) {
 			a.semanticErr(fmt.Sprintf("expect numeric type for %s", string(unaryExpr.GetOperatorKind())), unaryExpr.GetPosition())
 			return false
 		}
 	case model.OperatorKind_NOT:
-		if !semtypes.IsSubtypeSimple(exprTy, semtypes.BOOLEAN) {
+		if !semtypes.IsSubtype(a.tyCtx(), exprTy, semtypes.BOOLEAN) {
 			a.semanticErr(fmt.Sprintf("expect boolean type for %s", string(unaryExpr.GetOperatorKind())), unaryExpr.GetPosition())
 			return false
 		}
@@ -1166,7 +1166,7 @@ func analyzeBinaryExpr[A analyzer](a A, binaryExpr *ast.BLangBinaryExpr, expecte
 			return false
 		}
 	} else if isRangeExpr(binaryExpr) {
-		if !semtypes.IsSubtypeSimple(lhsTy, semtypes.INT) || !semtypes.IsSubtypeSimple(rhsTy, semtypes.INT) {
+		if !semtypes.IsSubtype(a.tyCtx(), lhsTy, semtypes.INT) || !semtypes.IsSubtype(a.tyCtx(), rhsTy, semtypes.INT) {
 			a.semanticErr(fmt.Sprintf("expect int types for %s", string(binaryExpr.GetOperatorKind())), binaryExpr.GetPosition())
 			return false
 		}
@@ -1175,7 +1175,7 @@ func analyzeBinaryExpr[A analyzer](a A, binaryExpr *ast.BLangBinaryExpr, expecte
 			return false
 		}
 	} else if isLogicalExpression(binaryExpr) {
-		if !semtypes.IsSubtypeSimple(lhsTy, semtypes.BOOLEAN) || !semtypes.IsSubtypeSimple(rhsTy, semtypes.BOOLEAN) {
+		if !semtypes.IsSubtype(a.tyCtx(), lhsTy, semtypes.BOOLEAN) || !semtypes.IsSubtype(a.tyCtx(), rhsTy, semtypes.BOOLEAN) {
 			a.semanticErr(fmt.Sprintf("expect boolean types for %s", string(binaryExpr.GetOperatorKind())), binaryExpr.GetPosition())
 			return false
 		}
@@ -1288,7 +1288,7 @@ func analyzeSimpleVariableDef[A analyzer](a A, simpleVariableDef *ast.BLangSimpl
 	variable := simpleVariableDef.GetVariable().(*ast.BLangSimpleVariable)
 	expectedType := variable.GetDeterminedType()
 	if variable.GetName().GetValue() == string(model.IGNORE) {
-		if !semtypes.IsSubtypeSimple(expectedType, semtypes.ANY) {
+		if !semtypes.IsSubtype(a.tyCtx(), expectedType, semtypes.ANY) {
 			a.semanticErr("wildcard binding pattern type must be a subtype of 'any'", variable.GetPosition())
 			return false
 		}
@@ -1476,7 +1476,7 @@ func validateForeach[A analyzer](a A, foreachStmt *ast.BLangForeach) bool {
 	variable := foreachStmt.VariableDef.GetVariable().(*ast.BLangSimpleVariable)
 	variableType := a.ctx().SymbolType(variable.Symbol())
 	if binExpr, ok := collection.(*ast.BLangBinaryExpr); ok && isRangeExpr(binExpr) {
-		if !semtypes.IsSubtypeSimple(variableType, semtypes.INT) {
+		if !semtypes.IsSubtype(a.tyCtx(), variableType, semtypes.INT) {
 			a.semanticErr("foreach variable must be a subtype of int for range expression", collection.GetPosition())
 			return false
 		}
@@ -1484,14 +1484,14 @@ func validateForeach[A analyzer](a A, foreachStmt *ast.BLangForeach) bool {
 		collectionType := collection.GetDeterminedType()
 		var expectedValueType semtypes.SemType
 		switch {
-		case semtypes.IsSubtypeSimple(collectionType, semtypes.LIST):
+		case semtypes.IsSubtype(a.tyCtx(), collectionType, semtypes.LIST):
 			memberTypes := semtypes.ListAllMemberTypesInner(a.tyCtx(), collectionType)
 			var result semtypes.SemType = semtypes.NEVER
 			for _, each := range memberTypes.SemTypes {
 				result = semtypes.Union(result, each)
 			}
 			expectedValueType = result
-		case semtypes.IsSubtypeSimple(collectionType, semtypes.MAPPING):
+		case semtypes.IsSubtype(a.tyCtx(), collectionType, semtypes.MAPPING):
 			expectedValueType = semtypes.MappingMemberTypeInnerVal(a.tyCtx(), collectionType, semtypes.STRING)
 		default:
 			tyCtx := a.tyCtx()

--- a/semantics/symbol_resolver.go
+++ b/semantics/symbol_resolver.go
@@ -54,6 +54,7 @@ type symbolResolver interface {
 	GetPkgID() model.PackageID
 	GetScope() model.Scope
 	GetCtx() *context.CompilerContext
+	TypeContext() semtypes.Context
 	GetTypeDefns() map[model.SymbolRef]ast.TypeDefinition
 }
 
@@ -70,6 +71,7 @@ type (
 
 	moduleSymbolResolver struct {
 		ctx            *context.CompilerContext
+		tyCtx          semtypes.Context
 		scope          *model.ModuleScope
 		pkgID          model.PackageID
 		typeDefns      map[model.SymbolRef]ast.TypeDefinition
@@ -101,6 +103,7 @@ func newModuleSymbolResolver(ctx *context.CompilerContext, pkgID model.PackageID
 	}
 	return &moduleSymbolResolver{
 		ctx:       ctx,
+		tyCtx:     semtypes.ContextFrom(ctx.GetTypeEnv()),
 		scope:     scope,
 		pkgID:     pkgID,
 		typeDefns: make(map[model.SymbolRef]ast.TypeDefinition),
@@ -155,6 +158,10 @@ func (ms *moduleSymbolResolver) GetCtx() *context.CompilerContext {
 	return ms.ctx
 }
 
+func (ms *moduleSymbolResolver) TypeContext() semtypes.Context {
+	return ms.tyCtx
+}
+
 func (ms *moduleSymbolResolver) nextDefaultSymbolName() string {
 	name := fmt.Sprintf("$default$%d", ms.defaultCounter)
 	ms.defaultCounter++
@@ -193,6 +200,10 @@ func (bs *blockSymbolResolver) GetCtx() *context.CompilerContext {
 	return bs.parent.GetCtx()
 }
 
+func (bs *blockSymbolResolver) TypeContext() semtypes.Context {
+	return bs.parent.TypeContext()
+}
+
 func (bs *blockSymbolResolver) GetTypeDefns() map[model.SymbolRef]ast.TypeDefinition {
 	return bs.parent.GetTypeDefns()
 }
@@ -221,7 +232,7 @@ func (ms *moduleSymbolResolver) isTypeRefToTypedesc(ref *ast.BLangUserDefinedTyp
 			return false
 		}
 		ty := ms.ctx.GetSymbol(symRef).Type()
-		return ty != nil && semtypes.IsSubtypeSimple(ty, semtypes.TYPEDESC)
+		return ty != nil && semtypes.IsSubtype(ms.tyCtx, ty, semtypes.TYPEDESC)
 	}
 	symRef, _, ok := ms.GetSymbol(typeName)
 	if !ok {
@@ -983,7 +994,7 @@ func resolveObjectInclusions[T symbolResolver](resolver T, unresolvedInclusions 
 			case *model.ClassSymbol:
 				carrier = s
 			case *model.ObjectTypeSymbol:
-				if s.Type() == nil || !semtypes.IsSubtypeSimple(s.Type(), semtypes.OBJECT) {
+				if s.Type() == nil || !semtypes.IsSubtype(resolver.TypeContext(), s.Type(), semtypes.OBJECT) {
 					ctx.SemanticError("type inclusion must be an object type or class", inc.GetPosition())
 					continue
 				}
@@ -1029,7 +1040,7 @@ func resolveRecordTypeInclusions[T symbolResolver](resolver T, typeInclusions []
 		} else {
 			sym := ctx.GetSymbol(symRef)
 			recSym, ok := sym.(*model.RecordSymbol)
-			if !ok || recSym.Type() == nil || !semtypes.IsSubtypeSimple(recSym.Type(), semtypes.MAPPING) {
+			if !ok || recSym.Type() == nil || !semtypes.IsSubtype(resolver.TypeContext(), recSym.Type(), semtypes.MAPPING) {
 				ctx.SemanticError("included type is not a record type", udt.GetPosition())
 				continue
 			}

--- a/semantics/type_resolver.go
+++ b/semantics/type_resolver.go
@@ -1269,7 +1269,7 @@ func buildReturnTypeOp(t typeResolver, params map[string]param, node ast.BLangNo
 		return &model.BinaryTypeOp{Kind: model.TypeOpIntersection, Lhs: lhs, Rhs: rhs}, true
 	case *ast.BLangUserDefinedType:
 		if n.PkgAlias.Value == "" {
-			if p, ok := params[n.TypeName.Value]; ok && semtypes.IsSubtypeSimple(p.ty, semtypes.TYPEDESC) {
+			if p, ok := params[n.TypeName.Value]; ok && semtypes.IsSubtype(t.typeContext(), p.ty, semtypes.TYPEDESC) {
 				return &model.RefTypeOp{Index: p.index}, true
 			}
 		}
@@ -2366,7 +2366,7 @@ func resolveExpressionInner(t typeResolver, chain *binding, expr ast.BLangAction
 // synthesized into a call-site argument list, expectedType is the inferred
 // typedesc<T>. In either case the determined type becomes expectedType.
 func resolveInferredTypedescDefault(t typeResolver, chain *binding, e *ast.BLangInferredTypedescDefault, expectedType semtypes.SemType) (semtypes.SemType, expressionEffect, bool) {
-	if expectedType == nil || !semtypes.IsSubtypeSimple(expectedType, semtypes.TYPEDESC) {
+	if expectedType == nil || !semtypes.IsSubtype(t.typeContext(), expectedType, semtypes.TYPEDESC) {
 		t.semanticError("inferred typedesc default '<>' is only allowed as the default for a typedesc parameter", e.GetPosition())
 		return nil, expressionEffect{}, false
 	}
@@ -2419,7 +2419,7 @@ func resolveXMLSequenceLiteral(t typeResolver, chain *binding, e *ast.BLangXMLSe
 		if !ok {
 			return nil, expressionEffect{}, false
 		}
-		if !semtypes.IsSubtypeSimple(childTy, semtypes.XML) {
+		if !semtypes.IsSubtype(t.typeContext(), childTy, semtypes.XML) {
 			t.semanticError(fmt.Sprintf("expected xml value, got %s", semtypes.ToString(t.typeContext(), childTy)), child.GetPosition())
 			return nil, expressionEffect{}, false
 		}
@@ -2876,8 +2876,8 @@ func isLogicalExpression(opExpr opExpr) bool {
 	}
 }
 
-func isNumericType(ty semtypes.SemType) bool {
-	return semtypes.IsSubtypeSimple(ty, semtypes.NUMBER)
+func isNumericType(cx semtypes.Context, ty semtypes.SemType) bool {
+	return semtypes.IsSubtype(cx, ty, semtypes.NUMBER)
 }
 
 func resolveGroupExpr(t typeResolver, chain *binding, expr *ast.BLangGroupExpr, expectedType semtypes.SemType) (semtypes.SemType, expressionEffect, bool) {
@@ -3018,14 +3018,14 @@ func resolveQueryCollectionElementType(
 	pos diagnostics.Location,
 ) (semtypes.SemType, bool) {
 	switch {
-	case semtypes.IsSubtypeSimple(collectionTy, semtypes.LIST):
+	case semtypes.IsSubtype(t.typeContext(), collectionTy, semtypes.LIST):
 		memberTypes := semtypes.ListAllMemberTypesInner(t.typeContext(), collectionTy)
 		var result semtypes.SemType = semtypes.NEVER
 		for _, each := range memberTypes.SemTypes {
 			result = semtypes.Union(result, each)
 		}
 		return result, true
-	case semtypes.IsSubtypeSimple(collectionTy, semtypes.MAPPING):
+	case semtypes.IsSubtype(t.typeContext(), collectionTy, semtypes.MAPPING):
 		return semtypes.MappingMemberTypeInnerValProj(t.typeContext(), collectionTy, semtypes.STRING), true
 	default:
 		t.unimplemented("query from clause currently supports only list or map collections", pos)
@@ -3144,7 +3144,7 @@ func resolveQueryIntermediateClauses(t typeResolver, chain *binding, queryExpr *
 			if !ok {
 				return nil, false
 			}
-			if !semtypes.IsSubtypeSimple(whereTy, semtypes.BOOLEAN) {
+			if !semtypes.IsSubtype(t.typeContext(), whereTy, semtypes.BOOLEAN) {
 				t.semanticError("where clause expression must be boolean", clause.GetPosition())
 				return nil, false
 			}
@@ -3155,7 +3155,7 @@ func resolveQueryIntermediateClauses(t typeResolver, chain *binding, queryExpr *
 			if !ok {
 				return nil, false
 			}
-			if !semtypes.IsSubtypeSimple(limitTy, semtypes.INT) {
+			if !semtypes.IsSubtype(t.typeContext(), limitTy, semtypes.INT) {
 				t.semanticError("limit clause expression must be int", clause.GetPosition())
 				return nil, false
 			}
@@ -3334,7 +3334,7 @@ func resolveErrorConstructorExpr(t typeResolver, chain *binding, expr *ast.BLang
 		if !ok {
 			return nil, expressionEffect{}, false
 		}
-		if !semtypes.IsSubtypeSimple(refTy, semtypes.ERROR) {
+		if !semtypes.IsSubtype(t.typeContext(), refTy, semtypes.ERROR) {
 			t.semanticError("error type parameter must be a subtype of error", expr.ErrorTypeRef.GetPosition())
 			return nil, expressionEffect{}, false
 		} else {
@@ -3394,7 +3394,7 @@ func resolveUnaryExpr(t typeResolver, chain *binding, expr *ast.BLangUnaryExpr, 
 		resultTy = underlyingTy
 
 	case model.OperatorKind_BITWISE_COMPLEMENT:
-		if !semtypes.IsSubtypeSimple(underlyingTy, semtypes.INT) {
+		if !semtypes.IsSubtype(t.typeContext(), underlyingTy, semtypes.INT) {
 			t.semanticError(fmt.Sprintf("expect int type for %s", string(expr.GetOperatorKind())), expr.GetPosition())
 			return nil, expressionEffect{}, false
 		}
@@ -3415,7 +3415,7 @@ func resolveUnaryExpr(t typeResolver, chain *binding, expr *ast.BLangUnaryExpr, 
 		}
 
 	case model.OperatorKind_NOT:
-		if semtypes.IsSubtypeSimple(exprTy, semtypes.BOOLEAN) {
+		if semtypes.IsSubtype(t.typeContext(), exprTy, semtypes.BOOLEAN) {
 			if semtypes.IsSameType(t.typeContext(), exprTy, semtypes.BOOLEAN) {
 				resultTy = semtypes.BOOLEAN
 			} else {
@@ -3459,7 +3459,7 @@ func negateNumericType(exprTy semtypes.SemType) semtypes.SemType {
 
 func additiveSingletonType(t typeResolver, lhsTy, rhsTy semtypes.SemType, op model.OperatorKind, loc diagnostics.Location) (semtypes.SemType, bool) {
 	bothSameType := func(ty semtypes.BasicTypeBitSet) bool {
-		return semtypes.IsSubtypeSimple(lhsTy, ty) && semtypes.IsSubtypeSimple(rhsTy, ty)
+		return semtypes.IsSubtype(t.typeContext(), lhsTy, ty) && semtypes.IsSubtype(t.typeContext(), rhsTy, ty)
 	}
 	switch {
 	case bothSameType(semtypes.XML):
@@ -3744,7 +3744,7 @@ func resolveMultiplicativeExprInner(t typeResolver, chain *binding, lhsTy semtyp
 
 	lhsBasicTy := semtypes.WidenToBasicTypes(lhsTy)
 	rhsBasicTy := semtypes.WidenToBasicTypes(rhsTy)
-	if !isNumericType(lhsBasicTy) || !isNumericType(rhsBasicTy) {
+	if !isNumericType(t.typeContext(), lhsBasicTy) || !isNumericType(t.typeContext(), rhsBasicTy) {
 		t.semanticError(fmt.Sprintf("expect numeric types for %s", string(op)), pos)
 		return nil, expressionEffect{}, false
 	}
@@ -4060,11 +4060,12 @@ func resolveIndexBasedAccess(t typeResolver, chain *binding, expr *ast.BLangInde
 	}
 
 	var resultTy semtypes.SemType
+	tyCtx := t.typeContext()
 
-	if semtypes.IsSubtypeSimple(containerExprTy, semtypes.LIST) {
+	if semtypes.IsSubtype(tyCtx, containerExprTy, semtypes.LIST) {
 		resultTy = semtypes.ListMemberTypeInnerVal(t.typeContext(), containerExprTy, keyExprTy)
-	} else if semtypes.IsSubtypeSimple(containerExprTy, semtypes.MAPPING|semtypes.NIL) {
-		containerNilable := !semtypes.IsSubtypeSimple(containerExprTy, semtypes.MAPPING)
+	} else if semtypes.IsSubtype(tyCtx, containerExprTy, semtypes.MAPPING|semtypes.NIL) {
+		containerNilable := !semtypes.IsSubtype(t.typeContext(), containerExprTy, semtypes.MAPPING)
 		mappingTy := containerExprTy
 		if containerNilable {
 			mappingTy = semtypes.Diff(containerExprTy, semtypes.NIL)
@@ -4075,7 +4076,7 @@ func resolveIndexBasedAccess(t typeResolver, chain *binding, expr *ast.BLangInde
 			memberTy = semtypes.Union(semtypes.Diff(memberTy, semtypes.UNDEF), semtypes.NIL)
 		}
 		resultTy = memberTy
-	} else if semtypes.IsSubtypeSimple(containerExprTy, semtypes.STRING) {
+	} else if semtypes.IsSubtype(tyCtx, containerExprTy, semtypes.STRING) {
 		resultTy = semtypes.STRING
 	} else {
 		t.semanticError("unsupported container type for index based access", expr.GetPosition())
@@ -4096,14 +4097,14 @@ func resolveFieldBaseAccess(t typeResolver, chain *binding, expr *ast.BLangField
 
 	var memberTy semtypes.SemType
 	switch {
-	case semtypes.IsSubtypeSimple(containerExprTy, semtypes.OBJECT):
+	case semtypes.IsSubtype(tyCtx, containerExprTy, semtypes.OBJECT):
 		memberTy = semtypes.ObjectMemberType(tyCtx, semtypes.StringConst(key), containerExprTy)
 		if memberTy == nil {
 			t.semanticError("field not found in object type", expr.GetPosition())
 			return nil, expressionEffect{}, false
 		}
-	case semtypes.IsSubtypeSimple(containerExprTy, semtypes.MAPPING|semtypes.NIL):
-		containerNilable := !semtypes.IsSubtypeSimple(containerExprTy, semtypes.MAPPING)
+	case semtypes.IsSubtype(tyCtx, containerExprTy, semtypes.MAPPING|semtypes.NIL):
+		containerNilable := !semtypes.IsSubtype(t.typeContext(), containerExprTy, semtypes.MAPPING)
 		mappingTy := containerExprTy
 		if containerNilable {
 			mappingTy = semtypes.Diff(containerExprTy, semtypes.NIL)
@@ -4193,21 +4194,21 @@ func resolveMethodCall(t typeResolver, chain *binding, expr *ast.BLangInvocation
 	if !ok {
 		return nil, expressionEffect{}, false
 	}
-	if semtypes.IsSubtypeSimple(recieverTy, semtypes.OBJECT) {
+	if semtypes.IsSubtype(t.typeContext(), recieverTy, semtypes.OBJECT) {
 		return resolveObjectMethodCall(t, chain, expr, methodSymbol, expectedType)
 	}
 	var symbolRef model.SymbolRef
 	var pkgAlias ast.BLangIdentifier
 	switch {
-	case semtypes.IsSubtypeSimple(recieverTy, semtypes.LIST):
+	case semtypes.IsSubtype(t.typeContext(), recieverTy, semtypes.LIST):
 		symbolRef, pkgAlias, ok = resolveLangLibImport(t, array.PackageName, methodSymbol.name, expr)
-	case semtypes.IsSubtypeSimple(recieverTy, semtypes.INT):
+	case semtypes.IsSubtype(t.typeContext(), recieverTy, semtypes.INT):
 		symbolRef, pkgAlias, ok = resolveLangLibImport(t, bInt.PackageName, methodSymbol.name, expr)
-	case semtypes.IsSubtypeSimple(recieverTy, semtypes.MAPPING):
+	case semtypes.IsSubtype(t.typeContext(), recieverTy, semtypes.MAPPING):
 		symbolRef, pkgAlias, ok = resolveLangLibImport(t, bMap.PackageName, methodSymbol.name, expr)
-	case semtypes.IsSubtypeSimple(recieverTy, semtypes.ERROR):
+	case semtypes.IsSubtype(t.typeContext(), recieverTy, semtypes.ERROR):
 		symbolRef, pkgAlias, ok = resolveLangLibImport(t, bError.PackageName, methodSymbol.name, expr)
-	case semtypes.IsSubtypeSimple(recieverTy, semtypes.STRING):
+	case semtypes.IsSubtype(t.typeContext(), recieverTy, semtypes.STRING):
 		symbolRef, pkgAlias, ok = resolveLangLibImport(t, bString.PackageName, methodSymbol.name, expr)
 	default:
 		symbolRef, pkgAlias, ok = resolveLangLibImport(t, bValue.PackageName, methodSymbol.name, expr)
@@ -4250,7 +4251,7 @@ func finishResolveMethodCall(t typeResolver, chain *binding, receiverTy semtypes
 	methodSymbol *deferredMethodSymbol, argExprs []ast.BLangExpression, node ast.BLangNode,
 ) (model.SymbolRef, semtypes.SemType, expressionEffect, bool) {
 	fnTy := semtypes.ObjectMemberType(t.typeContext(), semtypes.StringConst(methodName), receiverTy)
-	if fnTy == nil || !semtypes.IsSubtypeSimple(fnTy, semtypes.FUNCTION) {
+	if fnTy == nil || !semtypes.IsSubtype(t.typeContext(), fnTy, semtypes.FUNCTION) {
 		remoteMethodName := model.RemoteMethodName(methodName)
 		if methodName != remoteMethodName && isRemoteMethod(t, receiverTy, remoteMethodName) {
 			t.semanticError("remote methods must be invoked using '->' notation", node.GetPosition())
@@ -4405,7 +4406,7 @@ func resolveFunctionCallArgs(t typeResolver, chain *binding, inv invocable, fnSy
 			t.internalError("function symbol has no type", inv.GetPosition())
 			return nil, narrowedSymbol, chain, false
 		}
-		if !semtypes.IsSubtypeSimple(fnTy, semtypes.FUNCTION) {
+		if !semtypes.IsSubtype(t.typeContext(), fnTy, semtypes.FUNCTION) {
 			t.semanticError("not a function value", inv.GetPosition())
 			return nil, narrowedSymbol, chain, false
 		}
@@ -4772,7 +4773,7 @@ func resolveFixedArraySize(t typeResolver, lenExp ast.BLangExpression) (int, boo
 		return 0, false
 	}
 	sizeTy := lenExp.GetDeterminedType()
-	if sizeTy == nil || !semtypes.IsSubtypeSimple(sizeTy, semtypes.INT) {
+	if sizeTy == nil || !semtypes.IsSubtype(t.typeContext(), sizeTy, semtypes.INT) {
 		t.semanticError("fixed-length array size must be a singleton int", lenExp.GetPosition())
 		return 0, false
 	}
@@ -4972,7 +4973,7 @@ func resolveBTypeInner(t typeResolver, btype ast.BType, depth int) (semtypes.Sem
 				if !ok {
 					return nil, false
 				}
-				if !semtypes.IsSubtypeSimple(constraint, semtypes.XML) {
+				if !semtypes.IsSubtype(t.typeContext(), constraint, semtypes.XML) {
 					t.semanticError(fmt.Sprintf("xml type constraint must be a subtype of xml, got %s", semtypes.ToString(t.typeContext(), constraint)), ty.GetPosition())
 					return nil, false
 				}

--- a/semantics/type_resolver_query_test.go
+++ b/semantics/type_resolver_query_test.go
@@ -305,7 +305,7 @@ func TestResolveQueryExprMapCollection(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected resolveQueryExpr to succeed for map collection")
 	}
-	if !semtypes.IsSubtypeSimple(queryTy, semtypes.LIST) {
+	if !semtypes.IsSubtype(semtypes.ContextFrom(cx.GetTypeEnv()), queryTy, semtypes.LIST) {
 		t.Fatalf("expected query result type to be a list, got %v", queryTy)
 	}
 }
@@ -323,7 +323,7 @@ func TestResolveQueryExprMapConstructType(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected resolveQueryExpr to succeed for map construct type")
 	}
-	if !semtypes.IsSubtypeSimple(queryTy, semtypes.MAPPING) {
+	if !semtypes.IsSubtype(semtypes.ContextFrom(cx.GetTypeEnv()), queryTy, semtypes.MAPPING) {
 		t.Fatalf("expected query result type to be mapping, got %v", queryTy)
 	}
 	if len(cx.Diagnostics()) > 0 {
@@ -360,7 +360,7 @@ func TestResolveQueryExprOrderByClause(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected resolveQueryExpr to succeed for order by clause")
 	}
-	if !semtypes.IsSubtypeSimple(queryTy, semtypes.LIST) {
+	if !semtypes.IsSubtype(semtypes.ContextFrom(cx.GetTypeEnv()), queryTy, semtypes.LIST) {
 		t.Fatalf("expected query result type to be a list, got %v", queryTy)
 	}
 	if len(cx.Diagnostics()) > 0 {
@@ -387,7 +387,7 @@ func TestResolveQueryExprJoinClause(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected resolveQueryExpr to succeed for join clause")
 	}
-	if !semtypes.IsSubtypeSimple(queryTy, semtypes.LIST) {
+	if !semtypes.IsSubtype(semtypes.ContextFrom(cx.GetTypeEnv()), queryTy, semtypes.LIST) {
 		t.Fatalf("expected query result type to be a list, got %v", queryTy)
 	}
 	if len(cx.Diagnostics()) > 0 {
@@ -409,7 +409,7 @@ func TestResolveQueryExprMultipleOrderByConsecutive(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected resolveQueryExpr to succeed for consecutive order by clauses")
 	}
-	if !semtypes.IsSubtypeSimple(queryTy, semtypes.LIST) {
+	if !semtypes.IsSubtype(semtypes.ContextFrom(cx.GetTypeEnv()), queryTy, semtypes.LIST) {
 		t.Fatalf("expected query result type to be a list, got %v", queryTy)
 	}
 	if len(cx.Diagnostics()) > 0 {
@@ -432,7 +432,7 @@ func TestResolveQueryExprMultipleOrderByNonConsecutive(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected resolveQueryExpr to succeed for non-consecutive order by clauses")
 	}
-	if !semtypes.IsSubtypeSimple(queryTy, semtypes.LIST) {
+	if !semtypes.IsSubtype(semtypes.ContextFrom(cx.GetTypeEnv()), queryTy, semtypes.LIST) {
 		t.Fatalf("expected query result type to be a list, got %v", queryTy)
 	}
 	if len(cx.Diagnostics()) > 0 {


### PR DESCRIPTION
## Purpose
$subject 
Resolves #491 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed narrowed field-access behavior for records inside union types so record fields are accessed reliably.

* **Tests**
  * Updated/added integration tests to validate expected output for the narrowed field-access scenario.

* **Refactor**
  * Internal type-checking logic made consistent and context-aware to improve compiler correctness around subtype checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ballerina-platform/ballerina-lang-go/pull/496?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->