### PR TITLE
Add support for ephimaral type atoms for runtime 

### DIFF
--- a/corpus/ast/subset9/09-object/listener-lifecycle1-v.txt
+++ b/corpus/ast/subset9/09-object/listener-lifecycle1-v.txt
@@ -56,8 +56,6 @@
   (variable l (type
     (user-defined-type LifecycleListener)) (expr
     (new ())))
-  (variable _ (expr
-    (simple-var-ref l)))
   (function main () (
     (value-type null))
     (block-function-body

--- a/corpus/bal/subset9/09-bug/quoted-identifier-duplicate1-e.bal
+++ b/corpus/bal/subset9/09-bug/quoted-identifier-duplicate1-e.bal
@@ -18,4 +18,5 @@ public function main() {
     int foo = 5;
     var _ = foo;
     int 'foo = 10; // @error
+    var _ = 'foo;
 }

--- a/corpus/bal/subset9/09-object/listener-lifecycle1-v.bal
+++ b/corpus/bal/subset9/09-object/listener-lifecycle1-v.bal
@@ -42,8 +42,7 @@ class LifecycleListener {
     }
 }
 
-listener LifecycleListener l = new ();
-var _ = l;
+public listener LifecycleListener l = new ();
 
 public function main() {
     io:println("main"); // @output main

--- a/corpus/bir/subset9/09-object/listener-lifecycle1-v.txt
+++ b/corpus/bir/subset9/09-object/listener-lifecycle1-v.txt
@@ -2,7 +2,6 @@ module $anon.. v 0.0.0;
 import ballerina.io v 0.0.0;
 import ballerina.io v 0.0.0;
 $moduleListeners  [object { public function attach(never, [string...]) returns nil|error; public function detach(never) returns nil|error; public function gracefulStop() returns nil|error; public function immediateStop() returns nil|error; public function start() returns nil|error }|object { public function attach(never, string) returns nil|error; public function detach(never) returns nil|error; public function gracefulStop() returns nil|error; public function immediateStop() returns nil|error; public function start() returns nil|error }|object { public function attach(never, nil) returns nil|error; public function detach(never) returns nil|error; public function gracefulStop() returns nil|error; public function immediateStop() returns nil|error; public function start() returns nil|error }...];
-_  object { public function attach(service object, nil) returns nil; public function detach(service object) returns nil|error; public function gracefulStop() returns nil|error; public function immediateStop() returns nil|error; public function init() returns nil; public function start() returns nil|error };
 l  object { public function attach(service object, nil) returns nil; public function detach(service object) returns nil|error; public function gracefulStop() returns nil|error; public function immediateStop() returns nil|error; public function init() returns nil; public function start() returns nil|error };
 class LifecycleListener {
 

--- a/corpus/desugared/subset9/09-object/listener-lifecycle1-v.txt
+++ b/corpus/desugared/subset9/09-object/listener-lifecycle1-v.txt
@@ -3,7 +3,6 @@
   (import-package ballerina lang array (as lang.array))
   (variable l (type
     (user-defined-type LifecycleListener)))
-  (variable _)
   (variable $moduleListeners)
   (class-definition LifecycleListener
     (function init () (
@@ -68,10 +67,7 @@
       (expression-stmt
         (invocation lang.array push (
           (simple-var-ref $moduleListeners)
-          (simple-var-ref l))))
-      (assignment
-        (simple-var-ref _)
-        (simple-var-ref l))))
+          (simple-var-ref l))))))
   (function main () (
     (value-type null))
     (block-function-body

--- a/corpus/integration/subset7/07-closure/typeCast2-p.txtar
+++ b/corpus/integration/subset7/07-closure/typeCast2-p.txtar
@@ -1,4 +1,4 @@
 -- stdout --
 -- stderr --
-error: bad type cast: cannot cast value of type function(1|2|3) returns "a"|"b" to function(1|2) returns "a"|"b"&function(2|3) returns "b"|"c"
+error: bad type cast
         at main(typeCast2-p.bal:30)

--- a/corpus/integration/subset7/07-function/typeCast3-p.txtar
+++ b/corpus/integration/subset7/07-function/typeCast3-p.txtar
@@ -1,4 +1,4 @@
 -- stdout --
 -- stderr --
-error: bad type cast: cannot cast value of type function(1|2|3) returns "a"|"b" to function(1|2) returns "a"|"b"&function(2|3) returns "b"|"c"
+error: bad type cast
         at main(typeCast3-p.bal:31)

--- a/corpus/integration/subset8/08-inttest/typecast1-p.txtar
+++ b/corpus/integration/subset8/08-inttest/typecast1-p.txtar
@@ -1,4 +1,4 @@
 -- stdout --
 -- stderr --
-error: bad type cast: cannot cast value of type 5 to 2|3|4
+error: bad type cast
         at main(typecast1-p.bal:22)

--- a/corpus/integration/subset8/08-inttest/typecast2-p.txtar
+++ b/corpus/integration/subset8/08-inttest/typecast2-p.txtar
@@ -1,4 +1,4 @@
 -- stdout --
 -- stderr --
-error: bad type cast: cannot cast value of type 2.7 to 1|2
+error: bad type cast
         at main(typecast2-p.bal:22)

--- a/corpus/integration/subset8/08-inttest/typecast3-p.txtar
+++ b/corpus/integration/subset8/08-inttest/typecast3-p.txtar
@@ -1,4 +1,4 @@
 -- stdout --
 -- stderr --
-error: bad type cast: cannot cast value of type 300 to int:Signed8
+error: bad type cast
         at main(typecast3-p.bal:20)

--- a/corpus/integration/subset8/08-singleton/stringcast2-p.txtar
+++ b/corpus/integration/subset8/08-singleton/stringcast2-p.txtar
@@ -1,4 +1,4 @@
 -- stdout --
 -- stderr --
-error: bad type cast: cannot cast value of type "gren" to "blue"|"green"|"red"
+error: bad type cast
         at main(stringcast2-p.bal:27)

--- a/corpus/integration/subset9/09-bug/quoted-identifier-duplicate1-e.txtar
+++ b/corpus/integration/subset9/09-bug/quoted-identifier-duplicate1-e.txtar
@@ -5,9 +5,3 @@ error[SEMANTIC_ERROR]: Variable already defined: foo
    |
 20 |     int 'foo = 10; // @error
    |     ^^^^^^^^^^^^^^
-
-error[SEMANTIC_ERROR]: unused variable 'foo'
-  --> quoted-identifier-duplicate1-e.bal:20:5
-   |
-20 |     int 'foo = 10; // @error
-   |     ^^^^^^^^^^^^^^

--- a/lib/langlibs/go/lang.map/map.go
+++ b/lib/langlibs/go/lang.map/map.go
@@ -21,7 +21,6 @@ import (
 	"ballerina-lang-go/runtime/extern"
 	"ballerina-lang-go/semtypes"
 	"ballerina-lang-go/values"
-	"sync"
 )
 
 const (
@@ -34,15 +33,10 @@ func mapLength(_ *extern.Context, args []values.BalValue) (values.BalValue, erro
 	return int64(m.Len()), nil
 }
 
-func mapKeys(rt *runtime.Runtime) extern.NativeFunc {
-	var stringArrayTy semtypes.SemType
-	var stringArrayOnce sync.Once
+func mapKeys(env semtypes.Env) extern.NativeFunc {
+	ld := semtypes.NewListDefinition()
+	stringArrayTy := ld.DefineListTypeWrappedWithEnvSemType(env, semtypes.STRING)
 	return func(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
-		stringArrayOnce.Do(func() {
-			env := rt.GetTypeEnv()
-			ld := semtypes.NewListDefinition()
-			stringArrayTy = ld.DefineListTypeWrappedWithEnvSemType(env, semtypes.STRING)
-		})
 		m := args[0].(*values.Map)
 		keys := m.Keys()
 		items := make([]values.BalValue, len(keys))
@@ -65,7 +59,7 @@ func mapRemove(ctx *extern.Context, args []values.BalValue) (values.BalValue, er
 
 func initMapModule(rt *runtime.Runtime) {
 	runtime.RegisterExternFunction(rt, orgName, moduleName, "length", mapLength)
-	runtime.RegisterExternFunction(rt, orgName, moduleName, "keys", mapKeys(rt))
+	runtime.RegisterExternFunction(rt, orgName, moduleName, "keys", mapKeys(rt.GetTypeEnv()))
 	runtime.RegisterExternFunction(rt, orgName, moduleName, "remove", mapRemove)
 }
 

--- a/lib/stdlibs/ballerina/http/0.0.1/go1.2/native/http_native.go
+++ b/lib/stdlibs/ballerina/http/0.0.1/go1.2/native/http_native.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	"ballerina-lang-go/bir"
@@ -49,8 +48,8 @@ func init() {
 	runtime.RegisterModuleInitializer(initHttpModule)
 }
 
-// httpTypes holds the lazily-built semtypes used by the http runtime.
-// All entries are computed once on first use (so concurrent reads shouldn't be a problem);
+// httpTypes holds the semtypes used by the http runtime. They are built once
+// in initHttpModule (single-threaded) and captured by the handler closures.
 type httpTypes struct {
 	byteArrTy  semtypes.SemType
 	strArrTy   semtypes.SemType
@@ -85,28 +84,20 @@ func initHttpModule(rt *runtime.Runtime) {
 		"ballerina/http:TRAILING": "TRAILING",
 	})
 
-	var (
-		once  sync.Once
-		types httpTypes
-	)
-	ensureTypes := func() {
-		once.Do(func() {
-			env := rt.GetTypeEnv()
-			bld := semtypes.NewListDefinition()
-			types.byteArrTy = bld.DefineListTypeWrappedWithEnvSemType(env, semtypes.BYTE)
-			sld := semtypes.NewListDefinition()
-			types.strArrTy = sld.DefineListTypeWrappedWithEnvSemType(env, semtypes.STRING)
-			typCtx := semtypes.ContextFrom(env)
-			jsonTy := semtypes.CreateJSON(typCtx)
-			jmd := semtypes.NewMappingDefinition()
-			types.jsonMapTy = jmd.DefineMappingTypeWrapped(env, nil, jsonTy)
-			jld := semtypes.NewListDefinition()
-			types.jsonListTy = jld.DefineListTypeWrappedWithEnvSemType(env, jsonTy)
-		})
+	env := rt.GetTypeEnv()
+	jsonTy := semtypes.CreateJSON(semtypes.ContextFrom(env))
+	byteArrLd := semtypes.NewListDefinition()
+	strArrLd := semtypes.NewListDefinition()
+	jsonMapMd := semtypes.NewMappingDefinition()
+	jsonListLd := semtypes.NewListDefinition()
+	types := httpTypes{
+		byteArrTy:  byteArrLd.DefineListTypeWrappedWithEnvSemType(env, semtypes.BYTE),
+		strArrTy:   strArrLd.DefineListTypeWrappedWithEnvSemType(env, semtypes.STRING),
+		jsonMapTy:  jsonMapMd.DefineMappingTypeWrapped(env, nil, jsonTy),
+		jsonListTy: jsonListLd.DefineListTypeWrappedWithEnvSemType(env, jsonTy),
 	}
 
 	msgToBody := func(tc semtypes.Context, msg values.BalValue) ([]byte, string) {
-		ensureTypes()
 		switch v := msg.(type) {
 		case string:
 			return []byte(v), "text/plain"
@@ -486,7 +477,6 @@ func initHttpModule(rt *runtime.Runtime) {
 
 	runtime.RegisterExternFunction(rt, orgName, moduleName, "Response.getJsonPayload",
 		func(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
-			ensureTypes()
 			self := args[0].(*values.Object)
 			bodyVal, _ := self.Get("body")
 			body := bodyVal.(string)
@@ -501,7 +491,6 @@ func initHttpModule(rt *runtime.Runtime) {
 
 	runtime.RegisterExternFunction(rt, orgName, moduleName, "Response.getBinaryPayload",
 		func(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
-			ensureTypes()
 			self := args[0].(*values.Object)
 			bodyVal, _ := self.Get("body")
 			body := bodyVal.(string)
@@ -550,7 +539,6 @@ func initHttpModule(rt *runtime.Runtime) {
 
 	runtime.RegisterExternFunction(rt, orgName, moduleName, "Response.getHeaderNames",
 		func(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
-			ensureTypes()
 			self := args[0].(*values.Object)
 			keys := responseHeaders(self).Keys()
 			items := make([]values.BalValue, len(keys))

--- a/runtime/internal/exec/non_terminators.go
+++ b/runtime/internal/exec/non_terminators.go
@@ -71,7 +71,7 @@ func execNewMap(ctx *extern.Context, newMap *bir.NewMap, frame *Frame) {
 	}
 	atomic := semtypes.ToMappingAtomicType(ctx.TypeCtx, newMap.Type)
 	if atomic == nil {
-		panic(fmt.Sprintf("mapping inherent type has no atomic representation: %s", semtypes.ToString(ctx.TypeCtx, newMap.Type)))
+		panic("mapping inherent type has no atomic representation")
 	}
 	m := values.NewMap(newMap.Type, atomic, newMap.IsReadonly, entries)
 	setOperandValue(ctx, newMap.GetLhsOperand(), frame, m)
@@ -239,19 +239,18 @@ func castValue(ctx *extern.Context, value values.BalValue, targetType semtypes.S
 	case semtypes.IsSubtypeSimple(targetType, semtypes.DECIMAL):
 		converted = toDecimal(value)
 	default:
-		panic(badTypeCastError(typeCtx, valueType, targetType))
+		panic(badTypeCastError())
 	}
 	// Numeric conversion only guarantees the basic type; narrow subtypes
 	// (e.g. `2|3|4`, `int:Signed8`, `byte`) still require a membership check.
 	if !semtypes.IsSubtype(typeCtx, values.SemTypeForValue(converted), targetType) {
-		panic(badTypeCastError(typeCtx, valueType, targetType))
+		panic(badTypeCastError())
 	}
 	return converted
 }
 
-func badTypeCastError(typeCtx semtypes.Context, valueType, targetType semtypes.SemType) *values.Error {
-	return values.NewErrorWithMessage(fmt.Sprintf("bad type cast: cannot cast value of type %s to %s",
-		semtypes.ToString(typeCtx, valueType), semtypes.ToString(typeCtx, targetType)))
+func badTypeCastError() *values.Error {
+	return values.NewErrorWithMessage("bad type cast")
 }
 
 func toInt(value any) int64 {

--- a/runtime/internal/modules/registry_impl.go
+++ b/runtime/internal/modules/registry_impl.go
@@ -20,7 +20,6 @@ import (
 	"ballerina-lang-go/bir"
 	"ballerina-lang-go/model"
 	"ballerina-lang-go/runtime/extern"
-	"ballerina-lang-go/semtypes"
 )
 
 type Registry struct {
@@ -29,7 +28,6 @@ type Registry struct {
 	nativeFunctions map[string]*ExternFunction
 	runtimeBuiltins map[string]extern.NativeFunc
 	modules         map[string]*BIRModule
-	typeEnv         semtypes.Env
 }
 
 func NewRegistry(builtins map[string]extern.NativeFunc) *Registry {
@@ -80,14 +78,6 @@ func (r *Registry) RegisterModule(id *model.PackageID, m *BIRModule) *BIRModule 
 
 func (r *Registry) GetModule(pkgId *model.PackageID) *BIRModule {
 	return r.modules[moduleKey(pkgId)]
-}
-
-func (r *Registry) SetTypeEnv(env semtypes.Env) {
-	r.typeEnv = env
-}
-
-func (r *Registry) GetTypeEnv() semtypes.Env {
-	return r.typeEnv
 }
 
 func (r *Registry) RegisterExternFunction(orgName string, moduleName string, funcName string, impl extern.NativeFunc) {

--- a/runtime/lifecycle.go
+++ b/runtime/lifecycle.go
@@ -135,6 +135,7 @@ func initializingAction(rt *Runtime) {
 	rt.mu.Lock()
 	rt.state = StateInitializing
 	rt.mu.Unlock()
+	rt.env.TypeEnv.Freeze()
 	rt.setupSignalListeners()
 }
 

--- a/semtypes/canonical_key.go
+++ b/semtypes/canonical_key.go
@@ -18,7 +18,11 @@ package semtypes
 
 import "sync"
 
-type atomKey int
+type atomKey struct {
+	index int
+	gen   uint64
+	rec   bool
+}
 
 type bddKey int
 
@@ -48,12 +52,12 @@ var bddKeyInterner = struct {
 	keys: make(map[bddNodeKey]bddKey),
 }
 
-func typeAtomKey(index int) atomKey {
-	return atomKey(index << 1)
+func typeAtomKey(index int, gen uint64) atomKey {
+	return atomKey{index: index, gen: gen}
 }
 
 func recAtomKey(index int) atomKey {
-	return atomKey(index<<1 | 1)
+	return atomKey{index: index, rec: true}
 }
 
 func internBddNodeKey(key bddNodeKey) bddKey {

--- a/semtypes/cell_subtype.go
+++ b/semtypes/cell_subtype.go
@@ -32,6 +32,6 @@ func cellContainingWithEnvSemTypeCellMutability(env Env, ty SemType, mut CellMut
 	}
 	atomicCell := cellAtomicTypeFrom(ty, mut)
 	atom := env.cellAtom(&atomicCell)
-	bdd := bddAtom(&atom)
+	bdd := bddAtom(atom)
 	return getBasicSubtype(BTCell, bdd)
 }

--- a/semtypes/env.go
+++ b/semtypes/env.go
@@ -16,8 +16,10 @@
 package semtypes
 
 import (
+	"math"
 	"sync"
 	"sync/atomic"
+	"weak"
 )
 
 // Env is an opaque pointer to the type environment. All (potentially recursive) types are defined in a type environment.
@@ -28,7 +30,6 @@ type Env = *env
 func CreateTypeEnv() Env {
 	env := &env{
 		atomTable: make(map[atomicType]typeAtom),
-		types:     make(map[string]SemType),
 	}
 	fillRecAtoms(predefTypeEnv, &env.recListAtoms, predefTypeEnv.initializedRecListAtoms)
 	fillRecAtoms(predefTypeEnv, &env.recMappingAtoms, predefTypeEnv.initializedRecMappingAtoms)
@@ -61,13 +62,50 @@ type env struct {
 
 	distinctAtoms     int
 	distinctAtomMutex sync.Mutex
-	// migration-note: unlike java implementation this will leak memory. So be careful about adding atoms in an unbounded way.
-	atomTableMutex sync.Mutex
-	atomTable      map[atomicType]typeAtom
-
-	types map[string]SemType
+	atomTableMutex    sync.Mutex
+	atomTable         map[atomicType]typeAtom
 
 	preallocatedTypeVals preallocatedTypeVals
+
+	// frozen seals the persistent atom stores once the runtime begins
+	// interpretation. After freeze, atomTable and the rec-atom slices are
+	// read-only and any new atom is allocated in the ephemeral store instead.
+	frozen          atomic.Bool
+	ephemeralMu     sync.Mutex
+	ephemeralSlots  []ephemeralSlot
+	frozenAtomCount int
+}
+
+// ephemeralSlot holds a single runtime (ephemeral) type atom via a weak
+// pointer so it can be garbage collected with its owning value/type. A slot's
+// position gives the atom a stable index (frozenAtomCount + position); reusing a
+// freed slot bumps gen so the atom's canonicalKey stays unique across reuse.
+type ephemeralSlot struct {
+	gen uint64
+	ptr weak.Pointer[typeAtom]
+}
+
+// Freeze seals the persistent atom stores. It is called by the runtime state
+// machine when it first transitions into the initializing state, before any
+// interpretation runs. It is idempotent.
+func (e *env) Freeze() {
+	e.atomTableMutex.Lock()
+	defer e.atomTableMutex.Unlock()
+	if e.frozen.Load() {
+		return
+	}
+	e.frozenAtomCount = len(e.atomTable)
+	e.frozen.Store(true)
+}
+
+// assertNotFrozenForRecAtom guards recursive-atom allocation. Recursive types
+// are stored permanently in the env and cannot be created at runtime, so any
+// attempt to allocate a rec atom after freeze (e.g. Definition.GetSemType) is a
+// bug.
+func (e *env) assertNotFrozenForRecAtom() {
+	if e.frozen.Load() {
+		panic("cannot define recursive types at runtime")
+	}
 }
 
 func (e *env) recListAtomCount() int {
@@ -96,6 +134,7 @@ func (e *env) distinctAtomCountGetAndIncrement() int {
 }
 
 func (e *env) recFunctionAtom() recAtom {
+	e.assertNotFrozenForRecAtom()
 	e.recFunctionAtomsMutex.Lock()
 	defer e.recFunctionAtomsMutex.Unlock()
 	result := len(e.recFunctionAtoms)
@@ -116,32 +155,77 @@ func (e *env) getRecFunctionAtomType(rec recAtom) *functionAtomicType {
 	return e.recFunctionAtoms[rec.index()]
 }
 
-func (e *env) listAtom(atomicType *ListAtomicType) typeAtom {
+func (e *env) listAtom(atomicType *ListAtomicType) *typeAtom {
 	return e.typeAtom(atomicType)
 }
 
-func (e *env) mappingAtom(atomicType *MappingAtomicType) typeAtom {
+func (e *env) mappingAtom(atomicType *MappingAtomicType) *typeAtom {
 	return e.typeAtom(atomicType)
 }
 
-func (e *env) functionAtom(atomicType *functionAtomicType) typeAtom {
+func (e *env) functionAtom(atomicType *functionAtomicType) *typeAtom {
 	return e.typeAtom(atomicType)
 }
 
-func (e *env) cellAtom(atomicType *cellAtomicType) typeAtom {
+func (e *env) cellAtom(atomicType *cellAtomicType) *typeAtom {
 	return e.typeAtom(atomicType)
 }
 
-func (e *env) typeAtom(atomicType atomicType) typeAtom {
+// typeAtom returns the atom for atomicType. Persistent atoms are stored in the
+// atomTable by value and a fresh pointer to a copy is returned (atom identity is
+// by index, not pointer). After freeze, new atoms are ephemeral so the env can
+// only retain them weakly.
+func (e *env) typeAtom(atomicType atomicType) *typeAtom {
+	if e.frozen.Load() {
+		// After freezing atom table is immutable so we can do lookup lock free
+		if ta, ok := e.atomTable[atomicType]; ok {
+			return &ta
+		}
+		return e.newEphemeralAtom(atomicType)
+	}
 	e.atomTableMutex.Lock()
+	if e.frozen.Load() {
+		e.atomTableMutex.Unlock()
+		if ta, ok := e.atomTable[atomicType]; ok {
+			return &ta
+		}
+		return e.newEphemeralAtom(atomicType)
+	}
 	defer e.atomTableMutex.Unlock()
 	ta, ok := e.atomTable[atomicType]
 	if ok {
-		return ta
+		return &ta
 	}
 	ta = createTypeAtom(len(e.atomTable), atomicType)
 	e.atomTable[atomicType] = ta
-	return ta
+	return &ta
+}
+
+// newEphemeralAtom allocates a type atom that the env retains only via a
+// weak pointer. It reuses a slot whose previous occupant has been collected,
+// otherwise appends a new slot. A slot whose gen has reached the max is retired
+// (skipped) rather than wrapped, since reusing a gen could alias a stale memo
+// entry on the atom's canonicalKey.
+func (e *env) newEphemeralAtom(atomicType atomicType) *typeAtom {
+	// In theory we can improve through put by having per slot rw locks and one lock for resizing the array
+	// Idea is we can create ephemeral atoms concurrently, but I don't feel like dealing with the complexity
+	// is worth it (array resizing, etc)
+	e.ephemeralMu.Lock()
+	defer e.ephemeralMu.Unlock()
+	for i := range e.ephemeralSlots {
+		slot := &e.ephemeralSlots[i]
+		if slot.ptr.Value() != nil || slot.gen == math.MaxUint64 {
+			continue
+		}
+		slot.gen++
+		p := createEphemeralTypeAtom(e.frozenAtomCount+i, slot.gen, atomicType)
+		slot.ptr = weak.Make(p)
+		return p
+	}
+	i := len(e.ephemeralSlots)
+	p := createEphemeralTypeAtom(e.frozenAtomCount+i, 1, atomicType)
+	e.ephemeralSlots = append(e.ephemeralSlots, ephemeralSlot{gen: 1, ptr: weak.Make(p)})
+	return p
 }
 
 func (e *env) listAtomType(atom atom) *ListAtomicType {
@@ -166,6 +250,7 @@ func (e *env) mappingAtomType(atom atom) *MappingAtomicType {
 }
 
 func (e *env) recListAtom() recAtom {
+	e.assertNotFrozenForRecAtom()
 	e.recListAtomsMutex.Lock()
 	defer e.recListAtomsMutex.Unlock()
 	result := len(e.recListAtoms)
@@ -174,6 +259,7 @@ func (e *env) recListAtom() recAtom {
 }
 
 func (e *env) recMappingAtom() recAtom {
+	e.assertNotFrozenForRecAtom()
 	e.recMappingAtomsMutex.Lock()
 	defer e.recMappingAtomsMutex.Unlock()
 	result := len(e.recMappingAtoms)

--- a/semtypes/env_init_test.go
+++ b/semtypes/env_init_test.go
@@ -74,52 +74,52 @@ func TestEnvInitAtomTable(t *testing.T) {
 	ta0, ok := atomTable[&cellAtomicVal]
 	assertTrue(t, ok, "cellAtomicVal should be in atomTable")
 	assertEqual(t, ta0.AtomicType, &cellAtomicVal)
-	assertEqual(t, ta0, typeAtom0)
+	assertEqual(t, ta0, *typeAtom0)
 
 	ta1, ok := atomTable[&cellAtomicNever]
 	assertTrue(t, ok, "cellAtomicNever should be in atomTable")
 	assertEqual(t, ta1.AtomicType, &cellAtomicNever)
-	assertEqual(t, ta1, typeAtom1)
+	assertEqual(t, ta1, *typeAtom1)
 
 	ta2, ok := atomTable[&cellAtomicInner]
 	assertTrue(t, ok, "cellAtomicInner should be in atomTable")
 	assertEqual(t, ta2.AtomicType, &cellAtomicInner)
-	assertEqual(t, ta2, typeAtom2)
+	assertEqual(t, ta2, *typeAtom2)
 
 	ta3, ok := atomTable[&cellAtomicInnerMapping]
 	assertTrue(t, ok, "cellAtomicInnerMapping should be in atomTable")
 	assertEqual(t, ta3.AtomicType, &cellAtomicInnerMapping)
-	assertEqual(t, ta3, typeAtom3)
+	assertEqual(t, ta3, *typeAtom3)
 
 	ta4, ok := atomTable[&listAtomicMapping]
 	assertTrue(t, ok, "listAtomicMapping should be in atomTable")
 	assertEqual(t, ta4.AtomicType, &listAtomicMapping)
-	assertEqual(t, ta4, typeAtom4)
+	assertEqual(t, ta4, *typeAtom4)
 
 	ta5, ok := atomTable[CELL_ATOMIC_INNER_MAPPING_RO]
 	assertTrue(t, ok, "CELL_ATOMIC_INNER_MAPPING_RO should be in atomTable")
 	assertEqual(t, ta5.AtomicType, CELL_ATOMIC_INNER_MAPPING_RO)
-	assertEqual(t, ta5, typeAtom5)
+	assertEqual(t, ta5, *typeAtom5)
 
 	ta6, ok := atomTable[&listAtomicMappingRo]
 	assertTrue(t, ok, "listAtomicMappingRo should be in atomTable")
 	assertEqual(t, ta6.AtomicType, &listAtomicMappingRo)
-	assertEqual(t, ta6, typeAtom6)
+	assertEqual(t, ta6, *typeAtom6)
 
 	ta7, ok := atomTable[&cellAtomicInnerRo]
 	assertTrue(t, ok, "cellAtomicInnerRo should be in atomTable")
 	assertEqual(t, ta7.AtomicType, &cellAtomicInnerRo)
-	assertEqual(t, ta7, typeAtom7)
+	assertEqual(t, ta7, *typeAtom7)
 
 	ta8, ok := atomTable[&cellAtomicUndef]
 	assertTrue(t, ok, "cellAtomicUndef should be in atomTable")
 	assertEqual(t, ta8.AtomicType, &cellAtomicUndef)
-	assertEqual(t, ta8, typeAtom8)
+	assertEqual(t, ta8, *typeAtom8)
 
 	ta9, ok := atomTable[&listAtomicTwoElement]
 	assertTrue(t, ok, "listAtomicTwoElement should be in atomTable")
 	assertEqual(t, ta9.AtomicType, &listAtomicTwoElement)
-	assertEqual(t, ta9, typeAtom9)
+	assertEqual(t, ta9, *typeAtom9)
 }
 
 // TestTypeAtomIndices tests type atom indices uniqueness

--- a/semtypes/ephemeral_atom_test.go
+++ b/semtypes/ephemeral_atom_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package semtypes
+
+import (
+	"runtime"
+	"testing"
+)
+
+func defineRuntimeList(env Env, member SemType) SemType {
+	ld := NewListDefinition()
+	return ld.DefineListTypeWrappedWithEnvSemType(env, member)
+}
+
+func TestFreezeRoutesNewAtomsToEphemeralStore(t *testing.T) {
+	env := CreateTypeEnv()
+	env.Freeze()
+
+	env.atomTableMutex.Lock()
+	before := len(env.atomTable)
+	env.atomTableMutex.Unlock()
+
+	ty := defineRuntimeList(env, STRING)
+
+	env.atomTableMutex.Lock()
+	after := len(env.atomTable)
+	env.atomTableMutex.Unlock()
+
+	if after != before {
+		t.Fatalf("atomTable grew after freeze: before=%d after=%d", before, after)
+	}
+
+	atom := ToListAtomicType(ContextFrom(env), ty)
+	if atom == nil {
+		t.Fatal("expected a list atomic type for the runtime list")
+	}
+	if got := len(env.ephemeralSlots); got == 0 {
+		t.Fatal("expected ephemeral slots to be populated")
+	}
+	for _, slot := range env.ephemeralSlots {
+		if p := slot.ptr.Value(); p != nil && p.index() < env.frozenAtomCount {
+			t.Fatalf("ephemeral atom idx %d must be >= frozenAtomCount %d", p.index(), env.frozenAtomCount)
+		}
+	}
+}
+
+func TestEphemeralAtomIsReclaimedAndSlotReused(t *testing.T) {
+	env := CreateTypeEnv()
+	env.Freeze()
+
+	// Hold a runtime type, capture its ephemeral slot, then drop it.
+	slotsAfterFirst := func() int {
+		ty := defineRuntimeList(env, STRING)
+		if n := liveEphemeralSlots(env); n == 0 {
+			t.Fatal("expected at least one live ephemeral slot")
+		}
+		slots := len(env.ephemeralSlots)
+		runtime.KeepAlive(ty)
+		return slots
+	}()
+
+	// Force collection; the slot's weak pointer should clear.
+	reclaimed := false
+	for i := 0; i < 5 && !reclaimed; i++ {
+		runtime.GC()
+		if liveEphemeralSlots(env) == 0 {
+			reclaimed = true
+		}
+	}
+	if !reclaimed {
+		t.Fatal("expected the ephemeral atom to be garbage collected")
+	}
+
+	// A new runtime type reuses the freed slot instead of growing the array.
+	ty2 := defineRuntimeList(env, INT)
+	if ToListAtomicType(ContextFrom(env), ty2) == nil {
+		t.Fatal("expected a list atomic type for the second runtime list")
+	}
+	if grew := len(env.ephemeralSlots); grew > slotsAfterFirst {
+		t.Fatalf("expected slot reuse, but slots grew from %d to %d", slotsAfterFirst, grew)
+	}
+	runtime.KeepAlive(ty2)
+}
+
+func TestFrozenEnvForbidsRecursiveTypes(t *testing.T) {
+	env := CreateTypeEnv()
+	env.Freeze()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected a panic when allocating a recursive atom after freeze")
+		}
+	}()
+	ld := &ListDefinition{}
+	ld.GetSemType(env) // allocates a rec atom -> must panic
+}
+
+func liveEphemeralSlots(env Env) int {
+	env.ephemeralMu.Lock()
+	defer env.ephemeralMu.Unlock()
+	n := 0
+	for _, slot := range env.ephemeralSlots {
+		if slot.ptr.Value() != nil {
+			n++
+		}
+	}
+	return n
+}

--- a/semtypes/function_definition.go
+++ b/semtypes/function_definition.go
@@ -61,7 +61,7 @@ func (f *FunctionDefinition) defineInternal(env Env, atomicType functionAtomicTy
 		a = rec
 		env.setRecFunctionAtomType(*rec, &atomicType)
 	} else {
-		a = new(env.functionAtom(&atomicType))
+		a = env.functionAtom(&atomicType)
 	}
 	return f.createSemType(a)
 }

--- a/semtypes/list_alternative.go
+++ b/semtypes/list_alternative.go
@@ -89,7 +89,7 @@ func intersectListAtoms(env Env, atoms []*ListAtomicType) (SemType, ListAtomicTy
 		}
 	}
 	typeAtom := env.listAtom(atom)
-	ty := createBasicSemType(BTList, bddAtom(&typeAtom))
+	ty := createBasicSemType(BTList, bddAtom(typeAtom))
 	return ty, *atom, true
 }
 

--- a/semtypes/list_definition.go
+++ b/semtypes/list_definition.go
@@ -95,7 +95,7 @@ func (l *ListDefinition) define(env Env, initial []SemType, fixedLength int, res
 		atom = rec
 		env.setRecListAtomType(*rec, &atomicType)
 	} else {
-		atom = new(env.listAtom(&atomicType))
+		atom = env.listAtom(&atomicType)
 	}
 	return l.createSemType(env, atom)
 }

--- a/semtypes/mapping_alternative.go
+++ b/semtypes/mapping_alternative.go
@@ -68,7 +68,7 @@ func intersectMappingAtoms(env Env, atoms []*MappingAtomicType) (SemType, *Mappi
 		atom = result
 	}
 	typeAtom := env.mappingAtom(atom)
-	ty := createBasicSemType(BTMapping, bddAtom(&typeAtom))
+	ty := createBasicSemType(BTMapping, bddAtom(typeAtom))
 	return ty, atom, true
 }
 

--- a/semtypes/mapping_definition.go
+++ b/semtypes/mapping_definition.go
@@ -63,7 +63,7 @@ func (m *MappingDefinition) Define(env Env, fields []CellField, rest SemType) Se
 		a = rec
 		env.setRecMappingAtomType(*rec, &atomicType)
 	} else {
-		a = new(env.mappingAtom(&atomicType))
+		a = env.mappingAtom(&atomicType)
 	}
 	return m.createSemType(env, a)
 }

--- a/semtypes/preallocated_type_vals.go
+++ b/semtypes/preallocated_type_vals.go
@@ -93,7 +93,7 @@ func newBasicCellTypeVals(env Env, mut CellMutability) basicCellTypeVals {
 func createCellTypeVal(env Env, ty basicTypeBitSet, mut CellMutability) SemType {
 	atomicCell := cellAtomicTypeFrom(ty.semType(), mut)
 	atom := env.cellAtom(&atomicCell)
-	bdd := bddAtom(&atom)
+	bdd := bddAtom(atom)
 	return getBasicSubtype(BTCell, bdd)
 }
 

--- a/semtypes/type_atom.go
+++ b/semtypes/type_atom.go
@@ -20,6 +20,7 @@ import "ballerina-lang-go/common"
 
 type typeAtom struct {
 	idx        int
+	gen        uint64
 	AtomicType atomicType
 }
 
@@ -34,10 +35,21 @@ func createTypeAtom(index int, atomicType atomicType) typeAtom {
 	}
 }
 
+func createEphemeralTypeAtom(index int, gen uint64, atomicType atomicType) *typeAtom {
+	common.Assert(index >= 0)
+	common.Assert(gen > 0)
+
+	return &typeAtom{
+		idx:        index,
+		gen:        gen,
+		AtomicType: atomicType,
+	}
+}
+
 func (t *typeAtom) index() int {
 	return t.idx
 }
 
 func (t *typeAtom) canonicalKey() atomKey {
-	return typeAtomKey(t.idx)
+	return typeAtomKey(t.idx, t.gen)
 }


### PR DESCRIPTION
## Purpose
Resolves #471 
Depends on #507 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Shortened type-cast failure diagnostics to a concise `error: bad type cast`.
  * Updated quoted-identifier duplicate reporting to show a duplicate-definition error (`Variable already defined: foo`) instead of an unused-variable message.
* **Improvements**
  * Made the lifecycle listener instance publicly accessible for easier integration.
  * Improved runtime type environment initialization and semtype handling to reduce overhead and avoid unnecessary lazy setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->