### PR TITLE
Fix The foreach loop does not work with var type for the iterable

### DIFF
--- a/corpus/ast/subset9/09-bug/foreach-var-v.txt
+++ b/corpus/ast/subset9/09-bug/foreach-var-v.txt
@@ -1,0 +1,117 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (class-definition NumberIterator
+    (variable items (type
+      (array-type
+        (value-type int) dimensions: 1 ([]))) (expr
+      (list-constructor-expr
+        (literal 1)
+        (literal 2)
+        (literal 3))))
+    (variable idx (type
+      (value-type int)) (expr
+      (literal 0)))
+    (function next () (
+      (union-type
+        (record-type
+          (field value
+            (value-type int)))
+        (value-type null)))
+      (block-function-body
+        (if
+          (binary-expr >=
+            (field-based-access idx
+              (simple-var-ref self))
+            (literal 3))
+          (block-stmt
+            (return
+              (literal <nil>))) ())
+        (block-stmt
+          (var-def
+            (variable val (type
+              (value-type int)) (expr
+              (index-based-access
+                (field-based-access items
+                  (simple-var-ref self))
+                (field-based-access idx
+                  (simple-var-ref self))))))
+          (compound-assignment +
+            (field-based-access idx
+              (simple-var-ref self))
+            (literal 1))
+          (return
+            (mapping-constructor-expr
+              (key-value
+                (literal value)
+                (simple-var-ref val))))))))
+  (class-definition NumberGenerator
+    (function iterator () (
+      (user-defined-type NumberIterator))
+      (block-function-body
+        (return
+          (new ())))))
+  (function main () (
+    (union-type
+      (error-type)
+      (value-type null)))
+    (block-function-body
+      (var-def
+        (variable names (type
+          (array-type
+            (value-type string) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal John)
+            (literal Jane)
+            (literal Doe)))))
+      (foreach
+        (var-def
+          (variable name))
+        (simple-var-ref names)
+        (block-stmt
+          (expression-stmt
+            (invocation io println (
+              (literal Hello, )
+              (simple-var-ref name))))))
+      (var-def
+        (variable scores (type
+          (constrained-type
+            (builtin-ref-type map)
+            (value-type int))) (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal alice)
+              (literal 10))
+            (key-value
+              (literal bob)
+              (literal 20))))))
+      (foreach
+        (var-def
+          (variable score))
+        (simple-var-ref scores)
+        (block-stmt
+          (expression-stmt
+            (invocation io println (
+              (simple-var-ref score))))))
+      (var-def
+        (variable gen (type
+          (user-defined-type NumberGenerator)) (expr
+          (new ()))))
+      (foreach
+        (var-def
+          (variable value))
+        (simple-var-ref gen)
+        (block-stmt
+          (expression-stmt
+            (invocation io println (
+              (simple-var-ref value))))))
+      (foreach
+        (var-def
+          (variable i))
+        (binary-expr ..<
+          (literal 0)
+          (literal 3))
+        (block-stmt
+          (expression-stmt
+            (invocation io println (
+              (simple-var-ref i)))))))))

--- a/corpus/bal/subset9/09-bug/foreach-non-iterable-e.bal
+++ b/corpus/bal/subset9/09-bug/foreach-non-iterable-e.bal
@@ -1,0 +1,27 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+class Foo {
+}
+
+public function main() {
+    foreach int a in 5 { // @error
+    }
+
+    Foo f = new;
+    foreach int a in f { // @error
+    }
+}

--- a/corpus/bal/subset9/09-bug/foreach-var-no-next-e.bal
+++ b/corpus/bal/subset9/09-bug/foreach-var-no-next-e.bal
@@ -1,0 +1,27 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+class BadIterable {
+    public function iterator() returns int {
+        return 0;
+    }
+}
+
+public function main() {
+    BadIterable b = new;
+    foreach var a in b { // @error
+    }
+}

--- a/corpus/bal/subset9/09-bug/foreach-var-non-iterable-e.bal
+++ b/corpus/bal/subset9/09-bug/foreach-var-non-iterable-e.bal
@@ -1,0 +1,27 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+class Foo {
+}
+
+public function main() {
+    foreach var a in 5 { // @error
+    }
+
+    Foo f = new;
+    foreach var a in f { // @error
+    }
+}

