### PR TITLE
Fix mapping constructor candidate selection ignoring optional fields

### DIFF
--- a/corpus/ast/subset9/09-bug/mapping-constructor-v.txt
+++ b/corpus/ast/subset9/09-bug/mapping-constructor-v.txt
@@ -1,0 +1,64 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (type-definition ZoneOffset
+    (intersection-type
+      (value-type readonly)
+      (record-type
+        (field hours optional
+          (value-type int))
+        (field minutes optional
+          (value-type int)))))
+  (type-definition RequiredX
+    (record-type
+      (field x
+        (value-type int))))
+  (type-definition OptionalXRequiredY
+    (record-type
+      (field x optional
+        (value-type int))
+      (field y
+        (value-type int))))
+  (type-definition RequiredXOptionalY
+    (record-type
+      (field x
+        (value-type int))
+      (field y optional
+        (value-type int))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable z (type
+          (user-defined-type ZoneOffset)) (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal hours)
+              (literal 0))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref z))))
+      (var-def
+        (variable u1 (type
+          (union-type
+            (user-defined-type RequiredX)
+            (user-defined-type OptionalXRequiredY))) (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal y)
+              (literal 1))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref u1))))
+      (var-def
+        (variable u2 (type
+          (union-type
+            (user-defined-type OptionalXRequiredY)
+            (user-defined-type RequiredXOptionalY))) (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal x)
+              (literal 1))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref u2)))))))

--- a/corpus/bal/subset9/09-bug/mapping-constructor-ambiguous-e.bal
+++ b/corpus/bal/subset9/09-bug/mapping-constructor-ambiguous-e.bal
@@ -1,0 +1,28 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type RequiredX record {
+    int x;
+};
+
+type OptionalX record {
+    int x?;
+};
+
+public function main() {
+    RequiredX|OptionalX value = {x: 1}; // @error ambiguous inherent type
+    _ = value;
+}

--- a/corpus/bal/subset9/09-bug/mapping-constructor-v.bal
+++ b/corpus/bal/subset9/09-bug/mapping-constructor-v.bal
@@ -1,0 +1,47 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+type ZoneOffset readonly & record {
+    int hours?;
+    int minutes?;
+};
+
+type RequiredX record {
+    int x;
+};
+
+type OptionalXRequiredY record {
+    int x?;
+    int y;
+};
+
+type RequiredXOptionalY record {
+    int x;
+    int y?;
+};
+
+public function main() {
+    ZoneOffset z = {hours: 0};
+    io:println(z); // @output {"hours":0}
+
+    RequiredX|OptionalXRequiredY u1 = {y: 1};
+    io:println(u1); // @output {"y":1}
+
+    OptionalXRequiredY|RequiredXOptionalY u2 = {x: 1};
+    io:println(u2); // @output {"x":1}
+}

--- a/corpus/bir/subset9/09-bug/mapping-constructor-v.txt
+++ b/corpus/bir/subset9/09-bug/mapping-constructor-v.txt
@@ -1,0 +1,28 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad hours
+    %2 = ConstantLoad 0
+    %3 = newMap {| hours: int, minutes: int, nil|boolean|int|float|decimal|string|regexp|readonly&[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|readonly&{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table|xml<xml:Text|xml:Element|xml:Comment|xml:ProcessingInstruction>... |}{%1=%2}
+    z = %3;
+    %5 = println(z) -> bb1;
+  }
+  bb1 {
+    %6 = ConstantLoad y
+    %7 = ConstantLoad 1
+    %8 = newMap {| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%6=%7}
+    u1 = %8;
+    %10 = println(u1) -> bb2;
+  }
+  bb2 {
+    %11 = ConstantLoad x
+    %12 = ConstantLoad 1
+    %13 = newMap {| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%11=%12}
+    u2 = %13;
+    %15 = println(u2) -> bb3;
+  }
+  bb3 {
+    return;
+  }
+}