--- a/corpus/bal/subset9/09-bug/foreach-var-v.bal
+++ b/corpus/bal/subset9/09-bug/foreach-var-v.bal
@@ -1,0 +1,66 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+class NumberIterator {
+    int[] items = [1, 2, 3];
+    int idx = 0;
+
+    public function next() returns record {|int value;|}? {
+        if self.idx >= 3 {
+            return ();
+        }
+        int val = self.items[self.idx];
+        self.idx += 1;
+        return {value: val};
+    }
+}
+
+class NumberGenerator {
+    public function iterator() returns NumberIterator {
+        return new;
+    }
+}
+
+public function main() returns error? {
+    string[] names = ["John", "Jane", "Doe"];
+
+    foreach var name in names {
+        io:println("Hello, ", name); // @output Hello, John
+    }
+    // @output Hello, Jane
+    // @output Hello, Doe
+
+    map<int> scores = {alice: 10, bob: 20};
+    foreach var score in scores {
+        io:println(score); // @output 10
+                           // @output 20
+    }
+
+    NumberGenerator gen = new;
+    foreach var value in gen {
+        io:println(value); // @output 1
+                           // @output 2
+                           // @output 3
+    }
+
+    foreach var i in 0..<3 {
+        io:println(i); // @output 0
+                       // @output 1
+                       // @output 2
+    }
+}

--- a/corpus/bir/subset9/09-bug/foreach-var-v.txt
+++ b/corpus/bir/subset9/09-bug/foreach-var-v.txt
@@ -1,0 +1,257 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+import ballerina.io v 0.0.0;
+import ballerina.io v 0.0.0;
+class NumberIterator {
+  items [int...]
+  idx int
+
+  init() -> nil{
+    bb0 {
+      %2 = ConstantLoad 1
+      %3 = ConstantLoad 2
+      %4 = ConstantLoad 3
+      %5 = ConstantLoad 3
+      %6 = newArray [int...][%5]{%2, %3, %4}
+      %7 = ConstantLoad items
+      self[%7] = %6;
+      %8 = ConstantLoad 0
+      %9 = ConstantLoad idx
+      self[%9] = %8;
+      return;
+    }
+  }
+
+  next() -> nil|{| value: int, never... |}{
+    bb0 {
+      %4 = ConstantLoad idx
+      %3 = self[%4];
+      %5 = %3;
+      %6 = ConstantLoad 3
+      %7 = %6;
+      %2 = >= %5 %7;
+      %2 ? bb1 : bb2;
+    }
+    bb1 {
+      %8 = ConstantLoad <nil>
+      %0 = %8;
+      return;
+    }
+    bb2 {
+      %11 = ConstantLoad idx
+      %10 = self[%11];
+      %13 = ConstantLoad items
+      %12 = self[%13];
+      %9 = %12[%10];
+      val = %9;
+      %15 = ConstantLoad idx
+      %16 = self[%15];
+      %17 = %16;
+      %18 = ConstantLoad 1
+      %19 = %18;
+      %20 = + %17 %19;
+      self[%15] = %20;
+      %21 = ConstantLoad value
+      %22 = newMap {| value: int, never... |}{%21=val}
+      %0 = %22;
+      return;
+    }
+  }
+}
+class NumberGenerator {
+
+  init() -> nil{
+    bb0 {
+      return;
+    }
+  }
+
+  iterator() -> object { int idx; function init() returns nil; [int...] items; function next() returns nil|{| value: int, never... |} }{
+    bb0 {
+      %2 = newObject $anon/.:NumberIterator
+      %3 = init(%2) -> bb1;
+    }
+    bb1 {
+      %5 = %3 is nil
+      %5 ? bb2 : bb3;
+    }
+    bb2 {
+      %4 = %2;
+      GOTO bb4;
+    }
+    bb3 {
+      %4 = %3;
+      GOTO bb4;
+    }
+    bb4 {
+      %0 = %4;
+      return;
+    }
+  }
+}
+main() -> nil|error{
+  bb0 {
+    %1 = ConstantLoad John
+    %2 = ConstantLoad Jane
+    %3 = ConstantLoad Doe
+    %4 = ConstantLoad 3
+    %5 = newArray [string...][%4]{%1, %2, %3}
+    names = %5;
+    $desugar$0 = names;
+    %8 = ConstantLoad 0
+    $desugar$1 = %8;
+    %10 = length($desugar$0) -> bb1;
+  }
+  bb1 {
+    $desugar$2 = %10;
+    GOTO bb2;
+  }
+  bb2 {
+    %13 = $desugar$1;
+    %14 = $desugar$2;
+    %12 = < %13 %14;
+    %12 ? bb3 : bb4;
+  }
+  bb3 {
+    PushScopeFrame 8
+    %0 = (1, $desugar$0)[(1, $desugar$1)];
+    name = %0;
+    %2 = ConstantLoad Hello, 
+    %3 = println(%2,name) -> bb5;
+  }
+  bb4 {
+    %15 = ConstantLoad alice
+    %16 = ConstantLoad 10
+    %17 = ConstantLoad bob
+    %18 = ConstantLoad 20
+    %19 = newMap {| int... |}{%15=%16, %17=%18}
+    scores = %19;
+    $desugar$3 = scores;
+    %22 = keys($desugar$3) -> bb6;
+  }
+  bb5 {
+    %5 = (1, $desugar$1);
+    %6 = ConstantLoad 1
+    %7 = %6;
+    %4 = + %5 %7;
+    (1, $desugar$1) = %4;
+    PopScopeFrame
+    GOTO bb2;
+  }
+  bb6 {
+    $desugar$4 = %22;
+    %24 = ConstantLoad 0
+    $desugar$5 = %24;
+    %26 = length($desugar$4) -> bb7;
+  }
+  bb7 {
+    $desugar$6 = %26;
+    GOTO bb8;
+  }
+  bb8 {
+    %29 = $desugar$5;
+    %30 = $desugar$6;
+    %28 = < %29 %30;
+    %28 ? bb9 : bb10;
+  }
+  bb9 {
+    PushScopeFrame 9
+    %1 = (1, $desugar$4)[(1, $desugar$5)];
+    %0 = (1, $desugar$3)[%1];
+    score = %0;
+    %3 = score;
+    %4 = println(%3) -> bb11;
+  }
+  bb10 {
+    %31 = newObject $anon/.:NumberGenerator
+    %32 = init(%31) -> bb12;
+  }
+  bb11 {
+    %6 = (1, $desugar$5);
+    %7 = ConstantLoad 1
+    %8 = %7;
+    %5 = + %6 %8;
+    (1, $desugar$5) = %5;
+    PopScopeFrame
+    GOTO bb8;
+  }
+  bb12 {
+    %34 = %32 is nil
+    %34 ? bb13 : bb14;
+  }
+  bb13 {
+    %33 = %31;
+    GOTO bb15;
+  }
+  bb14 {
+    %33 = %32;
+    GOTO bb15;
+  }
+  bb15 {
+    gen = %33;
+    $desugar$7 = gen;
+    %37 = iterator($desugar$7) -> bb16;
+  }
+  bb16 {
+    $desugar$9 = %37;
+    GOTO bb17;
+  }
+  bb17 {
+    %39 = ConstantLoad true
+    %39 ? bb18 : bb19;
+  }
+  bb18 {
+    PushScopeFrame 8
+    %0 = next((1, $desugar$9)) -> bb20;
+  }
+  bb19 {
+    %40 = ConstantLoad 0
+    i = %40;
+    %42 = ConstantLoad 3
+    $desugar$12 = %42;
+    GOTO bb24;
+  }
+  bb20 {
+    $desugar$11 = %0;
+    %2 = $desugar$11 is nil
+    %2 ? bb21 : bb22;
+  }
+  bb21 {
+    PopScopeFrame
+    GOTO bb19;
+  }
+  bb22 {
+    %4 = ConstantLoad value
+    %3 = $desugar$11[%4];
+    value = %3;
+    %6 = value;
+    %7 = println(%6) -> bb23;
+  }
+  bb23 {
+    PopScopeFrame
+    GOTO bb17;
+  }
+  bb24 {
+    %45 = i;
+    %46 = $desugar$12;
+    %44 = < %45 %46;
+    %44 ? bb25 : bb26;
+  }
+  bb25 {
+    PushScopeFrame 6
+    %0 = (1, i);
+    %1 = println(%0) -> bb27;
+  }
+  bb26 {
+    return;
+  }
+  bb27 {
+    %3 = (1, i);
+    %4 = ConstantLoad 1
+    %5 = %4;
+    %2 = + %3 %5;
+    (1, i) = %2;
+    PopScopeFrame
+    GOTO bb24;
+  }
+}