--- a/corpus/cfg/subset9/09-bug/mapping-constructor-v.txt
+++ b/corpus/cfg/subset9/09-bug/mapping-constructor-v.txt
@@ -1,0 +1,38 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable z (type
+        (user-defined-type ZoneOffset)) (expr
+        (mapping-constructor-expr
+          (key-value
+            (literal hours)
+            (literal 0))))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref z))))
+    (var-def
+      (variable u1 (type
+        (union-type
+          (user-defined-type RequiredX)
+          (user-defined-type OptionalXRequiredY))) (expr
+        (mapping-constructor-expr
+          (key-value
+            (literal y)
+            (literal 1))))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref u1))))
+    (var-def
+      (variable u2 (type
+        (union-type
+          (user-defined-type OptionalXRequiredY)
+          (user-defined-type RequiredXOptionalY))) (expr
+        (mapping-constructor-expr
+          (key-value
+            (literal x)
+            (literal 1))))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref u2))))
+  )
+)

--- a/corpus/desugared/subset9/09-bug/mapping-constructor-v.txt
+++ b/corpus/desugared/subset9/09-bug/mapping-constructor-v.txt
@@ -1,0 +1,63 @@
+(package
+  (import-package ballerina io (as io))
+  (type-definition ZoneOffset
+    (intersection-type
+      (value-type readonly)
+      (record-type
+        (field hours optional
+          (value-type int))
+        (field minutes optional
+          (value-type int)))))
+  (type-definition RequiredX
+    (record-type
+      (field x
+        (value-type int))))
+  (type-definition OptionalXRequiredY
+    (record-type
+      (field x optional
+        (value-type int))
+      (field y
+        (value-type int))))
+  (type-definition RequiredXOptionalY
+    (record-type
+      (field x
+        (value-type int))
+      (field y optional
+        (value-type int))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable z (type
+          (user-defined-type ZoneOffset)) (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal hours)
+              (literal 0))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref z))))
+      (var-def
+        (variable u1 (type
+          (union-type
+            (user-defined-type RequiredX)
+            (user-defined-type OptionalXRequiredY))) (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal y)
+              (literal 1))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref u1))))
+      (var-def
+        (variable u2 (type
+          (union-type
+            (user-defined-type OptionalXRequiredY)
+            (user-defined-type RequiredXOptionalY))) (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal x)
+              (literal 1))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref u2)))))))

--- a/corpus/integration/subset9/09-bug/mapping-constructor-ambiguous-e.txtar
+++ b/corpus/integration/subset9/09-bug/mapping-constructor-ambiguous-e.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: ambiguous inherent type for mapping constructor
+  --> mapping-constructor-ambiguous-e.bal:26:33
+   |
+26 |     RequiredX|OptionalX value = {x: 1}; // @error ambiguous inherent type
+   |                                 ^^^^^^

--- a/corpus/integration/subset9/09-bug/mapping-constructor-v.txtar
+++ b/corpus/integration/subset9/09-bug/mapping-constructor-v.txtar
@@ -1,0 +1,5 @@
+-- stdout --
+{"hours":0}
+{"y":1}
+{"x":1}
+-- stderr --

--- a/semtypes/mapping_alternative.go
+++ b/semtypes/mapping_alternative.go
@@ -98,6 +98,9 @@ func MappingAlternativeAllowsFields(cx Context, alt MappingAlternative, fields [
 			for _, name := range pos.Names {
 				for {
 					if i >= n {
+						if pos.IsOptional(cx, name) {
+							continue names
+						}
 						return false
 					}
 					fieldName := fields[i].Name
@@ -114,6 +117,9 @@ func MappingAlternativeAllowsFields(cx Context, alt MappingAlternative, fields [
 						continue names
 					}
 					if fieldName > name {
+						if pos.IsOptional(cx, name) {
+							continue names
+						}
 						return false
 					}
 					// in < case only type check is needed and FieldInnerVal give the rest type correctly


### PR DESCRIPTION
## Purpose
$subject
Fix https://github.com/ballerina-platform/ballerina-lang-go/issues/487


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test cases for mapping constructor functionality, including union type construction and ambiguous type error detection.
  * Added test fixtures to validate mapping constructor behavior with various field configurations.

* **Bug Fixes**
  * Improved handling of optional fields during mapping field matching to properly skip optional fields when validating assignments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ballerina-platform/ballerina-lang-go/pull/499?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->