--- a/corpus/cfg/subset9/09-bug/foreach-var-v.txt
+++ b/corpus/cfg/subset9/09-bug/foreach-var-v.txt
@@ -1,0 +1,118 @@
+(NumberGenerator
+  (iterator
+    (bb0 () ()
+      (return
+        (new ()))
+    )
+  )
+)
+(NumberIterator
+  (next
+    (bb0 () (bb1 bb2)
+      (binary-expr >=
+        (field-based-access idx
+          (simple-var-ref self))
+        (literal 3))
+    )
+    (bb1 (bb0) ()
+      (return
+        (literal <nil>))
+    )
+    (bb2 (bb0) ()
+      (var-def
+        (variable val (type
+          (value-type int)) (expr
+          (index-based-access
+            (field-based-access items
+              (simple-var-ref self))
+            (field-based-access idx
+              (simple-var-ref self))))))
+      (compound-assignment +
+        (field-based-access idx
+          (simple-var-ref self))
+        (literal 1))
+      (return
+        (mapping-constructor-expr
+          (key-value
+            (literal value)
+            (simple-var-ref val))))
+    )
+  )
+)
+(main
+  (bb0 () (bb1)
+    (var-def
+      (variable names (type
+        (array-type
+          (value-type string) dimensions: 1 ([]))) (expr
+        (list-constructor-expr
+          (literal John)
+          (literal Jane)
+          (literal Doe)))))
+  )
+  (bb1 (bb0 bb2) (bb2 bb3)
+    (simple-var-ref names)
+    (var-def
+      (variable name))
+  )
+  (bb2 (bb1) (bb1)
+    (expression-stmt
+      (invocation io println (
+        (literal Hello, )
+        (simple-var-ref name))))
+  )
+  (bb3 (bb1) (bb4)
+    (var-def
+      (variable scores (type
+        (constrained-type
+          (builtin-ref-type map)
+          (value-type int))) (expr
+        (mapping-constructor-expr
+          (key-value
+            (literal alice)
+            (literal 10))
+          (key-value
+            (literal bob)
+            (literal 20))))))
+  )
+  (bb4 (bb3 bb5) (bb5 bb6)
+    (simple-var-ref scores)
+    (var-def
+      (variable score))
+  )
+  (bb5 (bb4) (bb4)
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref score))))
+  )
+  (bb6 (bb4) (bb7)
+    (var-def
+      (variable gen (type
+        (user-defined-type NumberGenerator)) (expr
+        (new ()))))
+  )
+  (bb7 (bb6 bb8) (bb8 bb9)
+    (simple-var-ref gen)
+    (var-def
+      (variable value))
+  )
+  (bb8 (bb7) (bb7)
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref value))))
+  )
+  (bb9 (bb7) (bb10))
+  (bb10 (bb9 bb11) (bb11 bb12)
+    (binary-expr ..<
+      (literal 0)
+      (literal 3))
+    (var-def
+      (variable i))
+  )
+  (bb11 (bb10) (bb10)
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref i))))
+  )
+  (bb12 (bb10) ())
+)

--- a/corpus/desugared/subset9/09-bug/foreach-var-v.txt
+++ b/corpus/desugared/subset9/09-bug/foreach-var-v.txt
@@ -1,0 +1,208 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang array (as lang.array))
+  (import-package ballerina lang map (as lang.map))
+  (class-definition NumberIterator
+    (variable items (type
+      (array-type
+        (value-type int) dimensions: 1 ([]))))
+    (variable idx (type
+      (value-type int)))
+    (function init () ()
+      (block-function-body
+        (assignment
+          (index-based-access
+            (simple-var-ref self)
+            (literal items))
+          (list-constructor-expr
+            (literal 1)
+            (literal 2)
+            (literal 3)))
+        (assignment
+          (index-based-access
+            (simple-var-ref self)
+            (literal idx))
+          (literal 0))))
+    (function next () (
+      (union-type
+        (record-type
+          (field value
+            (value-type int)))
+        (value-type null)))
+      (block-function-body
+        (if
+          (binary-expr >=
+            (index-based-access
+              (simple-var-ref self)
+              (literal idx))
+            (literal 3))
+          (block-stmt
+            (return
+              (literal <nil>))) ())
+        (block-stmt
+          (var-def
+            (variable val (type
+              (value-type int)) (expr
+              (index-based-access
+                (index-based-access
+                  (simple-var-ref self)
+                  (literal items))
+                (index-based-access
+                  (simple-var-ref self)
+                  (literal idx))))))
+          (compound-assignment +
+            (index-based-access
+              (simple-var-ref self)
+              (literal idx))
+            (literal 1))
+          (return
+            (mapping-constructor-expr
+              (key-value
+                (literal value)
+                (simple-var-ref val))))))))
+  (class-definition NumberGenerator
+    (function init () ()
+      (block-function-body))
+    (function iterator () (
+      (user-defined-type NumberIterator))
+      (block-function-body
+        (return
+          (new ())))))
+  (function main () (
+    (union-type
+      (error-type)
+      (value-type null)))
+    (block-function-body
+      (var-def
+        (variable names (type
+          (array-type
+            (value-type string) dimensions: 1 ([]))) (expr
+          (list-constructor-expr
+            (literal John)
+            (literal Jane)
+            (literal Doe)))))
+      (var-def
+        (variable $desugar$0 (expr
+          (simple-var-ref names))))
+      (var-def
+        (variable $desugar$1 (expr
+          (numeric-literal 0))))
+      (var-def
+        (variable $desugar$2 (expr
+          (invocation lang.array length (
+            (simple-var-ref $desugar$0))))))
+      (while
+        (binary-expr <
+          (simple-var-ref $desugar$1)
+          (simple-var-ref $desugar$2))
+        (block-stmt
+          (var-def
+            (variable name (expr
+              (index-based-access
+                (simple-var-ref $desugar$0)
+                (simple-var-ref $desugar$1)))))
+          (expression-stmt
+            (invocation io println (
+              (literal Hello, )
+              (simple-var-ref name))))
+          (assignment
+            (simple-var-ref $desugar$1)
+            (binary-expr +
+              (simple-var-ref $desugar$1)
+              (numeric-literal 1)))))
+      (var-def
+        (variable scores (type
+          (constrained-type
+            (builtin-ref-type map)
+            (value-type int))) (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal alice)
+              (literal 10))
+            (key-value
+              (literal bob)
+              (literal 20))))))
+      (var-def
+        (variable $desugar$3 (expr
+          (simple-var-ref scores))))
+      (var-def
+        (variable $desugar$4 (expr
+          (invocation lang.map keys (
+            (simple-var-ref $desugar$3))))))
+      (var-def
+        (variable $desugar$5 (expr
+          (numeric-literal 0))))
+      (var-def
+        (variable $desugar$6 (expr
+          (invocation lang.array length (
+            (simple-var-ref $desugar$4))))))
+      (while
+        (binary-expr <
+          (simple-var-ref $desugar$5)
+          (simple-var-ref $desugar$6))
+        (block-stmt
+          (var-def
+            (variable score (expr
+              (index-based-access
+                (simple-var-ref $desugar$3)
+                (index-based-access
+                  (simple-var-ref $desugar$4)
+                  (simple-var-ref $desugar$5))))))
+          (expression-stmt
+            (invocation io println (
+              (simple-var-ref score))))
+          (assignment
+            (simple-var-ref $desugar$5)
+            (binary-expr +
+              (simple-var-ref $desugar$5)
+              (numeric-literal 1)))))
+      (var-def
+        (variable gen (type
+          (user-defined-type NumberGenerator)) (expr
+          (new ()))))
+      (var-def
+        (variable $desugar$7 (expr
+          (simple-var-ref gen))))
+      (var-def
+        (variable $desugar$9 (expr
+          (invocation iterator expr:
+            (simple-var-ref $desugar$7) ()))))
+      (while
+        (literal true)
+        (block-stmt
+          (var-def
+            (variable $desugar$11 (expr
+              (invocation next expr:
+                (simple-var-ref $desugar$9) ()))))
+          (if
+            (type-test-expr is
+              (simple-var-ref $desugar$11))
+            (block-stmt
+              (break)) ())
+          (var-def
+            (variable value (expr
+              (index-based-access
+                (simple-var-ref $desugar$11)
+                (literal value)))))
+          (expression-stmt
+            (invocation io println (
+              (simple-var-ref value))))))
+      (var-def
+        (variable i (expr
+          (literal 0))))
+      (var-def
+        (variable $desugar$12 (expr
+          (literal 3))))
+      (while
+        (binary-expr <
+          (simple-var-ref i)
+          (simple-var-ref $desugar$12))
+        (block-stmt
+          (expression-stmt
+            (invocation io println (
+              (simple-var-ref i))))
+          (assignment
+            (simple-var-ref i)
+            (binary-expr +
+              (simple-var-ref i)
+              (numeric-literal 1))))))))

--- a/corpus/integration/subset9/09-bug/foreach-non-iterable-e.txtar
+++ b/corpus/integration/subset9/09-bug/foreach-non-iterable-e.txtar
@@ -1,0 +1,13 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: incompatible types: expected an iterable collection
+  --> foreach-non-iterable-e.bal:21:22
+   |
+21 |     foreach int a in 5 { // @error
+   |                      ^
+
+error[SEMANTIC_ERROR]: incompatible types: expected an iterable collection
+  --> foreach-non-iterable-e.bal:25:22
+   |
+25 |     foreach int a in f { // @error
+   |                      ^

--- a/corpus/integration/subset9/09-bug/foreach-var-no-next-e.txtar
+++ b/corpus/integration/subset9/09-bug/foreach-var-no-next-e.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: foreach iterator does not have a next method
+  --> foreach-var-no-next-e.bal:25:22
+   |
+25 |     foreach var a in b { // @error
+   |                      ^

--- a/corpus/integration/subset9/09-bug/foreach-var-non-iterable-e.txtar
+++ b/corpus/integration/subset9/09-bug/foreach-var-non-iterable-e.txtar
@@ -1,0 +1,13 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: foreach collection is not iterable
+  --> foreach-var-non-iterable-e.bal:21:22
+   |
+21 |     foreach var a in 5 { // @error
+   |                      ^
+
+error[SEMANTIC_ERROR]: foreach collection is not iterable
+  --> foreach-var-non-iterable-e.bal:25:22
+   |
+25 |     foreach var a in f { // @error
+   |                      ^

--- a/corpus/integration/subset9/09-bug/foreach-var-v.txtar
+++ b/corpus/integration/subset9/09-bug/foreach-var-v.txtar
@@ -1,0 +1,13 @@
+-- stdout --
+Hello, John
+Hello, Jane
+Hello, Doe
+10
+20
+1
+2
+3
+0
+1
+2
+-- stderr --

--- a/semantics/type_resolver.go
+++ b/semantics/type_resolver.go
@@ -969,18 +969,23 @@ func resolveStatementInner(t typeResolver, chain *binding, stmt ast.StatementNod
 	case *ast.BLangBlockStmt:
 		return resolveBlockStatements(t, chain, s.Stmts)
 	case *ast.BLangForeach:
-		if s.VariableDef != nil {
-			variable := s.VariableDef.GetVariable().(*ast.BLangSimpleVariable)
-			if !resolveSimpleVariable(t, chain, variable) {
+		collectionTy, _, ok := resolveActionOrExpression(t, chain, s.Collection, nil)
+		if !ok {
+			return defaultStmtEffect(chain), false
+		}
+		variable := s.VariableDef.GetVariable().(*ast.BLangSimpleVariable)
+		if s.GetIsDeclaredWithVar() {
+			variableTy, ok := resolveForeachVariableType(t, s.Collection, collectionTy)
+			if !ok {
 				return defaultStmtEffect(chain), false
 			}
-			s.VariableDef.SetDeterminedType(semtypes.NEVER)
+			variable.Name.SetDeterminedType(semtypes.NEVER)
+			setExpectedType(variable, variableTy)
+			updateSymbolType(t, variable, variableTy)
+		} else if !resolveSimpleVariable(t, chain, variable) {
+			return defaultStmtEffect(chain), false
 		}
-		if s.Collection != nil {
-			if _, _, ok := resolveActionOrExpression(t, chain, s.Collection, nil); !ok {
-				return defaultStmtEffect(chain), false
-			}
-		}
+		s.VariableDef.SetDeterminedType(semtypes.NEVER)
 		// foreach may run zero times, so the post-loop chain starts from the
 		// loop-entry chain. Body completion and any break paths are merged in.
 		loopT := &loopTypeResolver{parentResolver: t}
@@ -3030,6 +3035,36 @@ func resolveQueryCollectionElementType(
 	default:
 		t.unimplemented("query from clause currently supports only list or map collections", pos)
 		return nil, false
+	}
+}
+
+func resolveForeachVariableType(t typeResolver, collection ast.BLangActionOrExpression, collectionTy semtypes.SemType) (semtypes.SemType, bool) {
+	if binaryExpr, ok := collection.(*ast.BLangBinaryExpr); ok && isRangeExpr(binaryExpr) {
+		return semtypes.INT, true
+	}
+	ctx := t.typeContext()
+	switch {
+	case semtypes.IsSubtype(ctx, collectionTy, semtypes.LIST):
+		return semtypes.ListMemberTypeInnerVal(ctx, collectionTy, semtypes.INT), true
+	case semtypes.IsSubtype(ctx, collectionTy, semtypes.MAPPING):
+		return semtypes.MappingMemberTypeInnerVal(ctx, collectionTy, semtypes.STRING), true
+	default:
+		ld := semtypes.NewListDefinition()
+		emptyListTy := ld.DefineListTypeWrapped(t.typeEnv(), nil, 0, semtypes.NEVER, semtypes.CellMutability_CELL_MUT_NONE)
+		iteratorFnTy := semtypes.ObjectMemberType(ctx, semtypes.StringConst("iterator"), collectionTy)
+		if iteratorFnTy == nil || !semtypes.IsSubtype(ctx, iteratorFnTy, semtypes.FUNCTION) {
+			t.semanticError("foreach collection is not iterable", collection.GetPosition())
+			return nil, false
+		}
+		iteratorTy := semtypes.FunctionReturnType(ctx, iteratorFnTy, emptyListTy)
+		nextFnTy := semtypes.ObjectMemberType(ctx, semtypes.StringConst("next"), iteratorTy)
+		if nextFnTy == nil || !semtypes.IsSubtype(ctx, nextFnTy, semtypes.FUNCTION) {
+			t.semanticError("foreach iterator does not have a next method", collection.GetPosition())
+			return nil, false
+		}
+		nextReturnTy := semtypes.FunctionReturnType(ctx, nextFnTy, emptyListTy)
+		valueRecordTy := semtypes.Diff(semtypes.Diff(nextReturnTy, semtypes.NIL), semtypes.ERROR)
+		return semtypes.MappingMemberTypeInnerVal(ctx, valueRecordTy, semtypes.StringConst("value")), true
 	}
 }
 


### PR DESCRIPTION
## Purpose
$subject
Resolves #490 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced `foreach` loop validation with improved error detection for non-iterable values.
  * Added proper type inference for `foreach var` declarations across arrays, maps, ranges, and custom iterators.
  * Implemented iterator protocol support with `iterator()` and `next()` method validation.

* **Tests**
  * Added comprehensive test cases for `foreach` loop scenarios, including error conditions and successful iterations with various collection types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ballerina-platform/ballerina-lang-go/pull/498?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->