### PR TITLE
Add support for XML template expressions

### DIFF
--- a/ast/expressions.go
+++ b/ast/expressions.go
@@ -114,10 +114,17 @@ const (
 
 type TemplateExprKind uint8
 
+type XMLTemplateInsertionKind uint8
+
 const (
 	TemplateExprKindString TemplateExprKind = iota
 	TemplateExprKindXML
 	TemplateExprKindRaw
+)
+
+const (
+	XMLTemplateInsertionKindContent XMLTemplateInsertionKind = iota
+	XMLTemplateInsertionKindAttribute
 )
 
 type (
@@ -398,6 +405,19 @@ type (
 		Kind       TemplateExprKind
 		Strings    []string
 		Insertions []BLangExpression
+	}
+
+	XMLTemplateNamespaceInsertion struct {
+		Offset         int // this is the offest in the string where we need to insert the namespace declarations when we desugar to BLangTemplateExpr
+		UsedPrefixes   map[string]struct{}
+		NeedsDefaultNS bool
+		Namespaces     map[string]string
+	}
+
+	BLangXMLTemplateExpr struct {
+		BLangTemplateExpr
+		InsertionKinds      []XMLTemplateInsertionKind        // This tracks where do we do the insertion for each expression
+		NamespaceInsertions [][]XMLTemplateNamespaceInsertion // namespace insertion points for each template string
 	}
 
 	BLangXMLElementLiteral struct {
@@ -1035,6 +1055,7 @@ func createBLangUnaryExpr(location diagnostics.Location, operator model.Operator
 var (
 	_ BLangExpression = &BLangXMLSequenceLiteral{}
 	_ BLangExpression = &BLangTemplateExpr{}
+	_ BLangExpression = &BLangXMLTemplateExpr{}
 	_ BLangExpression = &BLangXMLElementLiteral{}
 	_ BLangExpression = &BLangXMLAttribute{}
 	_ BLangExpression = &BLangXMLPILiteral{}
@@ -1042,6 +1063,7 @@ var (
 	_ BLangExpression = &BLangXMLTextLiteral{}
 	_ BLangNode       = &BLangXMLSequenceLiteral{}
 	_ BLangNode       = &BLangTemplateExpr{}
+	_ BLangNode       = &BLangXMLTemplateExpr{}
 	_ BLangNode       = &BLangXMLElementLiteral{}
 	_ BLangNode       = &BLangXMLAttribute{}
 	_ BLangNode       = &BLangXMLPILiteral{}

--- a/ast/node_builder.go
+++ b/ast/node_builder.go
@@ -18,6 +18,7 @@ package ast
 
 import (
 	"fmt"
+	"iter"
 	"math"
 	"regexp"
 	"strconv"
@@ -2887,20 +2888,47 @@ func (n *NodeBuilder) TransformTemplateExpression(templateBLangExpression *tree.
 	case "string":
 		return n.buildStringTemplateExpr(templateBLangExpression, pos)
 	case "xml":
-		return n.buildXmlTemplateExpr(templateBLangExpression, pos)
+		return n.buildXMLTemplateExpr(templateBLangExpression, pos)
 	default:
 		n.cx.Unimplemented("unsupported template expression kind", pos)
 		return nil
 	}
 }
 
-func (n *NodeBuilder) buildXmlTemplateExpr(templateBLangExpression *tree.TemplateExpressionNode, pos diagnostics.Location) BLangNode {
+func (n *NodeBuilder) buildXMLTemplateExpr(templateBLangExpression *tree.TemplateExpressionNode, pos diagnostics.Location) BLangNode {
+	if !xmlTemplateHasInterpolation(templateBLangExpression.Content()) {
+		// If we don't have interpolations we build a literal as an optimization
+		return n.buildXMLSequenceLiteral(templateBLangExpression, pos)
+	}
+
+	tpl := &BLangXMLTemplateExpr{}
+	tpl.SetPosition(pos)
+	tpl.Kind = TemplateExprKindXML
+	for tok, diag := range n.flattenXMLTemplateContent(templateBLangExpression.Content(), XMLTemplateInsertionKindContent) {
+		if diag != nil {
+			n.reportXMLTemplateDiagnostic(diag)
+			continue
+		}
+		switch tok.Kind {
+		case xmlTemplateTokenKindText:
+			tpl.Strings = append(tpl.Strings, tok.Text)
+			tpl.NamespaceInsertions = append(tpl.NamespaceInsertions, tok.NamespaceInsertions)
+		case xmlTemplateTokenKindInsertion:
+			tpl.Insertions = append(tpl.Insertions, tok.Insertion)
+			tpl.InsertionKinds = append(tpl.InsertionKinds, tok.InsertionKind)
+		}
+	}
+	return tpl
+}
+
+func (n *NodeBuilder) buildXMLSequenceLiteral(templateBLangExpression *tree.TemplateExpressionNode, pos diagnostics.Location) BLangNode {
 	var children []BLangExpression
 	content := templateBLangExpression.Content()
 	for child := range content.Iterator() {
 		bl := n.TransformSyntaxNode(child)
 		if bl == nil {
-			continue
+			n.cx.InternalError("xml template child did not produce BLangNode", getPosition(n.de(), child))
+			return nil
 		}
 		expr, ok := bl.(BLangExpression)
 		if !ok {
@@ -2916,6 +2944,497 @@ func (n *NodeBuilder) buildXmlTemplateExpr(templateBLangExpression *tree.Templat
 	seq.pos = pos
 	seq.Children = children
 	return seq
+}
+
+func xmlTemplateHasInterpolation(content tree.NodeList[tree.Node]) bool {
+	for child := range content.Iterator() {
+		if xmlNodeHasInterpolation(child) {
+			return true
+		}
+	}
+	return false
+}
+
+func xmlNodeHasInterpolation(node tree.Node) bool {
+	return firstXMLInterpolation(node) != nil
+}
+
+func firstXMLInterpolation(node tree.Node) *tree.InterpolationNode {
+	switch x := node.(type) {
+	case *tree.InterpolationNode:
+		return x
+	case *tree.XMLElementNode:
+		content := x.Content()
+		for child := range content.Iterator() {
+			if ins := firstXMLInterpolation(child); ins != nil {
+				return ins
+			}
+		}
+		if start := x.StartTag(); start != nil {
+			attrs := start.Attributes()
+			for attr := range attrs.Iterator() {
+				if value := attr.Value(); value != nil {
+					if ins := firstXMLInterpolation(value); ins != nil {
+						return ins
+					}
+				}
+			}
+		}
+	case *tree.XMLEmptyElementNode:
+		attrs := x.Attributes()
+		for attr := range attrs.Iterator() {
+			if value := attr.Value(); value != nil {
+				if ins := firstXMLInterpolation(value); ins != nil {
+					return ins
+				}
+			}
+		}
+	case *tree.XMLAttributeValue:
+		value := x.Value()
+		for child := range value.Iterator() {
+			if ins := firstXMLInterpolation(child); ins != nil {
+				return ins
+			}
+		}
+	case *tree.XMLComment:
+		content := x.Content()
+		for child := range content.Iterator() {
+			if ins, ok := child.(*tree.InterpolationNode); ok {
+				return ins
+			}
+		}
+	case *tree.XMLProcessingInstruction:
+		data := x.Data()
+		for child := range data.Iterator() {
+			if ins, ok := child.(*tree.InterpolationNode); ok {
+				return ins
+			}
+		}
+	case *tree.XMLCDATANode:
+		content := x.Content()
+		for child := range content.Iterator() {
+			if ins, ok := child.(*tree.InterpolationNode); ok {
+				return ins
+			}
+		}
+	}
+	return nil
+}
+
+type xmlTemplateTokenKind uint8
+
+const (
+	xmlTemplateTokenKindText xmlTemplateTokenKind = iota
+	xmlTemplateTokenKindInsertion
+)
+
+type xmlTemplateToken struct {
+	Kind                xmlTemplateTokenKind
+	Text                string
+	NamespaceInsertions []XMLTemplateNamespaceInsertion
+	Insertion           BLangExpression
+	InsertionKind       XMLTemplateInsertionKind
+}
+
+func newXMLTemplateTextToken(value string, insertions ...XMLTemplateNamespaceInsertion) xmlTemplateToken {
+	return xmlTemplateToken{Kind: xmlTemplateTokenKindText, Text: value, NamespaceInsertions: insertions}
+}
+
+func newXMLTemplateInsertionToken(expr BLangExpression, kind XMLTemplateInsertionKind) xmlTemplateToken {
+	return xmlTemplateToken{Kind: xmlTemplateTokenKindInsertion, Insertion: expr, InsertionKind: kind}
+}
+
+type xmlTemplateTextAccumulator struct {
+	text                strings.Builder
+	namespaceInsertions []XMLTemplateNamespaceInsertion
+}
+
+func appendXMLTemplateText(current *xmlTemplateTextAccumulator, tok xmlTemplateToken) *xmlTemplateTextAccumulator {
+	if current == nil {
+		current = &xmlTemplateTextAccumulator{}
+	}
+	baseOffset := current.text.Len()
+	current.text.WriteString(tok.Text)
+	for _, insn := range tok.NamespaceInsertions {
+		insn.Offset += baseOffset
+		current.namespaceInsertions = append(current.namespaceInsertions, insn)
+	}
+	return current
+}
+
+func isTemplateAccumEmtpy(t *xmlTemplateTextAccumulator) bool {
+	return t == nil || t.text.Len() == 0
+}
+
+func xmlTemplateAccumToken(t *xmlTemplateTextAccumulator) xmlTemplateToken {
+	if t == nil {
+		return newXMLTemplateTextToken("")
+	}
+	return newXMLTemplateTextToken(t.text.String(), t.namespaceInsertions...)
+}
+
+type xmlTemplateDiagnostic struct {
+	Message  string
+	Position diagnostics.Location
+	Internal bool
+}
+
+func (n *NodeBuilder) flattenXMLTemplateContent(content tree.NodeList[tree.Node], kind XMLTemplateInsertionKind) iter.Seq2[xmlTemplateToken, *xmlTemplateDiagnostic] {
+	return func(yield func(xmlTemplateToken, *xmlTemplateDiagnostic) bool) {
+		var current *xmlTemplateTextAccumulator
+		rawYield := func(tok xmlTemplateToken, diag *xmlTemplateDiagnostic) bool {
+			if diag != nil {
+				if !isTemplateAccumEmtpy(current) && !yield(xmlTemplateAccumToken(current), nil) {
+					return false
+				}
+				current = nil
+				return yield(tok, diag)
+			}
+			switch tok.Kind {
+			case xmlTemplateTokenKindText:
+				current = appendXMLTemplateText(current, tok)
+				return true
+			case xmlTemplateTokenKindInsertion:
+				if !yield(xmlTemplateAccumToken(current), nil) {
+					return false
+				}
+				current = nil
+				return yield(tok, nil)
+			default:
+				return true
+			}
+		}
+		for child := range content.Iterator() {
+			if !n.flattenXMLTemplateNodeWithNamespace(child, kind, nil, rawYield) {
+				return
+			}
+		}
+		yield(xmlTemplateAccumToken(current), nil)
+	}
+}
+
+func (n *NodeBuilder) flattenXMLTemplateNodeWithNamespace(
+	node tree.Node,
+	kind XMLTemplateInsertionKind,
+	namespaceInsertion *XMLTemplateNamespaceInsertion,
+	yield func(xmlTemplateToken, *xmlTemplateDiagnostic) bool,
+) bool {
+	switch x := node.(type) {
+	case tree.Token:
+		return yield(newXMLTemplateTextToken(x.Text()), nil)
+	case *tree.InterpolationNode:
+		expr := n.createActionOrExpression(x.Expression())
+		be, ok := expr.(BLangExpression)
+		if !ok {
+			return yield(xmlTemplateToken{}, &xmlTemplateDiagnostic{
+				Message:  "interpolation did not produce BLangExpression",
+				Position: getPosition(n.de(), x),
+				Internal: true,
+			})
+		}
+		return yield(newXMLTemplateInsertionToken(be, kind), nil)
+	case *tree.XMLTextNode:
+		if c := x.Content(); c != nil {
+			return yield(newXMLTemplateTextToken(c.Text()), nil)
+		}
+		return true
+	case *tree.XMLElementNode:
+		return n.flattenXMLTemplateElement(x, namespaceInsertion, yield)
+	case *tree.XMLEmptyElementNode:
+		return n.flattenXMLTemplateEmptyElement(x, namespaceInsertion, yield)
+	case *tree.XMLComment:
+		if ins := firstXMLInterpolation(x); ins != nil {
+			return yield(xmlTemplateToken{}, &xmlTemplateDiagnostic{
+				Message:  "interpolation is not allowed in xml comment",
+				Position: getPosition(n.de(), ins),
+			})
+		}
+		return yield(newXMLTemplateTextToken(tree.ToSourceCode(x.InternalNode())), nil)
+	case *tree.XMLProcessingInstruction:
+		if ins := firstXMLInterpolation(x); ins != nil {
+			return yield(xmlTemplateToken{}, &xmlTemplateDiagnostic{
+				Message:  "interpolation is not allowed in xml processing instruction",
+				Position: getPosition(n.de(), ins),
+			})
+		}
+		return n.flattenXMLTemplatePI(x, yield)
+	case *tree.XMLCDATANode:
+		if ins := firstXMLInterpolation(x); ins != nil {
+			return yield(xmlTemplateToken{}, &xmlTemplateDiagnostic{
+				Message:  "interpolation is not allowed in xml CDATA section",
+				Position: getPosition(n.de(), ins),
+			})
+		}
+		return yield(newXMLTemplateTextToken(tree.ToSourceCode(x.InternalNode())), nil)
+	default:
+		return yield(newXMLTemplateTextToken(tree.ToSourceCode(node.InternalNode())), nil)
+	}
+}
+
+func (n *NodeBuilder) flattenXMLTemplateElement(
+	x *tree.XMLElementNode,
+	parentNamespaceInsertion *XMLTemplateNamespaceInsertion,
+	yield func(xmlTemplateToken, *xmlTemplateDiagnostic) bool,
+) bool {
+	start := x.StartTag()
+	if start == nil {
+		return true
+	}
+	attrs := start.Attributes()
+	name := n.xmlNameToString(start.Name())
+	namespaceInsertion := parentNamespaceInsertion
+	if namespaceInsertion == nil {
+		insn := n.collectXMLTemplateNamespaceInsertion(x)
+		namespaceInsertion = &insn
+	}
+	startText := "<" + name
+	if parentNamespaceInsertion == nil {
+		namespaceInsertion.Offset = len(startText)
+		if !yield(newXMLTemplateTextToken(startText, *namespaceInsertion), nil) {
+			return false
+		}
+	} else if !yield(newXMLTemplateTextToken(startText), nil) {
+		return false
+	}
+	if !n.flattenXMLTemplateAttributes(attrs, yield) {
+		return false
+	}
+	if !yield(newXMLTemplateTextToken(">"), nil) {
+		return false
+	}
+	content := x.Content()
+	for child := range content.Iterator() {
+		if !n.flattenXMLTemplateNodeWithNamespace(child, XMLTemplateInsertionKindContent, namespaceInsertion, yield) {
+			return false
+		}
+	}
+	return yield(newXMLTemplateTextToken("</"+name+">"), nil)
+}
+
+func (n *NodeBuilder) flattenXMLTemplateEmptyElement(
+	x *tree.XMLEmptyElementNode,
+	parentNamespaceInsertion *XMLTemplateNamespaceInsertion,
+	yield func(xmlTemplateToken, *xmlTemplateDiagnostic) bool,
+) bool {
+	name := n.xmlNameToString(x.Name())
+	namespaceInsertion := parentNamespaceInsertion
+	if namespaceInsertion == nil {
+		insn := n.collectXMLTemplateNamespaceInsertion(x)
+		namespaceInsertion = &insn
+	}
+	startText := "<" + name
+	if parentNamespaceInsertion == nil {
+		namespaceInsertion.Offset = len(startText)
+		if !yield(newXMLTemplateTextToken(startText, *namespaceInsertion), nil) {
+			return false
+		}
+	} else if !yield(newXMLTemplateTextToken(startText), nil) {
+		return false
+	}
+	if !n.flattenXMLTemplateAttributes(x.Attributes(), yield) {
+		return false
+	}
+	return yield(newXMLTemplateTextToken("/>"), nil)
+}
+
+func (n *NodeBuilder) flattenXMLTemplatePI(x *tree.XMLProcessingInstruction, yield func(xmlTemplateToken, *xmlTemplateDiagnostic) bool) bool {
+	if !yield(newXMLTemplateTextToken("<?"), nil) {
+		return false
+	}
+	if !yield(newXMLTemplateTextToken(n.xmlNameToString(x.Target())), nil) {
+		return false
+	}
+	var dataText strings.Builder
+	data := x.Data()
+	for child := range data.Iterator() {
+		if tok, ok := child.(tree.Token); ok {
+			dataText.WriteString(tok.Text())
+		}
+	}
+	if data := strings.TrimSpace(dataText.String()); data != "" {
+		if !yield(newXMLTemplateTextToken(" "), nil) {
+			return false
+		}
+		if !yield(newXMLTemplateTextToken(data), nil) {
+			return false
+		}
+	}
+	return yield(newXMLTemplateTextToken("?>"), nil)
+}
+
+func (n *NodeBuilder) flattenXMLTemplateAttributes(attrs tree.NodeList[*tree.XMLAttributeNode], yield func(xmlTemplateToken, *xmlTemplateDiagnostic) bool) bool {
+	for attr := range attrs.Iterator() {
+		name := n.xmlNameToString(attr.AttributeName())
+		if !yield(newXMLTemplateTextToken(" "+name+"="), nil) {
+			return false
+		}
+		if value := attr.Value(); value != nil {
+			if !n.flattenXMLTemplateAttributeValue(name, value, yield) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (n *NodeBuilder) flattenXMLTemplateAttributeValue(
+	name string,
+	value *tree.XMLAttributeValue,
+	yield func(xmlTemplateToken, *xmlTemplateDiagnostic) bool,
+) bool {
+	startQuote := "\""
+	if q := value.StartQuote(); q != nil && q.Text() != "" {
+		startQuote = q.Text()
+	}
+	endQuote := startQuote
+	if q := value.EndQuote(); q != nil && q.Text() != "" {
+		endQuote = q.Text()
+	}
+	if !yield(newXMLTemplateTextToken(startQuote), nil) {
+		return false
+	}
+	isXMLNS := isXMLTemplateXMLNSName(name)
+	items := value.Value()
+	for child := range items.Iterator() {
+		if ins, ok := child.(*tree.InterpolationNode); ok {
+			if isXMLNS {
+				if !yield(xmlTemplateToken{}, &xmlTemplateDiagnostic{
+					Message:  "interpolation is not allowed in xml xmlns attribute value",
+					Position: getPosition(n.de(), child),
+				}) {
+					return false
+				}
+				continue
+			}
+			if !n.flattenXMLTemplateNodeWithNamespace(ins, XMLTemplateInsertionKindAttribute, nil, yield) {
+				return false
+			}
+			continue
+		}
+		if tok, ok := child.(tree.Token); ok {
+			if !yield(newXMLTemplateTextToken(tok.Text()), nil) {
+				return false
+			}
+		}
+	}
+	return yield(newXMLTemplateTextToken(endQuote), nil)
+}
+
+func (n *NodeBuilder) reportXMLTemplateDiagnostic(diag *xmlTemplateDiagnostic) {
+	if diag.Internal {
+		n.cx.InternalError(diag.Message, diag.Position)
+		return
+	}
+	n.cx.SemanticError(diag.Message, diag.Position)
+}
+
+func (n *NodeBuilder) collectXMLTemplateNamespaceInsertion(node tree.Node) XMLTemplateNamespaceInsertion {
+	insn := XMLTemplateNamespaceInsertion{
+		UsedPrefixes: map[string]struct{}{},
+		Namespaces:   map[string]string{},
+	}
+	n.collectXMLTemplateNamespaceRefs(node, nil, &insn)
+	return insn
+}
+
+func (n *NodeBuilder) collectXMLTemplateNamespaceRefs(node tree.Node, scopes []map[string]struct{}, insn *XMLTemplateNamespaceInsertion) {
+	switch x := node.(type) {
+	case *tree.XMLElementNode:
+		start := x.StartTag()
+		if start == nil {
+			return
+		}
+		childScopes := appendXMLTemplateNamespaceScope(scopes, n.collectInlineXMLTemplatePrefixes(start.Attributes()))
+		n.recordXMLTemplateNameRef(n.xmlNameToString(start.Name()), true, childScopes, insn)
+		n.collectXMLTemplateAttributeNamespaceRefs(start.Attributes(), childScopes, insn)
+		content := x.Content()
+		for child := range content.Iterator() {
+			n.collectXMLTemplateNamespaceRefs(child, childScopes, insn)
+		}
+	case *tree.XMLEmptyElementNode:
+		childScopes := appendXMLTemplateNamespaceScope(scopes, n.collectInlineXMLTemplatePrefixes(x.Attributes()))
+		n.recordXMLTemplateNameRef(n.xmlNameToString(x.Name()), true, childScopes, insn)
+		n.collectXMLTemplateAttributeNamespaceRefs(x.Attributes(), childScopes, insn)
+	}
+}
+
+func (n *NodeBuilder) collectXMLTemplateAttributeNamespaceRefs(
+	attrs tree.NodeList[*tree.XMLAttributeNode],
+	scopes []map[string]struct{},
+	insn *XMLTemplateNamespaceInsertion,
+) {
+	for attr := range attrs.Iterator() {
+		name := n.xmlNameToString(attr.AttributeName())
+		if isXMLTemplateXMLNSName(name) {
+			continue
+		}
+		n.recordXMLTemplateNameRef(name, false, scopes, insn)
+	}
+}
+
+func (n *NodeBuilder) recordXMLTemplateNameRef(name string, isElement bool, scopes []map[string]struct{}, insn *XMLTemplateNamespaceInsertion) {
+	prefix, _ := splitXMLTemplateName(name)
+	if prefix == "xmlns" {
+		return
+	}
+	if prefix != "" {
+		if isXMLTemplatePrefixInScope(prefix, scopes) {
+			return
+		}
+		insn.UsedPrefixes[prefix] = struct{}{}
+		return
+	}
+	if isElement && !isXMLTemplatePrefixInScope("", scopes) {
+		insn.NeedsDefaultNS = true
+	}
+}
+
+func (n *NodeBuilder) collectInlineXMLTemplatePrefixes(attrs tree.NodeList[*tree.XMLAttributeNode]) map[string]struct{} {
+	prefixes := map[string]struct{}{}
+	for attr := range attrs.Iterator() {
+		name := n.xmlNameToString(attr.AttributeName())
+		if !isXMLTemplateXMLNSName(name) {
+			continue
+		}
+		_, local := splitXMLTemplateName(name)
+		if name == "xmlns" {
+			prefixes[""] = struct{}{}
+		} else {
+			prefixes[local] = struct{}{}
+		}
+	}
+	return prefixes
+}
+
+func appendXMLTemplateNamespaceScope(scopes []map[string]struct{}, scope map[string]struct{}) []map[string]struct{} {
+	if len(scope) == 0 {
+		return scopes
+	}
+	out := make([]map[string]struct{}, 0, len(scopes)+1)
+	out = append(out, scopes...)
+	out = append(out, scope)
+	return out
+}
+
+func isXMLTemplatePrefixInScope(prefix string, scopes []map[string]struct{}) bool {
+	for i := len(scopes) - 1; i >= 0; i-- {
+		if _, ok := scopes[i][prefix]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func splitXMLTemplateName(name string) (string, string) {
+	if idx := strings.IndexByte(name, ':'); idx >= 0 {
+		return name[:idx], name[idx+1:]
+	}
+	return "", name
+}
+
+func isXMLTemplateXMLNSName(name string) bool {
+	prefix, local := splitXMLTemplateName(name)
+	return name == "xmlns" || prefix == "xmlns" && local != ""
 }
 
 func (n *NodeBuilder) buildStringTemplateExpr(node *tree.TemplateExpressionNode, pos diagnostics.Location) BLangNode {

--- a/ast/pretty_printer.go
+++ b/ast/pretty_printer.go
@@ -222,6 +222,8 @@ func (p *PrettyPrinter) PrintInner(node BLangNode) {
 		p.printXMLSequenceLiteral(t)
 	case *BLangTemplateExpr:
 		p.printTemplateExpr(t)
+	case *BLangXMLTemplateExpr:
+		p.printXMLTemplateExpr(t)
 	case *BLangXMLElementLiteral:
 		p.printXMLElementLiteral(t)
 	case *BLangXMLAttribute:
@@ -401,6 +403,8 @@ func (p *PrettyPrinter) printTemplateExpr(node *BLangTemplateExpr) {
 	switch node.Kind {
 	case TemplateExprKindString:
 		p.printString("string-template-literal")
+	case TemplateExprKindXML:
+		p.printString("xml-template-literal")
 	default:
 		panic("unsupported template expr kind")
 	}
@@ -412,6 +416,33 @@ func (p *PrettyPrinter) printTemplateExpr(node *BLangTemplateExpr) {
 		p.endNode()
 		if i < len(node.Insertions) {
 			p.PrintInner(node.Insertions[i].(BLangNode))
+		}
+	}
+	p.indentLevel--
+	p.endNode()
+}
+
+func (p *PrettyPrinter) printXMLTemplateExpr(node *BLangXMLTemplateExpr) {
+	p.startNode()
+	p.printString("xml-template-literal")
+	p.indentLevel++
+	for i, s := range node.Strings {
+		p.startNode()
+		p.printString("template-string")
+		p.printString(fmt.Sprintf("%q", s))
+		p.endNode()
+		if i < len(node.Insertions) {
+			p.startNode()
+			switch node.InsertionKinds[i] {
+			case XMLTemplateInsertionKindAttribute:
+				p.printString("xml-template-attribute-insertion")
+			default:
+				p.printString("xml-template-content-insertion")
+			}
+			p.indentLevel++
+			p.PrintInner(node.Insertions[i].(BLangNode))
+			p.indentLevel--
+			p.endNode()
 		}
 	}
 	p.indentLevel--

--- a/ast/walk.go
+++ b/ast/walk.go
@@ -571,6 +571,11 @@ func Walk(v Visitor, node BLangNode) {
 			Walk(v, ins)
 		}
 
+	case *BLangXMLTemplateExpr:
+		for _, ins := range node.Insertions {
+			Walk(v, ins)
+		}
+
 	case *BLangXMLElementLiteral:
 		for i := range node.Attrs {
 			Walk(v, &node.Attrs[i])

--- a/bir/bir_gen.go
+++ b/bir/bir_gen.go
@@ -1151,6 +1151,8 @@ func templateExpression(ctx context, curBB *BIRBasicBlock, expr *ast.BLangTempla
 	switch expr.Kind {
 	case ast.TemplateExprKindString:
 		kind = TemplateKindString
+	case ast.TemplateExprKindXML:
+		kind = TemplateKindXML
 	default:
 		panic(fmt.Sprintf("unsupported template expr kind: %d", expr.Kind))
 	}

--- a/bir/pretty_print.go
+++ b/bir/pretty_print.go
@@ -589,6 +589,9 @@ func (p *PrettyPrinter) PrintNewXMLText(n *NewXMLText) string {
 
 func (p *PrettyPrinter) PrintEvalTemplateExpr(n *EvalTemplateExpr) string {
 	kindStr := "string"
+	if n.Kind == TemplateKindXML {
+		kindStr = "xml"
+	}
 	parts := strings.Builder{}
 	for i, s := range n.Strings {
 		if i > 0 {

--- a/corpus/ast/subset9/09-template-expr/template-attr-v.txt
+++ b/corpus/ast/subset9/09-template-expr/template-attr-v.txt
@@ -1,0 +1,36 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable id (type
+          (value-type int)) (expr
+          (literal 7))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<row id=\"")
+            (xml-template-attribute-insertion
+              (simple-var-ref id))
+            (template-string "\"/>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x))))
+      (var-def
+        (variable value (type
+          (value-type string)) (expr
+          (literal a&b"c<d))))
+      (var-def
+        (variable escaped (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<root value=\"")
+            (xml-template-attribute-insertion
+              (simple-var-ref value))
+            (template-string "\"/>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref escaped)))))))

--- a/corpus/ast/subset9/09-template-expr/template-bare-comment-v.txt
+++ b/corpus/ast/subset9/09-template-expr/template-bare-comment-v.txt
@@ -1,0 +1,21 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable x (type
+          (value-type string)) (expr
+          (literal x))))
+      (var-def
+        (variable v (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<!-- c -->")
+            (xml-template-content-insertion
+              (simple-var-ref x))
+            (template-string "")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref v)))))))

--- a/corpus/ast/subset9/09-template-expr/template-bare-pi-v.txt
+++ b/corpus/ast/subset9/09-template-expr/template-bare-pi-v.txt
@@ -1,0 +1,21 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable x (type
+          (value-type string)) (expr
+          (literal x))))
+      (var-def
+        (variable v (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<?tgt body?>")
+            (xml-template-content-insertion
+              (simple-var-ref x))
+            (template-string "")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref v)))))))

--- a/corpus/ast/subset9/09-template-expr/template-bare-text-v.txt
+++ b/corpus/ast/subset9/09-template-expr/template-bare-text-v.txt
@@ -1,0 +1,21 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable x (type
+          (value-type string)) (expr
+          (literal world))))
+      (var-def
+        (variable v (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "hello ")
+            (xml-template-content-insertion
+              (simple-var-ref x))
+            (template-string "")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref v)))))))

--- a/corpus/ast/subset9/09-template-expr/template-bare-v.txt
+++ b/corpus/ast/subset9/09-template-expr/template-bare-v.txt
@@ -1,0 +1,21 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable x (type
+          (value-type string)) (expr
+          (literal abc))))
+      (var-def
+        (variable v (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "")
+            (xml-template-content-insertion
+              (simple-var-ref x))
+            (template-string "")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref v)))))))

--- a/corpus/ast/subset9/09-template-expr/template-content-v.txt
+++ b/corpus/ast/subset9/09-template-expr/template-content-v.txt
@@ -1,0 +1,53 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (variable XML_VALUE (type
+    (value-type xml)) (expr
+    (xml-template-literal
+      (template-string "<root>")
+      (xml-template-content-insertion
+        (literal x))
+      (template-string "</root>"))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable name (type
+          (value-type string)) (expr
+          (literal world))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<greeting>Hello, ")
+            (xml-template-content-insertion
+              (simple-var-ref name))
+            (template-string "!</greeting>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x))))
+      (var-def
+        (variable markup (type
+          (value-type string)) (expr
+          (literal <child/>))))
+      (var-def
+        (variable amp (type
+          (value-type string)) (expr
+          (literal a&b))))
+      (var-def
+        (variable escaped (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<root>")
+            (xml-template-content-insertion
+              (simple-var-ref markup))
+            (template-string "|")
+            (xml-template-content-insertion
+              (simple-var-ref amp))
+            (template-string "</root>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref escaped))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref XML_VALUE)))))))

--- a/corpus/ast/subset9/09-template-expr/template-doctype-inject-v.txt
+++ b/corpus/ast/subset9/09-template-expr/template-doctype-inject-v.txt
@@ -1,0 +1,21 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable s (type
+          (value-type string)) (expr
+          (literal <!DOCTYPE x>))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "")
+            (xml-template-content-insertion
+              (simple-var-ref s))
+            (template-string "<a/>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x)))))))

--- a/corpus/ast/subset9/09-template-expr/template-dup-prefix-v.txt
+++ b/corpus/ast/subset9/09-template-expr/template-dup-prefix-v.txt
@@ -1,0 +1,25 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (xmlns
+    (literal https://example.com/u) as a)
+  (xmlns
+    (literal https://example.com/u) as b)
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable v (type
+          (value-type string)) (expr
+          (literal x))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<a:tag>")
+            (xml-template-content-insertion
+              (simple-var-ref v))
+            (template-string "</a:tag>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x)))))))

--- a/corpus/ast/subset9/09-template-expr/template-entity-v.txt
+++ b/corpus/ast/subset9/09-template-expr/template-entity-v.txt
@@ -1,0 +1,21 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable x (type
+          (value-type string)) (expr
+          (literal v))))
+      (var-def
+        (variable e (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<a>&amp;")
+            (xml-template-content-insertion
+              (simple-var-ref x))
+            (template-string "</a>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref e)))))))

--- a/corpus/ast/subset9/09-template-expr/template-inline-ns-scope-v.txt
+++ b/corpus/ast/subset9/09-template-expr/template-inline-ns-scope-v.txt
@@ -1,0 +1,23 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (xmlns
+    (literal https://example.com/outer) as p)
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable s (type
+          (value-type string)) (expr
+          (literal ))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<p:a>")
+            (xml-template-content-insertion
+              (simple-var-ref s))
+            (template-string "</p:a><b xmlns:p=\"https://example.com/inner\"><p:c/></b>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x)))))))

--- a/corpus/ast/subset9/09-template-expr/template-malformed-inject-v.txt
+++ b/corpus/ast/subset9/09-template-expr/template-malformed-inject-v.txt
@@ -1,0 +1,21 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable s (type
+          (value-type string)) (expr
+          (literal <a>))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "")
+            (xml-template-content-insertion
+              (simple-var-ref s))
+            (template-string "")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x)))))))

--- a/corpus/ast/subset9/09-template-expr/template-mixed-content-v.txt
+++ b/corpus/ast/subset9/09-template-expr/template-mixed-content-v.txt
@@ -1,0 +1,24 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable n (type
+          (value-type string)) (expr
+          (literal v))))
+      (var-def
+        (variable v (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "before ")
+            (xml-template-content-insertion
+              (simple-var-ref n))
+            (template-string " <m/> after ")
+            (xml-template-content-insertion
+              (simple-var-ref n))
+            (template-string "")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref v)))))))

--- a/corpus/ast/subset9/09-template-expr/template-mixed-v.txt
+++ b/corpus/ast/subset9/09-template-expr/template-mixed-v.txt
@@ -1,0 +1,28 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable n (type
+          (value-type int)) (expr
+          (literal 3))))
+      (var-def
+        (variable inner (type
+          (value-type xml)) (expr
+          (xml-element-literal i))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<root>n=")
+            (xml-template-content-insertion
+              (simple-var-ref n))
+            (template-string ", inner=")
+            (xml-template-content-insertion
+              (simple-var-ref inner))
+            (template-string "</root>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x)))))))

--- a/corpus/ast/subset9/09-template-expr/template-multi-attr-v.txt
+++ b/corpus/ast/subset9/09-template-expr/template-multi-attr-v.txt
@@ -1,0 +1,38 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (value-type string)) (expr
+          (literal A))))
+      (var-def
+        (variable b (type
+          (value-type string)) (expr
+          (literal B))))
+      (var-def
+        (variable n (type
+          (value-type int)) (expr
+          (literal 42))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<elem first=\"")
+            (xml-template-attribute-insertion
+              (simple-var-ref a))
+            (template-string "-")
+            (xml-template-attribute-insertion
+              (simple-var-ref b))
+            (template-string "\" n=\"")
+            (xml-template-attribute-insertion
+              (simple-var-ref n))
+            (template-string "\" mixed=\"lit-")
+            (xml-template-attribute-insertion
+              (simple-var-ref a))
+            (template-string "\"/>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x)))))))

--- a/corpus/ast/subset9/09-template-expr/template-multi-root-outer-ns-v.txt
+++ b/corpus/ast/subset9/09-template-expr/template-multi-root-outer-ns-v.txt
@@ -1,0 +1,23 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (xmlns
+    (literal https://example.com/outer) as p)
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable s (type
+          (value-type string)) (expr
+          (literal ))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<p:a>")
+            (xml-template-content-insertion
+              (simple-var-ref s))
+            (template-string "</p:a><p:b/>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x)))))))

--- a/corpus/ast/subset9/09-template-expr/template-multi-root-v.txt
+++ b/corpus/ast/subset9/09-template-expr/template-multi-root-v.txt
@@ -1,0 +1,21 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable x (type
+          (value-type string)) (expr
+          (literal mid))))
+      (var-def
+        (variable v (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<a/>")
+            (xml-template-content-insertion
+              (simple-var-ref x))
+            (template-string "<b/>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref v)))))))

--- a/corpus/ast/subset9/09-template-expr/template-ns-inherit-v.txt
+++ b/corpus/ast/subset9/09-template-expr/template-ns-inherit-v.txt
@@ -1,0 +1,23 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (xmlns
+    (literal https://example.com/d))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable v (type
+          (value-type string)) (expr
+          (literal leaf))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<outer><inner>")
+            (xml-template-content-insertion
+              (simple-var-ref v))
+            (template-string "</inner></outer>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x)))))))

--- a/corpus/ast/subset9/09-template-expr/template-pi-empty-data-v.txt
+++ b/corpus/ast/subset9/09-template-expr/template-pi-empty-data-v.txt
@@ -1,0 +1,21 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable body (type
+          (value-type string)) (expr
+          (literal tail))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<?empty?>")
+            (xml-template-content-insertion
+              (simple-var-ref body))
+            (template-string "")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x)))))))

--- a/corpus/ast/subset9/09-template-expr/template-prefixed-attr-v.txt
+++ b/corpus/ast/subset9/09-template-expr/template-prefixed-attr-v.txt
@@ -1,0 +1,23 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (xmlns
+    (literal https://example.com/attr) as p)
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable body (type
+          (value-type string)) (expr
+          (literal hello))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<root p:name=\"v\">")
+            (xml-template-content-insertion
+              (simple-var-ref body))
+            (template-string "</root>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x)))))))

--- a/corpus/ast/subset9/09-template-expr/template-single-quote-attr-v.txt
+++ b/corpus/ast/subset9/09-template-expr/template-single-quote-attr-v.txt
@@ -1,0 +1,21 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable id (type
+          (value-type string)) (expr
+          (literal abc))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<row id='")
+            (xml-template-attribute-insertion
+              (simple-var-ref id))
+            (template-string "'/>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x)))))))

--- a/corpus/ast/subset9/09-template-expr/template-xml-child-v.txt
+++ b/corpus/ast/subset9/09-template-expr/template-xml-child-v.txt
@@ -1,0 +1,21 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable child (type
+          (value-type xml)) (expr
+          (xml-element-literal c))))
+      (var-def
+        (variable parent (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<p>")
+            (xml-template-content-insertion
+              (simple-var-ref child))
+            (template-string "</p>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref parent)))))))

--- a/corpus/ast/subset9/09-template-expr/template-xml-prefix-v.txt
+++ b/corpus/ast/subset9/09-template-expr/template-xml-prefix-v.txt
@@ -1,0 +1,21 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable v (type
+          (value-type string)) (expr
+          (literal <a xml:lang="en"/>))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "")
+            (xml-template-content-insertion
+              (simple-var-ref v))
+            (template-string "")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x)))))))

--- a/corpus/ast/subset9/09-template-expr/template-xmldecl-inject-v.txt
+++ b/corpus/ast/subset9/09-template-expr/template-xmldecl-inject-v.txt
@@ -1,0 +1,21 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable s (type
+          (value-type string)) (expr
+          (literal <?xml version='1.0'?>))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "")
+            (xml-template-content-insertion
+              (simple-var-ref s))
+            (template-string "<a/>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x)))))))

--- a/corpus/ast/subset9/09-template-expr/template-xmlfoo-pi-v.txt
+++ b/corpus/ast/subset9/09-template-expr/template-xmlfoo-pi-v.txt
@@ -1,0 +1,21 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable x (type
+          (value-type string)) (expr
+          (literal v))))
+      (var-def
+        (variable v (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<?xmlfoo body?>")
+            (xml-template-content-insertion
+              (simple-var-ref x))
+            (template-string "")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref v)))))))

--- a/corpus/ast/subset9/09-template-expr/template-xmlns-escape-v.txt
+++ b/corpus/ast/subset9/09-template-expr/template-xmlns-escape-v.txt
@@ -1,0 +1,23 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (xmlns
+    (literal https://example.com/a&b"c) as p)
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable v (type
+          (value-type string)) (expr
+          (literal hi))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<p:tag>")
+            (xml-template-content-insertion
+              (simple-var-ref v))
+            (template-string "</p:tag>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x)))))))

--- a/corpus/ast/subset9/09-template-expr/template-xmlns-v.txt
+++ b/corpus/ast/subset9/09-template-expr/template-xmlns-v.txt
@@ -1,0 +1,23 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (xmlns
+    (literal https://example.com/foo) as foo)
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable v (type
+          (value-type string)) (expr
+          (literal hi))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<foo:tag>")
+            (xml-template-content-insertion
+              (simple-var-ref v))
+            (template-string "</foo:tag>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x)))))))

--- a/corpus/bal/subset9/09-template-expr/template-attr-v.bal
+++ b/corpus/bal/subset9/09-template-expr/template-attr-v.bal
@@ -1,0 +1,27 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    int id = 7;
+    xml x = xml `<row id="${id}"/>`;
+    io:println(x); // @output <row id="7"/>
+
+    string value = "a&b\"c<d";
+    xml escaped = xml `<root value="${value}"/>`;
+    io:println(escaped); // @output <root value="a&amp;b&quot;c&lt;d"/>
+}

--- a/corpus/bal/subset9/09-template-expr/template-bad-type-e.bal
+++ b/corpus/bal/subset9/09-template-expr/template-bad-type-e.bal
@@ -1,0 +1,24 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public function main() {
+    () n = ();
+    int[] a = [1, 2];
+    xml elem = xml `<x/>`;
+    xml _ = xml `${n}`;             // @error nil not allowed
+    xml _ = xml `${a}`;             // @error array not allowed in content
+    xml _ = xml `<r attr="${elem}"/>`;  // @error xml not allowed in attribute
+}

--- a/corpus/bal/subset9/09-template-expr/template-bare-comment-v.bal
+++ b/corpus/bal/subset9/09-template-expr/template-bare-comment-v.bal
@@ -1,0 +1,23 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    string x = "x";
+    xml v = xml `<!-- c -->${x}`;
+    io:println(v); // @output <!-- c -->x
+}

--- a/corpus/bal/subset9/09-template-expr/template-bare-pi-v.bal
+++ b/corpus/bal/subset9/09-template-expr/template-bare-pi-v.bal
@@ -1,0 +1,23 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    string x = "x";
+    xml v = xml `<?tgt body?>${x}`;
+    io:println(v); // @output <?tgt body?>x
+}

--- a/corpus/bal/subset9/09-template-expr/template-bare-text-v.bal
+++ b/corpus/bal/subset9/09-template-expr/template-bare-text-v.bal
@@ -1,0 +1,23 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    string x = "world";
+    xml v = xml `hello ${x}`;
+    io:println(v); // @output hello world
+}

--- a/corpus/bal/subset9/09-template-expr/template-bare-v.bal
+++ b/corpus/bal/subset9/09-template-expr/template-bare-v.bal
@@ -1,0 +1,23 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    string x = "abc";
+    xml v = xml `${x}`;
+    io:println(v); // @output abc
+}

--- a/corpus/bal/subset9/09-template-expr/template-cdata-e.bal
+++ b/corpus/bal/subset9/09-template-expr/template-cdata-e.bal
@@ -1,0 +1,20 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public function main() {
+    string s = "x";
+    xml x = xml `<![CDATA[hello ${s}]]>`; // @error interpolation not allowed in xml CDATA section
+}

--- a/corpus/bal/subset9/09-template-expr/template-comment-e.bal
+++ b/corpus/bal/subset9/09-template-expr/template-comment-e.bal
@@ -1,0 +1,20 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public function main() {
+    string s = "x";
+    xml x = xml `<!-- hello ${s} -->`; // @error interpolation not allowed in xml comment
+}

--- a/corpus/bal/subset9/09-template-expr/template-const-nonconst-e.bal
+++ b/corpus/bal/subset9/09-template-expr/template-const-nonconst-e.bal
@@ -1,0 +1,23 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function f() returns string => "x";
+
+const BAD = xml `<root>${f()}</root>`; // @error insertion is not a constant expression
+
+public function main() {
+    var _ = BAD;
+}

--- a/corpus/bal/subset9/09-template-expr/template-content-v.bal
+++ b/corpus/bal/subset9/09-template-expr/template-content-v.bal
@@ -1,0 +1,31 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+xml XML_VALUE = xml `<root>${"x"}</root>`;
+
+public function main() {
+    string name = "world";
+    xml x = xml `<greeting>Hello, ${name}!</greeting>`;
+    io:println(x); // @output <greeting>Hello, world!</greeting>
+
+    string markup = "<child/>";
+    string amp = "a&b";
+    xml escaped = xml `<root>${markup}|${amp}</root>`;
+    io:println(escaped); // @output <root>&lt;child/&gt;|a&amp;b</root>
+    io:println(XML_VALUE); // @output <root>x</root>
+}

--- a/corpus/bal/subset9/09-template-expr/template-doctype-inject-v.bal
+++ b/corpus/bal/subset9/09-template-expr/template-doctype-inject-v.bal
@@ -1,0 +1,23 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    string s = "<!DOCTYPE x>";
+    xml x = xml `${s}<a/>`;
+    io:println(x); // @output &lt;!DOCTYPE x&gt;<a/>
+}

--- a/corpus/bal/subset9/09-template-expr/template-dup-prefix-v.bal
+++ b/corpus/bal/subset9/09-template-expr/template-dup-prefix-v.bal
@@ -1,0 +1,26 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+xmlns "https://example.com/u" as a;
+xmlns "https://example.com/u" as b;
+
+public function main() {
+    string v = "x";
+    xml x = xml `<a:tag>${v}</a:tag>`;
+    io:println(x); // @output <a:tag xmlns:a="https://example.com/u">x</a:tag>
+}

--- a/corpus/bal/subset9/09-template-expr/template-entity-v.bal
+++ b/corpus/bal/subset9/09-template-expr/template-entity-v.bal
@@ -1,0 +1,23 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    string x = "v";
+    xml e = xml `<a>&amp;${x}</a>`;
+    io:println(e); // @output <a>&amp;v</a>
+}

--- a/corpus/bal/subset9/09-template-expr/template-inline-ns-scope-v.bal
+++ b/corpus/bal/subset9/09-template-expr/template-inline-ns-scope-v.bal
@@ -1,0 +1,25 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+xmlns "https://example.com/outer" as p;
+
+public function main() {
+    string s = "";
+    xml x = xml `<p:a>${s}</p:a><b xmlns:p="https://example.com/inner"><p:c/></b>`;
+    io:println(x); // @output <p:a xmlns:p="https://example.com/outer"/><b xmlns:p="https://example.com/inner"><p:c/></b>
+}

--- a/corpus/bal/subset9/09-template-expr/template-malformed-inject-v.bal
+++ b/corpus/bal/subset9/09-template-expr/template-malformed-inject-v.bal
@@ -1,0 +1,23 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    string s = "<a>";
+    xml x = xml `${s}`;
+    io:println(x); // @output &lt;a&gt;
+}

--- a/corpus/bal/subset9/09-template-expr/template-mixed-content-v.bal
+++ b/corpus/bal/subset9/09-template-expr/template-mixed-content-v.bal
@@ -1,0 +1,23 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    string n = "v";
+    xml v = xml `before ${n} <m/> after ${n}`;
+    io:println(v); // @output before v <m/> after v
+}

--- a/corpus/bal/subset9/09-template-expr/template-mixed-v.bal
+++ b/corpus/bal/subset9/09-template-expr/template-mixed-v.bal
@@ -1,0 +1,24 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    int n = 3;
+    xml inner = xml `<i/>`;
+    xml x = xml `<root>n=${n}, inner=${inner}</root>`;
+    io:println(x); // @output <root>n=3, inner=<i/></root>
+}

--- a/corpus/bal/subset9/09-template-expr/template-multi-attr-v.bal
+++ b/corpus/bal/subset9/09-template-expr/template-multi-attr-v.bal
@@ -1,0 +1,25 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    string a = "A";
+    string b = "B";
+    int n = 42;
+    xml x = xml `<elem first="${a}-${b}" n="${n}" mixed="lit-${a}"/>`;
+    io:println(x); // @output <elem first="A-B" n="42" mixed="lit-A"/>
+}

--- a/corpus/bal/subset9/09-template-expr/template-multi-root-outer-ns-v.bal
+++ b/corpus/bal/subset9/09-template-expr/template-multi-root-outer-ns-v.bal
@@ -1,0 +1,25 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+xmlns "https://example.com/outer" as p;
+
+public function main() {
+    string s = "";
+    xml x = xml `<p:a>${s}</p:a><p:b/>`;
+    io:println(x); // @output <p:a xmlns:p="https://example.com/outer"/><p:b xmlns:p="https://example.com/outer"/>
+}

--- a/corpus/bal/subset9/09-template-expr/template-multi-root-v.bal
+++ b/corpus/bal/subset9/09-template-expr/template-multi-root-v.bal
@@ -14,7 +14,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/io;
+
 public function main() {
-    string name = "x";
-    xml x = xml `<a>${name}</a>`; // @error xml interpolation not yet supported
+    string x = "mid";
+    xml v = xml `<a/>${x}<b/>`;
+    io:println(v); // @output <a/>mid<b/>
 }

--- a/corpus/bal/subset9/09-template-expr/template-ns-inherit-v.bal
+++ b/corpus/bal/subset9/09-template-expr/template-ns-inherit-v.bal
@@ -1,0 +1,25 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+xmlns "https://example.com/d";
+
+public function main() {
+    string v = "leaf";
+    xml x = xml `<outer><inner>${v}</inner></outer>`;
+    io:println(x); // @output <outer xmlns="https://example.com/d"><inner>leaf</inner></outer>
+}

--- a/corpus/bal/subset9/09-template-expr/template-pi-e.bal
+++ b/corpus/bal/subset9/09-template-expr/template-pi-e.bal
@@ -1,0 +1,20 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public function main() {
+    string s = "x";
+    xml x = xml `<?target body ${s}?>`; // @error interpolation not allowed in xml processing instruction
+}

--- a/corpus/bal/subset9/09-template-expr/template-pi-empty-data-v.bal
+++ b/corpus/bal/subset9/09-template-expr/template-pi-empty-data-v.bal
@@ -1,0 +1,23 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    string body = "tail";
+    xml x = xml `<?empty?>${body}`;
+    io:println(x); // @output <?empty ?>tail
+}

--- a/corpus/bal/subset9/09-template-expr/template-prefixed-attr-v.bal
+++ b/corpus/bal/subset9/09-template-expr/template-prefixed-attr-v.bal
@@ -1,0 +1,25 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+xmlns "https://example.com/attr" as p;
+
+public function main() {
+    string body = "hello";
+    xml x = xml `<root p:name="v">${body}</root>`;
+    io:println(x); // @output <root p:name="v" xmlns:p="https://example.com/attr">hello</root>
+}

--- a/corpus/bal/subset9/09-template-expr/template-query-xml-sequence-fv.bal
+++ b/corpus/bal/subset9/09-template-expr/template-query-xml-sequence-fv.bal
@@ -1,0 +1,23 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ballerina/io;
+
+public function main() {
+    int[] values = [1, 2];
+    // TODO: Support XML sequence insertion from query result: https://github.com/ballerina-platform/ballerina-lang-go/issues/533
+    xml x = xml `<root>${from var n in values select xml `<n>${n}</n>`}</root>`; // @error future: XML sequence insertion from query result
+    io:println(x); // @output <root><n>1</n><n>2</n></root>
+}

--- a/corpus/bal/subset9/09-template-expr/template-single-quote-attr-v.bal
+++ b/corpus/bal/subset9/09-template-expr/template-single-quote-attr-v.bal
@@ -1,0 +1,23 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    string id = "abc";
+    xml x = xml `<row id='${id}'/>`;
+    io:println(x); // @output <row id="abc"/>
+}

--- a/corpus/bal/subset9/09-template-expr/template-tagname-e.bal
+++ b/corpus/bal/subset9/09-template-expr/template-tagname-e.bal
@@ -1,0 +1,20 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public function main() {
+    string t = "tag";
+    xml x = xml `<${t}/>`; // @error parser does not accept interpolation as element name
+}

--- a/corpus/bal/subset9/09-template-expr/template-xml-child-v.bal
+++ b/corpus/bal/subset9/09-template-expr/template-xml-child-v.bal
@@ -1,0 +1,23 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    xml child = xml `<c/>`;
+    xml parent = xml `<p>${child}</p>`;
+    io:println(parent); // @output <p><c/></p>
+}

--- a/corpus/bal/subset9/09-template-expr/template-xml-prefix-v.bal
+++ b/corpus/bal/subset9/09-template-expr/template-xml-prefix-v.bal
@@ -1,0 +1,23 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    string v = "<a xml:lang=\"en\"/>";
+    xml x = xml `${v}`;
+    io:println(x); // @output &lt;a xml:lang="en"/&gt;
+}

--- a/corpus/bal/subset9/09-template-expr/template-xmldecl-inject-v.bal
+++ b/corpus/bal/subset9/09-template-expr/template-xmldecl-inject-v.bal
@@ -1,0 +1,23 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    string s = "<?xml version='1.0'?>";
+    xml x = xml `${s}<a/>`;
+    io:println(x); // @output &lt;?xml version='1.0'?&gt;<a/>
+}

--- a/corpus/bal/subset9/09-template-expr/template-xmlfoo-pi-v.bal
+++ b/corpus/bal/subset9/09-template-expr/template-xmlfoo-pi-v.bal
@@ -1,0 +1,23 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    string x = "v";
+    xml v = xml `<?xmlfoo body?>${x}`;
+    io:println(v); // @output <?xmlfoo body?>v
+}

--- a/corpus/bal/subset9/09-template-expr/template-xmlns-e.bal
+++ b/corpus/bal/subset9/09-template-expr/template-xmlns-e.bal
@@ -1,0 +1,20 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public function main() {
+    string ns = "https://example.com/";
+    xml x = xml `<r xmlns="${ns}"/>`; // @error interpolation not allowed in xmlns attribute value
+}

--- a/corpus/bal/subset9/09-template-expr/template-xmlns-escape-v.bal
+++ b/corpus/bal/subset9/09-template-expr/template-xmlns-escape-v.bal
@@ -1,0 +1,25 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+xmlns "https://example.com/a&b\"c" as p;
+
+public function main() {
+    string v = "hi";
+    xml x = xml `<p:tag>${v}</p:tag>`;
+    io:println(x); // @output <p:tag xmlns:p="https://example.com/a&amp;b&quot;c">hi</p:tag>
+}

--- a/corpus/bal/subset9/09-template-expr/template-xmlns-v.bal
+++ b/corpus/bal/subset9/09-template-expr/template-xmlns-v.bal
@@ -1,0 +1,25 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+xmlns "https://example.com/foo" as foo;
+
+public function main() {
+    string v = "hi";
+    xml x = xml `<foo:tag>${v}</foo:tag>`;
+    io:println(x); // @output <foo:tag xmlns:foo="https://example.com/foo">hi</foo:tag>
+}

--- a/corpus/bir/subset9/09-template-expr/template-attr-v.txt
+++ b/corpus/bir/subset9/09-template-expr/template-attr-v.txt
@@ -1,0 +1,29 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad 7
+    id = %1;
+    %3 = id;
+    %4 = escapeXMLAttribute(%3) -> bb1;
+  }
+  bb1 {
+    %5 = evalTemplate[xml]("<row id=\"", %4, "\"/>")
+    x = %5;
+    %7 = println(x) -> bb2;
+  }
+  bb2 {
+    %8 = ConstantLoad a&b"c<d
+    value = %8;
+    %10 = escapeXMLAttribute(value) -> bb3;
+  }
+  bb3 {
+    %11 = evalTemplate[xml]("<root value=\"", %10, "\"/>")
+    escaped = %11;
+    %13 = println(escaped) -> bb4;
+  }
+  bb4 {
+    return;
+  }
+}

--- a/corpus/bir/subset9/09-template-expr/template-bare-comment-v.txt
+++ b/corpus/bir/subset9/09-template-expr/template-bare-comment-v.txt
@@ -1,0 +1,18 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad x
+    x = %1;
+    %3 = escapeXMLContent(x) -> bb1;
+  }
+  bb1 {
+    %4 = evalTemplate[xml]("<!-- c -->", %3, "")
+    v = %4;
+    %6 = println(v) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}

--- a/corpus/bir/subset9/09-template-expr/template-bare-pi-v.txt
+++ b/corpus/bir/subset9/09-template-expr/template-bare-pi-v.txt
@@ -1,0 +1,18 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad x
+    x = %1;
+    %3 = escapeXMLContent(x) -> bb1;
+  }
+  bb1 {
+    %4 = evalTemplate[xml]("<?tgt body?>", %3, "")
+    v = %4;
+    %6 = println(v) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}

--- a/corpus/bir/subset9/09-template-expr/template-bare-text-v.txt
+++ b/corpus/bir/subset9/09-template-expr/template-bare-text-v.txt
@@ -1,0 +1,18 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad world
+    x = %1;
+    %3 = escapeXMLContent(x) -> bb1;
+  }
+  bb1 {
+    %4 = evalTemplate[xml]("hello ", %3, "")
+    v = %4;
+    %6 = println(v) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}

--- a/corpus/bir/subset9/09-template-expr/template-bare-v.txt
+++ b/corpus/bir/subset9/09-template-expr/template-bare-v.txt
@@ -1,0 +1,18 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad abc
+    x = %1;
+    %3 = escapeXMLContent(x) -> bb1;
+  }
+  bb1 {
+    %4 = evalTemplate[xml]("", %3, "")
+    v = %4;
+    %6 = println(v) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}

--- a/corpus/bir/subset9/09-template-expr/template-content-v.txt
+++ b/corpus/bir/subset9/09-template-expr/template-content-v.txt
@@ -1,0 +1,37 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+import ballerina.io v 0.0.0;
+XML_VALUE  xml;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad world
+    name = %1;
+    %3 = escapeXMLContent(name) -> bb1;
+  }
+  bb1 {
+    %4 = evalTemplate[xml]("<greeting>Hello, ", %3, "!</greeting>")
+    x = %4;
+    %6 = println(x) -> bb2;
+  }
+  bb2 {
+    %7 = ConstantLoad <child/>
+    markup = %7;
+    %9 = ConstantLoad a&b
+    amp = %9;
+    %11 = escapeXMLContent(markup) -> bb3;
+  }
+  bb3 {
+    %12 = escapeXMLContent(amp) -> bb4;
+  }
+  bb4 {
+    %13 = evalTemplate[xml]("<root>", %11, "|", %12, "</root>")
+    escaped = %13;
+    %15 = println(escaped) -> bb5;
+  }
+  bb5 {
+    %16 = println(XML_VALUE) -> bb6;
+  }
+  bb6 {
+    return;
+  }
+}

--- a/corpus/bir/subset9/09-template-expr/template-doctype-inject-v.txt
+++ b/corpus/bir/subset9/09-template-expr/template-doctype-inject-v.txt
@@ -1,0 +1,18 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad <!DOCTYPE x>
+    s = %1;
+    %3 = escapeXMLContent(s) -> bb1;
+  }
+  bb1 {
+    %4 = evalTemplate[xml]("", %3, "<a/>")
+    x = %4;
+    %6 = println(x) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}

--- a/corpus/bir/subset9/09-template-expr/template-dup-prefix-v.txt
+++ b/corpus/bir/subset9/09-template-expr/template-dup-prefix-v.txt
@@ -1,0 +1,18 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad x
+    v = %1;
+    %3 = escapeXMLContent(v) -> bb1;
+  }
+  bb1 {
+    %4 = evalTemplate[xml]("<a:tag xmlns:a=\"https://example.com/u\">", %3, "</a:tag>")
+    x = %4;
+    %6 = println(x) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}

--- a/corpus/bir/subset9/09-template-expr/template-entity-v.txt
+++ b/corpus/bir/subset9/09-template-expr/template-entity-v.txt
@@ -1,0 +1,18 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad v
+    x = %1;
+    %3 = escapeXMLContent(x) -> bb1;
+  }
+  bb1 {
+    %4 = evalTemplate[xml]("<a>&amp;", %3, "</a>")
+    e = %4;
+    %6 = println(e) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}

--- a/corpus/bir/subset9/09-template-expr/template-inline-ns-scope-v.txt
+++ b/corpus/bir/subset9/09-template-expr/template-inline-ns-scope-v.txt
@@ -1,0 +1,18 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad 
+    s = %1;
+    %3 = escapeXMLContent(s) -> bb1;
+  }
+  bb1 {
+    %4 = evalTemplate[xml]("<p:a xmlns:p=\"https://example.com/outer\">", %3, "</p:a><b xmlns:p=\"https://example.com/inner\"><p:c/></b>")
+    x = %4;
+    %6 = println(x) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}

--- a/corpus/bir/subset9/09-template-expr/template-malformed-inject-v.txt
+++ b/corpus/bir/subset9/09-template-expr/template-malformed-inject-v.txt
@@ -1,0 +1,18 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad <a>
+    s = %1;
+    %3 = escapeXMLContent(s) -> bb1;
+  }
+  bb1 {
+    %4 = evalTemplate[xml]("", %3, "")
+    x = %4;
+    %6 = println(x) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}

--- a/corpus/bir/subset9/09-template-expr/template-mixed-content-v.txt
+++ b/corpus/bir/subset9/09-template-expr/template-mixed-content-v.txt
@@ -1,0 +1,21 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad v
+    n = %1;
+    %3 = escapeXMLContent(n) -> bb1;
+  }
+  bb1 {
+    %4 = escapeXMLContent(n) -> bb2;
+  }
+  bb2 {
+    %5 = evalTemplate[xml]("before ", %3, " <m/> after ", %4, "")
+    v = %5;
+    %7 = println(v) -> bb3;
+  }
+  bb3 {
+    return;
+  }
+}

--- a/corpus/bir/subset9/09-template-expr/template-mixed-v.txt
+++ b/corpus/bir/subset9/09-template-expr/template-mixed-v.txt
@@ -1,0 +1,22 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad 3
+    n = %1;
+    %3 = ConstantLoad i
+    %4 = newXMLElement(%3, ())
+    inner = %4;
+    %6 = n;
+    %7 = escapeXMLContent(%6) -> bb1;
+  }
+  bb1 {
+    %8 = evalTemplate[xml]("<root>n=", %7, ", inner=", inner, "</root>")
+    x = %8;
+    %10 = println(x) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}

--- a/corpus/bir/subset9/09-template-expr/template-multi-attr-v.txt
+++ b/corpus/bir/subset9/09-template-expr/template-multi-attr-v.txt
@@ -1,0 +1,32 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad A
+    a = %1;
+    %3 = ConstantLoad B
+    b = %3;
+    %5 = ConstantLoad 42
+    n = %5;
+    %7 = escapeXMLAttribute(a) -> bb1;
+  }
+  bb1 {
+    %8 = escapeXMLAttribute(b) -> bb2;
+  }
+  bb2 {
+    %9 = n;
+    %10 = escapeXMLAttribute(%9) -> bb3;
+  }
+  bb3 {
+    %11 = escapeXMLAttribute(a) -> bb4;
+  }
+  bb4 {
+    %12 = evalTemplate[xml]("<elem first=\"", %7, "-", %8, "\" n=\"", %10, "\" mixed=\"lit-", %11, "\"/>")
+    x = %12;
+    %14 = println(x) -> bb5;
+  }
+  bb5 {
+    return;
+  }
+}

--- a/corpus/bir/subset9/09-template-expr/template-multi-root-outer-ns-v.txt
+++ b/corpus/bir/subset9/09-template-expr/template-multi-root-outer-ns-v.txt
@@ -1,0 +1,18 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad 
+    s = %1;
+    %3 = escapeXMLContent(s) -> bb1;
+  }
+  bb1 {
+    %4 = evalTemplate[xml]("<p:a xmlns:p=\"https://example.com/outer\">", %3, "</p:a><p:b xmlns:p=\"https://example.com/outer\"/>")
+    x = %4;
+    %6 = println(x) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}

--- a/corpus/bir/subset9/09-template-expr/template-multi-root-v.txt
+++ b/corpus/bir/subset9/09-template-expr/template-multi-root-v.txt
@@ -1,0 +1,18 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad mid
+    x = %1;
+    %3 = escapeXMLContent(x) -> bb1;
+  }
+  bb1 {
+    %4 = evalTemplate[xml]("<a/>", %3, "<b/>")
+    v = %4;
+    %6 = println(v) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}

--- a/corpus/bir/subset9/09-template-expr/template-ns-inherit-v.txt
+++ b/corpus/bir/subset9/09-template-expr/template-ns-inherit-v.txt
@@ -1,0 +1,18 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad leaf
+    v = %1;
+    %3 = escapeXMLContent(v) -> bb1;
+  }
+  bb1 {
+    %4 = evalTemplate[xml]("<outer xmlns=\"https://example.com/d\"><inner>", %3, "</inner></outer>")
+    x = %4;
+    %6 = println(x) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}

--- a/corpus/bir/subset9/09-template-expr/template-pi-empty-data-v.txt
+++ b/corpus/bir/subset9/09-template-expr/template-pi-empty-data-v.txt
@@ -1,0 +1,18 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad tail
+    body = %1;
+    %3 = escapeXMLContent(body) -> bb1;
+  }
+  bb1 {
+    %4 = evalTemplate[xml]("<?empty?>", %3, "")
+    x = %4;
+    %6 = println(x) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}

--- a/corpus/bir/subset9/09-template-expr/template-prefixed-attr-v.txt
+++ b/corpus/bir/subset9/09-template-expr/template-prefixed-attr-v.txt
@@ -1,0 +1,18 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad hello
+    body = %1;
+    %3 = escapeXMLContent(body) -> bb1;
+  }
+  bb1 {
+    %4 = evalTemplate[xml]("<root xmlns:p=\"https://example.com/attr\" p:name=\"v\">", %3, "</root>")
+    x = %4;
+    %6 = println(x) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}

--- a/corpus/bir/subset9/09-template-expr/template-single-quote-attr-v.txt
+++ b/corpus/bir/subset9/09-template-expr/template-single-quote-attr-v.txt
@@ -1,0 +1,18 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad abc
+    id = %1;
+    %3 = escapeXMLAttribute(id) -> bb1;
+  }
+  bb1 {
+    %4 = evalTemplate[xml]("<row id='", %3, "'/>")
+    x = %4;
+    %6 = println(x) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}

--- a/corpus/bir/subset9/09-template-expr/template-xml-child-v.txt
+++ b/corpus/bir/subset9/09-template-expr/template-xml-child-v.txt
@@ -1,0 +1,15 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad c
+    %2 = newXMLElement(%1, ())
+    child = %2;
+    %4 = evalTemplate[xml]("<p>", child, "</p>")
+    parent = %4;
+    %6 = println(parent) -> bb1;
+  }
+  bb1 {
+    return;
+  }
+}

--- a/corpus/bir/subset9/09-template-expr/template-xml-prefix-v.txt
+++ b/corpus/bir/subset9/09-template-expr/template-xml-prefix-v.txt
@@ -1,0 +1,18 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad <a xml:lang="en"/>
+    v = %1;
+    %3 = escapeXMLContent(v) -> bb1;
+  }
+  bb1 {
+    %4 = evalTemplate[xml]("", %3, "")
+    x = %4;
+    %6 = println(x) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}

--- a/corpus/bir/subset9/09-template-expr/template-xmldecl-inject-v.txt
+++ b/corpus/bir/subset9/09-template-expr/template-xmldecl-inject-v.txt
@@ -1,0 +1,18 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad <?xml version='1.0'?>
+    s = %1;
+    %3 = escapeXMLContent(s) -> bb1;
+  }
+  bb1 {
+    %4 = evalTemplate[xml]("", %3, "<a/>")
+    x = %4;
+    %6 = println(x) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}

--- a/corpus/bir/subset9/09-template-expr/template-xmlfoo-pi-v.txt
+++ b/corpus/bir/subset9/09-template-expr/template-xmlfoo-pi-v.txt
@@ -1,0 +1,18 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad v
+    x = %1;
+    %3 = escapeXMLContent(x) -> bb1;
+  }
+  bb1 {
+    %4 = evalTemplate[xml]("<?xmlfoo body?>", %3, "")
+    v = %4;
+    %6 = println(v) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}

--- a/corpus/bir/subset9/09-template-expr/template-xmlns-escape-v.txt
+++ b/corpus/bir/subset9/09-template-expr/template-xmlns-escape-v.txt
@@ -1,0 +1,18 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad hi
+    v = %1;
+    %3 = escapeXMLContent(v) -> bb1;
+  }
+  bb1 {
+    %4 = evalTemplate[xml]("<p:tag xmlns:p=\"https://example.com/a&amp;b&quot;c\">", %3, "</p:tag>")
+    x = %4;
+    %6 = println(x) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}

--- a/corpus/bir/subset9/09-template-expr/template-xmlns-v.txt
+++ b/corpus/bir/subset9/09-template-expr/template-xmlns-v.txt
@@ -1,0 +1,18 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad hi
+    v = %1;
+    %3 = escapeXMLContent(v) -> bb1;
+  }
+  bb1 {
+    %4 = evalTemplate[xml]("<foo:tag xmlns:foo=\"https://example.com/foo\">", %3, "</foo:tag>")
+    x = %4;
+    %6 = println(x) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}

--- a/corpus/cfg/subset9/09-template-expr/template-attr-v.txt
+++ b/corpus/cfg/subset9/09-template-expr/template-attr-v.txt
@@ -1,0 +1,34 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable id (type
+        (value-type int)) (expr
+        (literal 7))))
+    (var-def
+      (variable x (type
+        (value-type xml)) (expr
+        (xml-template-literal
+          (template-string "<row id=\"")
+          (xml-template-attribute-insertion
+            (simple-var-ref id))
+          (template-string "\"/>")))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref x))))
+    (var-def
+      (variable value (type
+        (value-type string)) (expr
+        (literal a&b"c<d))))
+    (var-def
+      (variable escaped (type
+        (value-type xml)) (expr
+        (xml-template-literal
+          (template-string "<root value=\"")
+          (xml-template-attribute-insertion
+            (simple-var-ref value))
+          (template-string "\"/>")))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref escaped))))
+  )
+)

--- a/corpus/cfg/subset9/09-template-expr/template-bare-comment-v.txt
+++ b/corpus/cfg/subset9/09-template-expr/template-bare-comment-v.txt
@@ -1,0 +1,19 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable x (type
+        (value-type string)) (expr
+        (literal x))))
+    (var-def
+      (variable v (type
+        (value-type xml)) (expr
+        (xml-template-literal
+          (template-string "<!-- c -->")
+          (xml-template-content-insertion
+            (simple-var-ref x))
+          (template-string "")))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref v))))
+  )
+)

--- a/corpus/cfg/subset9/09-template-expr/template-bare-pi-v.txt
+++ b/corpus/cfg/subset9/09-template-expr/template-bare-pi-v.txt
@@ -1,0 +1,19 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable x (type
+        (value-type string)) (expr
+        (literal x))))
+    (var-def
+      (variable v (type
+        (value-type xml)) (expr
+        (xml-template-literal
+          (template-string "<?tgt body?>")
+          (xml-template-content-insertion
+            (simple-var-ref x))
+          (template-string "")))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref v))))
+  )
+)

--- a/corpus/cfg/subset9/09-template-expr/template-bare-text-v.txt
+++ b/corpus/cfg/subset9/09-template-expr/template-bare-text-v.txt
@@ -1,0 +1,19 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable x (type
+        (value-type string)) (expr
+        (literal world))))
+    (var-def
+      (variable v (type
+        (value-type xml)) (expr
+        (xml-template-literal
+          (template-string "hello ")
+          (xml-template-content-insertion
+            (simple-var-ref x))
+          (template-string "")))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref v))))
+  )
+)

--- a/corpus/cfg/subset9/09-template-expr/template-bare-v.txt
+++ b/corpus/cfg/subset9/09-template-expr/template-bare-v.txt
@@ -1,0 +1,19 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable x (type
+        (value-type string)) (expr
+        (literal abc))))
+    (var-def
+      (variable v (type
+        (value-type xml)) (expr
+        (xml-template-literal
+          (template-string "")
+          (xml-template-content-insertion
+            (simple-var-ref x))
+          (template-string "")))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref v))))
+  )
+)

--- a/corpus/cfg/subset9/09-template-expr/template-content-v.txt
+++ b/corpus/cfg/subset9/09-template-expr/template-content-v.txt
@@ -1,0 +1,44 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable name (type
+        (value-type string)) (expr
+        (literal world))))
+    (var-def
+      (variable x (type
+        (value-type xml)) (expr
+        (xml-template-literal
+          (template-string "<greeting>Hello, ")
+          (xml-template-content-insertion
+            (simple-var-ref name))
+          (template-string "!</greeting>")))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref x))))
+    (var-def
+      (variable markup (type
+        (value-type string)) (expr
+        (literal <child/>))))
+    (var-def
+      (variable amp (type
+        (value-type string)) (expr
+        (literal a&b))))
+    (var-def
+      (variable escaped (type
+        (value-type xml)) (expr
+        (xml-template-literal
+          (template-string "<root>")
+          (xml-template-content-insertion
+            (simple-var-ref markup))
+          (template-string "|")
+          (xml-template-content-insertion
+            (simple-var-ref amp))
+          (template-string "</root>")))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref escaped))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref XML_VALUE))))
+  )
+)

--- a/corpus/cfg/subset9/09-template-expr/template-doctype-inject-v.txt
+++ b/corpus/cfg/subset9/09-template-expr/template-doctype-inject-v.txt
@@ -1,0 +1,19 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable s (type
+        (value-type string)) (expr
+        (literal <!DOCTYPE x>))))
+    (var-def
+      (variable x (type
+        (value-type xml)) (expr
+        (xml-template-literal
+          (template-string "")
+          (xml-template-content-insertion
+            (simple-var-ref s))
+          (template-string "<a/>")))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref x))))
+  )
+)

--- a/corpus/cfg/subset9/09-template-expr/template-dup-prefix-v.txt
+++ b/corpus/cfg/subset9/09-template-expr/template-dup-prefix-v.txt
@@ -1,0 +1,19 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable v (type
+        (value-type string)) (expr
+        (literal x))))
+    (var-def
+      (variable x (type
+        (value-type xml)) (expr
+        (xml-template-literal
+          (template-string "<a:tag>")
+          (xml-template-content-insertion
+            (simple-var-ref v))
+          (template-string "</a:tag>")))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref x))))
+  )
+)

--- a/corpus/cfg/subset9/09-template-expr/template-entity-v.txt
+++ b/corpus/cfg/subset9/09-template-expr/template-entity-v.txt
@@ -1,0 +1,19 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable x (type
+        (value-type string)) (expr
+        (literal v))))
+    (var-def
+      (variable e (type
+        (value-type xml)) (expr
+        (xml-template-literal
+          (template-string "<a>&amp;")
+          (xml-template-content-insertion
+            (simple-var-ref x))
+          (template-string "</a>")))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref e))))
+  )
+)

--- a/corpus/cfg/subset9/09-template-expr/template-inline-ns-scope-v.txt
+++ b/corpus/cfg/subset9/09-template-expr/template-inline-ns-scope-v.txt
@@ -1,0 +1,19 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable s (type
+        (value-type string)) (expr
+        (literal ))))
+    (var-def
+      (variable x (type
+        (value-type xml)) (expr
+        (xml-template-literal
+          (template-string "<p:a>")
+          (xml-template-content-insertion
+            (simple-var-ref s))
+          (template-string "</p:a><b xmlns:p=\"https://example.com/inner\"><p:c/></b>")))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref x))))
+  )
+)

--- a/corpus/cfg/subset9/09-template-expr/template-malformed-inject-v.txt
+++ b/corpus/cfg/subset9/09-template-expr/template-malformed-inject-v.txt
@@ -1,0 +1,19 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable s (type
+        (value-type string)) (expr
+        (literal <a>))))
+    (var-def
+      (variable x (type
+        (value-type xml)) (expr
+        (xml-template-literal
+          (template-string "")
+          (xml-template-content-insertion
+            (simple-var-ref s))
+          (template-string "")))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref x))))
+  )
+)

--- a/corpus/cfg/subset9/09-template-expr/template-mixed-content-v.txt
+++ b/corpus/cfg/subset9/09-template-expr/template-mixed-content-v.txt
@@ -1,0 +1,22 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable n (type
+        (value-type string)) (expr
+        (literal v))))
+    (var-def
+      (variable v (type
+        (value-type xml)) (expr
+        (xml-template-literal
+          (template-string "before ")
+          (xml-template-content-insertion
+            (simple-var-ref n))
+          (template-string " <m/> after ")
+          (xml-template-content-insertion
+            (simple-var-ref n))
+          (template-string "")))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref v))))
+  )
+)

--- a/corpus/cfg/subset9/09-template-expr/template-mixed-v.txt
+++ b/corpus/cfg/subset9/09-template-expr/template-mixed-v.txt
@@ -1,0 +1,26 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable n (type
+        (value-type int)) (expr
+        (literal 3))))
+    (var-def
+      (variable inner (type
+        (value-type xml)) (expr
+        (xml-element-literal i))))
+    (var-def
+      (variable x (type
+        (value-type xml)) (expr
+        (xml-template-literal
+          (template-string "<root>n=")
+          (xml-template-content-insertion
+            (simple-var-ref n))
+          (template-string ", inner=")
+          (xml-template-content-insertion
+            (simple-var-ref inner))
+          (template-string "</root>")))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref x))))
+  )
+)

--- a/corpus/cfg/subset9/09-template-expr/template-multi-attr-v.txt
+++ b/corpus/cfg/subset9/09-template-expr/template-multi-attr-v.txt
@@ -1,0 +1,36 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable a (type
+        (value-type string)) (expr
+        (literal A))))
+    (var-def
+      (variable b (type
+        (value-type string)) (expr
+        (literal B))))
+    (var-def
+      (variable n (type
+        (value-type int)) (expr
+        (literal 42))))
+    (var-def
+      (variable x (type
+        (value-type xml)) (expr
+        (xml-template-literal
+          (template-string "<elem first=\"")
+          (xml-template-attribute-insertion
+            (simple-var-ref a))
+          (template-string "-")
+          (xml-template-attribute-insertion
+            (simple-var-ref b))
+          (template-string "\" n=\"")
+          (xml-template-attribute-insertion
+            (simple-var-ref n))
+          (template-string "\" mixed=\"lit-")
+          (xml-template-attribute-insertion
+            (simple-var-ref a))
+          (template-string "\"/>")))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref x))))
+  )
+)

--- a/corpus/cfg/subset9/09-template-expr/template-multi-root-outer-ns-v.txt
+++ b/corpus/cfg/subset9/09-template-expr/template-multi-root-outer-ns-v.txt
@@ -1,0 +1,19 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable s (type
+        (value-type string)) (expr
+        (literal ))))
+    (var-def
+      (variable x (type
+        (value-type xml)) (expr
+        (xml-template-literal
+          (template-string "<p:a>")
+          (xml-template-content-insertion
+            (simple-var-ref s))
+          (template-string "</p:a><p:b/>")))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref x))))
+  )
+)

--- a/corpus/cfg/subset9/09-template-expr/template-multi-root-v.txt
+++ b/corpus/cfg/subset9/09-template-expr/template-multi-root-v.txt
@@ -1,0 +1,19 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable x (type
+        (value-type string)) (expr
+        (literal mid))))
+    (var-def
+      (variable v (type
+        (value-type xml)) (expr
+        (xml-template-literal
+          (template-string "<a/>")
+          (xml-template-content-insertion
+            (simple-var-ref x))
+          (template-string "<b/>")))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref v))))
+  )
+)

--- a/corpus/cfg/subset9/09-template-expr/template-ns-inherit-v.txt
+++ b/corpus/cfg/subset9/09-template-expr/template-ns-inherit-v.txt
@@ -1,0 +1,19 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable v (type
+        (value-type string)) (expr
+        (literal leaf))))
+    (var-def
+      (variable x (type
+        (value-type xml)) (expr
+        (xml-template-literal
+          (template-string "<outer><inner>")
+          (xml-template-content-insertion
+            (simple-var-ref v))
+          (template-string "</inner></outer>")))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref x))))
+  )
+)

--- a/corpus/cfg/subset9/09-template-expr/template-pi-empty-data-v.txt
+++ b/corpus/cfg/subset9/09-template-expr/template-pi-empty-data-v.txt
@@ -1,0 +1,19 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable body (type
+        (value-type string)) (expr
+        (literal tail))))
+    (var-def
+      (variable x (type
+        (value-type xml)) (expr
+        (xml-template-literal
+          (template-string "<?empty?>")
+          (xml-template-content-insertion
+            (simple-var-ref body))
+          (template-string "")))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref x))))
+  )
+)

--- a/corpus/cfg/subset9/09-template-expr/template-prefixed-attr-v.txt
+++ b/corpus/cfg/subset9/09-template-expr/template-prefixed-attr-v.txt
@@ -1,0 +1,19 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable body (type
+        (value-type string)) (expr
+        (literal hello))))
+    (var-def
+      (variable x (type
+        (value-type xml)) (expr
+        (xml-template-literal
+          (template-string "<root p:name=\"v\">")
+          (xml-template-content-insertion
+            (simple-var-ref body))
+          (template-string "</root>")))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref x))))
+  )
+)

--- a/corpus/cfg/subset9/09-template-expr/template-single-quote-attr-v.txt
+++ b/corpus/cfg/subset9/09-template-expr/template-single-quote-attr-v.txt
@@ -1,0 +1,19 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable id (type
+        (value-type string)) (expr
+        (literal abc))))
+    (var-def
+      (variable x (type
+        (value-type xml)) (expr
+        (xml-template-literal
+          (template-string "<row id='")
+          (xml-template-attribute-insertion
+            (simple-var-ref id))
+          (template-string "'/>")))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref x))))
+  )
+)

--- a/corpus/cfg/subset9/09-template-expr/template-xml-child-v.txt
+++ b/corpus/cfg/subset9/09-template-expr/template-xml-child-v.txt
@@ -1,0 +1,19 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable child (type
+        (value-type xml)) (expr
+        (xml-element-literal c))))
+    (var-def
+      (variable parent (type
+        (value-type xml)) (expr
+        (xml-template-literal
+          (template-string "<p>")
+          (xml-template-content-insertion
+            (simple-var-ref child))
+          (template-string "</p>")))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref parent))))
+  )
+)

--- a/corpus/cfg/subset9/09-template-expr/template-xml-prefix-v.txt
+++ b/corpus/cfg/subset9/09-template-expr/template-xml-prefix-v.txt
@@ -1,0 +1,19 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable v (type
+        (value-type string)) (expr
+        (literal <a xml:lang="en"/>))))
+    (var-def
+      (variable x (type
+        (value-type xml)) (expr
+        (xml-template-literal
+          (template-string "")
+          (xml-template-content-insertion
+            (simple-var-ref v))
+          (template-string "")))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref x))))
+  )
+)

--- a/corpus/cfg/subset9/09-template-expr/template-xmldecl-inject-v.txt
+++ b/corpus/cfg/subset9/09-template-expr/template-xmldecl-inject-v.txt
@@ -1,0 +1,19 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable s (type
+        (value-type string)) (expr
+        (literal <?xml version='1.0'?>))))
+    (var-def
+      (variable x (type
+        (value-type xml)) (expr
+        (xml-template-literal
+          (template-string "")
+          (xml-template-content-insertion
+            (simple-var-ref s))
+          (template-string "<a/>")))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref x))))
+  )
+)

--- a/corpus/cfg/subset9/09-template-expr/template-xmlfoo-pi-v.txt
+++ b/corpus/cfg/subset9/09-template-expr/template-xmlfoo-pi-v.txt
@@ -1,0 +1,19 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable x (type
+        (value-type string)) (expr
+        (literal v))))
+    (var-def
+      (variable v (type
+        (value-type xml)) (expr
+        (xml-template-literal
+          (template-string "<?xmlfoo body?>")
+          (xml-template-content-insertion
+            (simple-var-ref x))
+          (template-string "")))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref v))))
+  )
+)

--- a/corpus/cfg/subset9/09-template-expr/template-xmlns-escape-v.txt
+++ b/corpus/cfg/subset9/09-template-expr/template-xmlns-escape-v.txt
@@ -1,0 +1,19 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable v (type
+        (value-type string)) (expr
+        (literal hi))))
+    (var-def
+      (variable x (type
+        (value-type xml)) (expr
+        (xml-template-literal
+          (template-string "<p:tag>")
+          (xml-template-content-insertion
+            (simple-var-ref v))
+          (template-string "</p:tag>")))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref x))))
+  )
+)

--- a/corpus/cfg/subset9/09-template-expr/template-xmlns-v.txt
+++ b/corpus/cfg/subset9/09-template-expr/template-xmlns-v.txt
@@ -1,0 +1,19 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable v (type
+        (value-type string)) (expr
+        (literal hi))))
+    (var-def
+      (variable x (type
+        (value-type xml)) (expr
+        (xml-template-literal
+          (template-string "<foo:tag>")
+          (xml-template-content-insertion
+            (simple-var-ref v))
+          (template-string "</foo:tag>")))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref x))))
+  )
+)

--- a/corpus/desugared/subset9/09-template-expr/template-attr-v.txt
+++ b/corpus/desugared/subset9/09-template-expr/template-attr-v.txt
@@ -1,0 +1,36 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang __internal (as lang.__internal))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable id (type
+          (value-type int)) (expr
+          (literal 7))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<row id=\"")
+            (invocation lang.__internal escapeXMLAttribute (
+              (simple-var-ref id)))
+            (template-string "\"/>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x))))
+      (var-def
+        (variable value (type
+          (value-type string)) (expr
+          (literal a&b"c<d))))
+      (var-def
+        (variable escaped (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<root value=\"")
+            (invocation lang.__internal escapeXMLAttribute (
+              (simple-var-ref value)))
+            (template-string "\"/>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref escaped)))))))

--- a/corpus/desugared/subset9/09-template-expr/template-bare-comment-v.txt
+++ b/corpus/desugared/subset9/09-template-expr/template-bare-comment-v.txt
@@ -1,0 +1,21 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang __internal (as lang.__internal))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable x (type
+          (value-type string)) (expr
+          (literal x))))
+      (var-def
+        (variable v (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<!-- c -->")
+            (invocation lang.__internal escapeXMLContent (
+              (simple-var-ref x)))
+            (template-string "")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref v)))))))

--- a/corpus/desugared/subset9/09-template-expr/template-bare-pi-v.txt
+++ b/corpus/desugared/subset9/09-template-expr/template-bare-pi-v.txt
@@ -1,0 +1,21 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang __internal (as lang.__internal))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable x (type
+          (value-type string)) (expr
+          (literal x))))
+      (var-def
+        (variable v (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<?tgt body?>")
+            (invocation lang.__internal escapeXMLContent (
+              (simple-var-ref x)))
+            (template-string "")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref v)))))))

--- a/corpus/desugared/subset9/09-template-expr/template-bare-text-v.txt
+++ b/corpus/desugared/subset9/09-template-expr/template-bare-text-v.txt
@@ -1,0 +1,21 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang __internal (as lang.__internal))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable x (type
+          (value-type string)) (expr
+          (literal world))))
+      (var-def
+        (variable v (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "hello ")
+            (invocation lang.__internal escapeXMLContent (
+              (simple-var-ref x)))
+            (template-string "")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref v)))))))

--- a/corpus/desugared/subset9/09-template-expr/template-bare-v.txt
+++ b/corpus/desugared/subset9/09-template-expr/template-bare-v.txt
@@ -1,0 +1,21 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang __internal (as lang.__internal))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable x (type
+          (value-type string)) (expr
+          (literal abc))))
+      (var-def
+        (variable v (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "")
+            (invocation lang.__internal escapeXMLContent (
+              (simple-var-ref x)))
+            (template-string "")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref v)))))))

--- a/corpus/desugared/subset9/09-template-expr/template-content-v.txt
+++ b/corpus/desugared/subset9/09-template-expr/template-content-v.txt
@@ -1,0 +1,57 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang __internal (as lang.__internal))
+  (variable XML_VALUE (type
+    (value-type xml)))
+  (function init () ()
+    (block-function-body
+      (assignment
+        (simple-var-ref XML_VALUE)
+        (xml-template-literal
+          (template-string "<root>")
+          (invocation lang.__internal escapeXMLContent (
+            (literal x)))
+          (template-string "</root>")))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable name (type
+          (value-type string)) (expr
+          (literal world))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<greeting>Hello, ")
+            (invocation lang.__internal escapeXMLContent (
+              (simple-var-ref name)))
+            (template-string "!</greeting>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x))))
+      (var-def
+        (variable markup (type
+          (value-type string)) (expr
+          (literal <child/>))))
+      (var-def
+        (variable amp (type
+          (value-type string)) (expr
+          (literal a&b))))
+      (var-def
+        (variable escaped (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<root>")
+            (invocation lang.__internal escapeXMLContent (
+              (simple-var-ref markup)))
+            (template-string "|")
+            (invocation lang.__internal escapeXMLContent (
+              (simple-var-ref amp)))
+            (template-string "</root>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref escaped))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref XML_VALUE)))))))

--- a/corpus/desugared/subset9/09-template-expr/template-doctype-inject-v.txt
+++ b/corpus/desugared/subset9/09-template-expr/template-doctype-inject-v.txt
@@ -1,0 +1,21 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang __internal (as lang.__internal))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable s (type
+          (value-type string)) (expr
+          (literal <!DOCTYPE x>))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "")
+            (invocation lang.__internal escapeXMLContent (
+              (simple-var-ref s)))
+            (template-string "<a/>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x)))))))

--- a/corpus/desugared/subset9/09-template-expr/template-dup-prefix-v.txt
+++ b/corpus/desugared/subset9/09-template-expr/template-dup-prefix-v.txt
@@ -1,0 +1,21 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang __internal (as lang.__internal))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable v (type
+          (value-type string)) (expr
+          (literal x))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<a:tag xmlns:a=\"https://example.com/u\">")
+            (invocation lang.__internal escapeXMLContent (
+              (simple-var-ref v)))
+            (template-string "</a:tag>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x)))))))

--- a/corpus/desugared/subset9/09-template-expr/template-entity-v.txt
+++ b/corpus/desugared/subset9/09-template-expr/template-entity-v.txt
@@ -1,0 +1,21 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang __internal (as lang.__internal))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable x (type
+          (value-type string)) (expr
+          (literal v))))
+      (var-def
+        (variable e (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<a>&amp;")
+            (invocation lang.__internal escapeXMLContent (
+              (simple-var-ref x)))
+            (template-string "</a>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref e)))))))

--- a/corpus/desugared/subset9/09-template-expr/template-inline-ns-scope-v.txt
+++ b/corpus/desugared/subset9/09-template-expr/template-inline-ns-scope-v.txt
@@ -1,0 +1,21 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang __internal (as lang.__internal))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable s (type
+          (value-type string)) (expr
+          (literal ))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<p:a xmlns:p=\"https://example.com/outer\">")
+            (invocation lang.__internal escapeXMLContent (
+              (simple-var-ref s)))
+            (template-string "</p:a><b xmlns:p=\"https://example.com/inner\"><p:c/></b>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x)))))))

--- a/corpus/desugared/subset9/09-template-expr/template-malformed-inject-v.txt
+++ b/corpus/desugared/subset9/09-template-expr/template-malformed-inject-v.txt
@@ -1,0 +1,21 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang __internal (as lang.__internal))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable s (type
+          (value-type string)) (expr
+          (literal <a>))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "")
+            (invocation lang.__internal escapeXMLContent (
+              (simple-var-ref s)))
+            (template-string "")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x)))))))

--- a/corpus/desugared/subset9/09-template-expr/template-mixed-content-v.txt
+++ b/corpus/desugared/subset9/09-template-expr/template-mixed-content-v.txt
@@ -1,0 +1,24 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang __internal (as lang.__internal))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable n (type
+          (value-type string)) (expr
+          (literal v))))
+      (var-def
+        (variable v (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "before ")
+            (invocation lang.__internal escapeXMLContent (
+              (simple-var-ref n)))
+            (template-string " <m/> after ")
+            (invocation lang.__internal escapeXMLContent (
+              (simple-var-ref n)))
+            (template-string "")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref v)))))))

--- a/corpus/desugared/subset9/09-template-expr/template-mixed-v.txt
+++ b/corpus/desugared/subset9/09-template-expr/template-mixed-v.txt
@@ -1,0 +1,27 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang __internal (as lang.__internal))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable n (type
+          (value-type int)) (expr
+          (literal 3))))
+      (var-def
+        (variable inner (type
+          (value-type xml)) (expr
+          (xml-element-literal i))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<root>n=")
+            (invocation lang.__internal escapeXMLContent (
+              (simple-var-ref n)))
+            (template-string ", inner=")
+            (simple-var-ref inner)
+            (template-string "</root>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x)))))))

--- a/corpus/desugared/subset9/09-template-expr/template-multi-attr-v.txt
+++ b/corpus/desugared/subset9/09-template-expr/template-multi-attr-v.txt
@@ -1,0 +1,38 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang __internal (as lang.__internal))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (value-type string)) (expr
+          (literal A))))
+      (var-def
+        (variable b (type
+          (value-type string)) (expr
+          (literal B))))
+      (var-def
+        (variable n (type
+          (value-type int)) (expr
+          (literal 42))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<elem first=\"")
+            (invocation lang.__internal escapeXMLAttribute (
+              (simple-var-ref a)))
+            (template-string "-")
+            (invocation lang.__internal escapeXMLAttribute (
+              (simple-var-ref b)))
+            (template-string "\" n=\"")
+            (invocation lang.__internal escapeXMLAttribute (
+              (simple-var-ref n)))
+            (template-string "\" mixed=\"lit-")
+            (invocation lang.__internal escapeXMLAttribute (
+              (simple-var-ref a)))
+            (template-string "\"/>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x)))))))

--- a/corpus/desugared/subset9/09-template-expr/template-multi-root-outer-ns-v.txt
+++ b/corpus/desugared/subset9/09-template-expr/template-multi-root-outer-ns-v.txt
@@ -1,0 +1,21 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang __internal (as lang.__internal))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable s (type
+          (value-type string)) (expr
+          (literal ))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<p:a xmlns:p=\"https://example.com/outer\">")
+            (invocation lang.__internal escapeXMLContent (
+              (simple-var-ref s)))
+            (template-string "</p:a><p:b xmlns:p=\"https://example.com/outer\"/>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x)))))))

--- a/corpus/desugared/subset9/09-template-expr/template-multi-root-v.txt
+++ b/corpus/desugared/subset9/09-template-expr/template-multi-root-v.txt
@@ -1,0 +1,21 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang __internal (as lang.__internal))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable x (type
+          (value-type string)) (expr
+          (literal mid))))
+      (var-def
+        (variable v (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<a/>")
+            (invocation lang.__internal escapeXMLContent (
+              (simple-var-ref x)))
+            (template-string "<b/>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref v)))))))

--- a/corpus/desugared/subset9/09-template-expr/template-ns-inherit-v.txt
+++ b/corpus/desugared/subset9/09-template-expr/template-ns-inherit-v.txt
@@ -1,0 +1,21 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang __internal (as lang.__internal))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable v (type
+          (value-type string)) (expr
+          (literal leaf))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<outer xmlns=\"https://example.com/d\"><inner>")
+            (invocation lang.__internal escapeXMLContent (
+              (simple-var-ref v)))
+            (template-string "</inner></outer>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x)))))))

--- a/corpus/desugared/subset9/09-template-expr/template-pi-empty-data-v.txt
+++ b/corpus/desugared/subset9/09-template-expr/template-pi-empty-data-v.txt
@@ -1,0 +1,21 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang __internal (as lang.__internal))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable body (type
+          (value-type string)) (expr
+          (literal tail))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<?empty?>")
+            (invocation lang.__internal escapeXMLContent (
+              (simple-var-ref body)))
+            (template-string "")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x)))))))

--- a/corpus/desugared/subset9/09-template-expr/template-prefixed-attr-v.txt
+++ b/corpus/desugared/subset9/09-template-expr/template-prefixed-attr-v.txt
@@ -1,0 +1,21 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang __internal (as lang.__internal))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable body (type
+          (value-type string)) (expr
+          (literal hello))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<root xmlns:p=\"https://example.com/attr\" p:name=\"v\">")
+            (invocation lang.__internal escapeXMLContent (
+              (simple-var-ref body)))
+            (template-string "</root>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x)))))))

--- a/corpus/desugared/subset9/09-template-expr/template-single-quote-attr-v.txt
+++ b/corpus/desugared/subset9/09-template-expr/template-single-quote-attr-v.txt
@@ -1,0 +1,21 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang __internal (as lang.__internal))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable id (type
+          (value-type string)) (expr
+          (literal abc))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<row id='")
+            (invocation lang.__internal escapeXMLAttribute (
+              (simple-var-ref id)))
+            (template-string "'/>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x)))))))

--- a/corpus/desugared/subset9/09-template-expr/template-xml-child-v.txt
+++ b/corpus/desugared/subset9/09-template-expr/template-xml-child-v.txt
@@ -1,0 +1,19 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable child (type
+          (value-type xml)) (expr
+          (xml-element-literal c))))
+      (var-def
+        (variable parent (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<p>")
+            (simple-var-ref child)
+            (template-string "</p>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref parent)))))))

--- a/corpus/desugared/subset9/09-template-expr/template-xml-prefix-v.txt
+++ b/corpus/desugared/subset9/09-template-expr/template-xml-prefix-v.txt
@@ -1,0 +1,21 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang __internal (as lang.__internal))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable v (type
+          (value-type string)) (expr
+          (literal <a xml:lang="en"/>))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "")
+            (invocation lang.__internal escapeXMLContent (
+              (simple-var-ref v)))
+            (template-string "")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x)))))))

--- a/corpus/desugared/subset9/09-template-expr/template-xmldecl-inject-v.txt
+++ b/corpus/desugared/subset9/09-template-expr/template-xmldecl-inject-v.txt
@@ -1,0 +1,21 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang __internal (as lang.__internal))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable s (type
+          (value-type string)) (expr
+          (literal <?xml version='1.0'?>))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "")
+            (invocation lang.__internal escapeXMLContent (
+              (simple-var-ref s)))
+            (template-string "<a/>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x)))))))

--- a/corpus/desugared/subset9/09-template-expr/template-xmlfoo-pi-v.txt
+++ b/corpus/desugared/subset9/09-template-expr/template-xmlfoo-pi-v.txt
@@ -1,0 +1,21 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang __internal (as lang.__internal))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable x (type
+          (value-type string)) (expr
+          (literal v))))
+      (var-def
+        (variable v (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<?xmlfoo body?>")
+            (invocation lang.__internal escapeXMLContent (
+              (simple-var-ref x)))
+            (template-string "")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref v)))))))

--- a/corpus/desugared/subset9/09-template-expr/template-xmlns-escape-v.txt
+++ b/corpus/desugared/subset9/09-template-expr/template-xmlns-escape-v.txt
@@ -1,0 +1,21 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang __internal (as lang.__internal))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable v (type
+          (value-type string)) (expr
+          (literal hi))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<p:tag xmlns:p=\"https://example.com/a&amp;b&quot;c\">")
+            (invocation lang.__internal escapeXMLContent (
+              (simple-var-ref v)))
+            (template-string "</p:tag>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x)))))))

--- a/corpus/desugared/subset9/09-template-expr/template-xmlns-v.txt
+++ b/corpus/desugared/subset9/09-template-expr/template-xmlns-v.txt
@@ -1,0 +1,21 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang __internal (as lang.__internal))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable v (type
+          (value-type string)) (expr
+          (literal hi))))
+      (var-def
+        (variable x (type
+          (value-type xml)) (expr
+          (xml-template-literal
+            (template-string "<foo:tag xmlns:foo=\"https://example.com/foo\">")
+            (invocation lang.__internal escapeXMLContent (
+              (simple-var-ref v)))
+            (template-string "</foo:tag>")))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref x)))))))

--- a/corpus/integration/subset9/09-template-expr/template-attr-v.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-attr-v.txtar
@@ -1,0 +1,4 @@
+-- stdout --
+<row id="7"/>
+<root value="a&amp;b&quot;c&lt;d"/>
+-- stderr --

--- a/corpus/integration/subset9/09-template-expr/template-bad-type-e.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-bad-type-e.txtar
@@ -1,0 +1,19 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: incompatible type: expected boolean|int|float|decimal|string, got xml
+  --> template-bad-type-e.bal:23:28
+   |
+23 |     xml _ = xml `<r attr="${elem}"/>`;  // @error xml not allowed in attribute
+   |                            ^^^^
+
+error[SEMANTIC_ERROR]: incompatible type: expected boolean|int|float|decimal|string|xml, got [int...]
+  --> template-bad-type-e.bal:22:20
+   |
+22 |     xml _ = xml `${a}`;             // @error array not allowed in content
+   |                    ^
+
+error[SEMANTIC_ERROR]: incompatible type: expected boolean|int|float|decimal|string|xml, got nil
+  --> template-bad-type-e.bal:21:20
+   |
+21 |     xml _ = xml `${n}`;             // @error nil not allowed
+   |                    ^

--- a/corpus/integration/subset9/09-template-expr/template-bare-comment-v.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-bare-comment-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+<!-- c -->x
+-- stderr --

--- a/corpus/integration/subset9/09-template-expr/template-bare-pi-v.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-bare-pi-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+<?tgt body?>x
+-- stderr --

--- a/corpus/integration/subset9/09-template-expr/template-bare-text-v.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-bare-text-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+hello world
+-- stderr --

--- a/corpus/integration/subset9/09-template-expr/template-bare-v.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-bare-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+abc
+-- stderr --

--- a/corpus/integration/subset9/09-template-expr/template-cdata-e.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-cdata-e.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: interpolation is not allowed in xml CDATA section
+  --> template-cdata-e.bal:19:33
+   |
+19 |     xml x = xml `<![CDATA[hello ${s}]]>`; // @error interpolation not allowed in xml CDATA section
+   |                                 ^^^^

--- a/corpus/integration/subset9/09-template-expr/template-comment-e.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-comment-e.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: interpolation is not allowed in xml comment
+  --> template-comment-e.bal:19:29
+   |
+19 |     xml x = xml `<!-- hello ${s} -->`; // @error interpolation not allowed in xml comment
+   |                             ^^^^

--- a/corpus/integration/subset9/09-template-expr/template-const-nonconst-e.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-const-nonconst-e.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: expression is not a constant expression
+  --> template-const-nonconst-e.bal:19:26
+   |
+19 | const BAD = xml `<root>${f()}</root>`; // @error insertion is not a constant expression
+   |                          ^^^

--- a/corpus/integration/subset9/09-template-expr/template-content-v.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-content-v.txtar
@@ -1,0 +1,5 @@
+-- stdout --
+<greeting>Hello, world!</greeting>
+<root>&lt;child/&gt;|a&amp;b</root>
+<root>x</root>
+-- stderr --

--- a/corpus/integration/subset9/09-template-expr/template-doctype-inject-v.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-doctype-inject-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+&lt;!DOCTYPE x&gt;<a/>
+-- stderr --

--- a/corpus/integration/subset9/09-template-expr/template-dup-prefix-v.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-dup-prefix-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+<a:tag xmlns:a="https://example.com/u">x</a:tag>
+-- stderr --

--- a/corpus/integration/subset9/09-template-expr/template-entity-v.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-entity-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+<a>&amp;v</a>
+-- stderr --

--- a/corpus/integration/subset9/09-template-expr/template-inline-ns-scope-v.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-inline-ns-scope-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+<p:a xmlns:p="https://example.com/outer"/><b xmlns:p="https://example.com/inner"><p:c/></b>
+-- stderr --

--- a/corpus/integration/subset9/09-template-expr/template-malformed-inject-v.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-malformed-inject-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+&lt;a&gt;
+-- stderr --

--- a/corpus/integration/subset9/09-template-expr/template-mixed-content-v.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-mixed-content-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+before v <m/> after v
+-- stderr --

--- a/corpus/integration/subset9/09-template-expr/template-mixed-v.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-mixed-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+<root>n=3, inner=<i/></root>
+-- stderr --

--- a/corpus/integration/subset9/09-template-expr/template-multi-attr-v.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-multi-attr-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+<elem first="A-B" n="42" mixed="lit-A"/>
+-- stderr --

--- a/corpus/integration/subset9/09-template-expr/template-multi-root-outer-ns-v.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-multi-root-outer-ns-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+<p:a xmlns:p="https://example.com/outer"/><p:b xmlns:p="https://example.com/outer"/>
+-- stderr --

--- a/corpus/integration/subset9/09-template-expr/template-multi-root-v.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-multi-root-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+<a/>mid<b/>
+-- stderr --

--- a/corpus/integration/subset9/09-template-expr/template-ns-inherit-v.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-ns-inherit-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+<outer xmlns="https://example.com/d"><inner>leaf</inner></outer>
+-- stderr --

--- a/corpus/integration/subset9/09-template-expr/template-pi-e.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-pi-e.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: interpolation is not allowed in xml processing instruction
+  --> template-pi-e.bal:19:32
+   |
+19 |     xml x = xml `<?target body ${s}?>`; // @error interpolation not allowed in xml processing instruction
+   |                                ^^^^

--- a/corpus/integration/subset9/09-template-expr/template-pi-empty-data-v.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-pi-empty-data-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+<?empty ?>tail
+-- stderr --

--- a/corpus/integration/subset9/09-template-expr/template-prefixed-attr-v.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-prefixed-attr-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+<root p:name="v" xmlns:p="https://example.com/attr">hello</root>
+-- stderr --

--- a/corpus/integration/subset9/09-template-expr/template-query-xml-sequence-fv.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-query-xml-sequence-fv.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+-- stderr --
+fatal[UNIMPLEMENTED_ERROR]: xml template content insertion of list values is not supported yet
+  --> template-query-xml-sequence-fv.bal:20:26
+   |
+20 |     xml x = xml `<root>${from var n in values select xml `<n>${n}</n>`}</root>`; // @error future: XML sequence insertion from query result
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/corpus/integration/subset9/09-template-expr/template-single-quote-attr-v.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-single-quote-attr-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+<row id="abc"/>
+-- stderr --

--- a/corpus/integration/subset9/09-template-expr/template-tagname-e.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-tagname-e.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+-- stderr --
+error[SYNTAX_ERROR]: interpolation is not allowed for xml tag names
+  --> template-tagname-e.bal:19:23
+   |
+19 |     xml x = xml `<${t}/>`; // @error parser does not accept interpolation as element name
+   |

--- a/corpus/integration/subset9/09-template-expr/template-xml-child-v.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-xml-child-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+<p><c/></p>
+-- stderr --

--- a/corpus/integration/subset9/09-template-expr/template-xml-prefix-v.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-xml-prefix-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+&lt;a xml:lang="en"/&gt;
+-- stderr --

--- a/corpus/integration/subset9/09-template-expr/template-xmldecl-inject-v.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-xmldecl-inject-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+&lt;?xml version='1.0'?&gt;<a/>
+-- stderr --

--- a/corpus/integration/subset9/09-template-expr/template-xmlfoo-pi-v.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-xmlfoo-pi-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+<?xmlfoo body?>v
+-- stderr --

--- a/corpus/integration/subset9/09-template-expr/template-xmlns-e.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-xmlns-e.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: interpolation is not allowed in xml xmlns attribute value
+  --> template-xmlns-e.bal:19:27
+   |
+19 |     xml x = xml `<r xmlns="${ns}"/>`; // @error interpolation not allowed in xmlns attribute value
+   |                           ^^^^^

--- a/corpus/integration/subset9/09-template-expr/template-xmlns-escape-v.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-xmlns-escape-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+<p:tag xmlns:p="https://example.com/a&amp;b&quot;c">hi</p:tag>
+-- stderr --

--- a/corpus/integration/subset9/09-template-expr/template-xmlns-v.txtar
+++ b/corpus/integration/subset9/09-template-expr/template-xmlns-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+<foo:tag xmlns:foo="https://example.com/foo">hi</foo:tag>
+-- stderr --

--- a/corpus/integration/subset9/09-template-expr/xml-fv.txtar
+++ b/corpus/integration/subset9/09-template-expr/xml-fv.txtar
@@ -1,7 +1,0 @@
--- stdout --
--- stderr --
-fatal[UNIMPLEMENTED_ERROR]: xml interpolation not yet supported
-  --> xml-fv.bal:19:21
-   |
-19 |     xml x = xml `<a>${name}</a>`; // @error xml interpolation not yet supported
-   |                     ^^^^^^^

--- a/corpus/integration_test.go
+++ b/corpus/integration_test.go
@@ -83,6 +83,8 @@ var (
 		"subset8/08-future/fieldlvalue1-fp.bal",
 		// https://github.com/ballerina-platform/ballerina-lang-go/issues/417
 		"subset8/08-xml/namespace12-v.bal",
+		// https://github.com/ballerina-platform/ballerina-lang-go/issues/533
+		"subset9/09-template-expr/template-query-xml-sequence-fv.bal",
 	}
 
 	// Skip project-level integration tests with non-deterministic output.

--- a/desugar/expression.go
+++ b/desugar/expression.go
@@ -19,11 +19,14 @@ package desugar
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	"ballerina-lang-go/ast"
 	"ballerina-lang-go/model"
 	"ballerina-lang-go/semtypes"
 	"ballerina-lang-go/tools/diagnostics"
+	"ballerina-lang-go/values"
 )
 
 type invocable interface {
@@ -130,6 +133,8 @@ func walkExpression(cx *functionContext, node ast.BLangActionOrExpression) desug
 		return desugaredNode[ast.BLangActionOrExpression]{replacementNode: expr}
 	case *ast.BLangTemplateExpr:
 		return walkTemplateExpr(cx, expr)
+	case *ast.BLangXMLTemplateExpr:
+		return walkXMLTemplateExpr(cx, expr)
 	default:
 		panic(fmt.Sprintf("unexpected expression type: %T", node))
 	}
@@ -480,6 +485,86 @@ func walkClientResourceAccessAction(cx *functionContext, expr *ast.BLangClientRe
 		initStmts:       initStmts,
 		replacementNode: expr,
 	}
+}
+
+func walkXMLTemplateExpr(cx *functionContext, expr *ast.BLangXMLTemplateExpr) desugaredNode[ast.BLangActionOrExpression] {
+	var initStmts []ast.StatementNode
+	for i, ins := range expr.Insertions {
+		r := walkExpression(cx, ins)
+		initStmts = append(initStmts, r.initStmts...)
+		insert := r.replacementNode.(ast.BLangExpression)
+		if shouldEscapeXMLTemplateInsertion(insert, expr.InsertionKinds[i], cx) {
+			insert = escapeXMLTemplateInsertion(cx, insert, expr.InsertionKinds[i])
+		}
+		expr.Insertions[i] = insert
+	}
+	expr.Strings = spliceXMLTemplateNamespaces(expr.Strings, expr.NamespaceInsertions)
+	plain := &ast.BLangTemplateExpr{Kind: ast.TemplateExprKindXML, Strings: expr.Strings, Insertions: expr.Insertions}
+	plain.SetPosition(expr.GetPosition())
+	plain.SetDeterminedType(expr.GetDeterminedType())
+	return desugaredNode[ast.BLangActionOrExpression]{initStmts: initStmts, replacementNode: plain}
+}
+
+func shouldEscapeXMLTemplateInsertion(insert ast.BLangExpression, kind ast.XMLTemplateInsertionKind, cx *functionContext) bool {
+	if kind == ast.XMLTemplateInsertionKindAttribute {
+		return true
+	}
+	// content needs to be escaped if they are not xml
+	return !semtypes.IsSubtype(semtypes.ContextFrom(cx.typeEnv()), insert.GetDeterminedType(), semtypes.XML)
+}
+
+func escapeXMLTemplateInsertion(cx *functionContext, insert ast.BLangExpression, kind ast.XMLTemplateInsertionKind) ast.BLangExpression {
+	switch kind {
+	case ast.XMLTemplateInsertionKindAttribute:
+		return createLangInternalInvocation(cx, "escapeXMLAttribute", semtypes.STRING, []ast.BLangExpression{insert}, insert.GetPosition())
+	case ast.XMLTemplateInsertionKindContent:
+		return createLangInternalInvocation(cx, "escapeXMLContent", semtypes.STRING, []ast.BLangExpression{insert}, insert.GetPosition())
+	default:
+		cx.internalError("unexpected xml template insert kind")
+		return insert
+	}
+}
+
+func spliceXMLTemplateNamespaces(parts []string, insertions [][]ast.XMLTemplateNamespaceInsertion) []string {
+	if len(insertions) == 0 || len(parts) == 0 {
+		return parts
+	}
+	out := append([]string(nil), parts...)
+	for stringIndex, stringInsertions := range insertions {
+		if stringIndex >= len(out) || len(stringInsertions) == 0 {
+			continue
+		}
+		ordered := append([]ast.XMLTemplateNamespaceInsertion(nil), stringInsertions...)
+		sort.SliceStable(ordered, func(i, j int) bool {
+			return ordered[i].Offset > ordered[j].Offset
+		})
+		for _, insn := range ordered {
+			if len(insn.Namespaces) == 0 {
+				continue
+			}
+			part := out[stringIndex]
+			if insn.Offset < 0 || insn.Offset > len(part) {
+				continue
+			}
+			keys := make([]string, 0, len(insn.Namespaces))
+			for k := range insn.Namespaces {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			var b strings.Builder
+			b.WriteString(part[:insn.Offset])
+			for _, k := range keys {
+				b.WriteByte(' ')
+				b.WriteString(k)
+				b.WriteString("=\"")
+				b.WriteString(values.EscapeXMLAttribute(insn.Namespaces[k]))
+				b.WriteByte('"')
+			}
+			b.WriteString(part[insn.Offset:])
+			out[stringIndex] = b.String()
+		}
+	}
+	return out
 }
 
 func walkInvocation(cx *functionContext, expr invocable) desugaredNode[ast.BLangActionOrExpression] {

--- a/lib/langinternal/compile/internal.go
+++ b/lib/langinternal/compile/internal.go
@@ -25,7 +25,10 @@ import (
 
 var PackageID = model.INTERNAL_PKG
 
-const PackageName = "lang.__internal"
+const (
+	PackageName                   = "lang.__internal"
+	templateInsertionAllowedTypes = semtypes.BOOLEAN | semtypes.INT | semtypes.FLOAT | semtypes.DECIMAL | semtypes.STRING
+)
 
 func GetInternalSymbols(ctx *context.CompilerContext) model.ExportedSymbolSpace {
 	space := ctx.NewSymbolSpace(*PackageID)
@@ -40,6 +43,14 @@ func GetInternalSymbols(ctx *context.CompilerContext) model.ExportedSymbolSpace 
 	addInternalFunction(ctx, space, "queryCollect", model.FunctionSignature{
 		ParamTypes: []semtypes.SemType{semtypes.LIST, semtypes.INT, semtypes.LIST},
 		ReturnType: semtypes.LIST,
+	})
+	addInternalFunction(ctx, space, "escapeXMLContent", model.FunctionSignature{
+		ParamTypes: []semtypes.SemType{templateInsertionAllowedTypes},
+		ReturnType: semtypes.STRING,
+	})
+	addInternalFunction(ctx, space, "escapeXMLAttribute", model.FunctionSignature{
+		ParamTypes: []semtypes.SemType{templateInsertionAllowedTypes},
+		ReturnType: semtypes.STRING,
 	})
 	return model.NewExportedSymbolSpace(space, nil)
 }

--- a/lib/langinternal/runtime/internal.go
+++ b/lib/langinternal/runtime/internal.go
@@ -102,6 +102,12 @@ func initInternalModule(rt *runtime.Runtime) {
 		flattenFlags := args[2].(*values.List)
 		return queryCollect(ctx, rows, int(slotCount), flattenFlags)
 	})
+	runtime.RegisterExternFunction(rt, orgName, moduleName, "escapeXMLContent", func(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
+		return values.EscapeXMLContent(values.String(args[0], nil)), nil
+	})
+	runtime.RegisterExternFunction(rt, orgName, moduleName, "escapeXMLAttribute", func(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
+		return values.EscapeXMLAttribute(values.String(args[0], nil)), nil
+	})
 }
 
 type queryGroupState struct {

--- a/runtime/internal/exec/non_terminators.go
+++ b/runtime/internal/exec/non_terminators.go
@@ -359,9 +359,6 @@ func execNewXMLElement(ctx *extern.Context, instr *bir.NewXMLElement, frame *Fra
 }
 
 func execEvalTemplateExpr(ctx *extern.Context, instr *bir.EvalTemplateExpr, frame *Frame) {
-	if instr.Kind != bir.TemplateKindString {
-		panic(fmt.Sprintf("unsupported template kind: %d", instr.Kind))
-	}
 	n := len(instr.Insertions)
 	buf := make([]byte, 0, instr.LiteralsTotalLen+8*n)
 	for i := 0; i < n; i++ {
@@ -373,7 +370,18 @@ func execEvalTemplateExpr(ctx *extern.Context, instr *bir.EvalTemplateExpr, fram
 	if len(buf) > 0 {
 		result = unsafe.String(&buf[0], len(buf))
 	}
-	setOperandValue(ctx, instr.LhsOp, frame, result)
+	switch instr.Kind {
+	case bir.TemplateKindString:
+		setOperandValue(ctx, instr.LhsOp, frame, result)
+	case bir.TemplateKindXML:
+		xmlValue, err := values.ParseAsXMLValue(result)
+		if err != nil {
+			panic(err)
+		}
+		setOperandValue(ctx, instr.LhsOp, frame, xmlValue)
+	default:
+		panic(fmt.Sprintf("unsupported template kind: %d", instr.Kind))
+	}
 }
 
 func execNewXMLSequence(ctx *extern.Context, instr *bir.NewXMLSequence, frame *Frame) {

--- a/semantics/semantic_analyzer.go
+++ b/semantics/semantic_analyzer.go
@@ -872,6 +872,10 @@ func validateConstantExpr(ctx *context.CompilerContext, expr ast.BLangExpression
 		for _, ins := range e.Insertions {
 			validateConstantExpr(ctx, ins, onNonConst)
 		}
+	case *ast.BLangXMLTemplateExpr:
+		for _, ins := range e.Insertions {
+			validateConstantExpr(ctx, ins, onNonConst)
+		}
 	default:
 		onNonConst(expr)
 	}
@@ -992,6 +996,8 @@ func analyzeActionOrExpression[A analyzer](a A, expr ast.BLangActionOrExpression
 		return validateResolvedType(a, expr, expectedType)
 	case *ast.BLangTemplateExpr:
 		return analyzeTemplateExpr(a, expr, expectedType)
+	case *ast.BLangXMLTemplateExpr:
+		return analyzeXMLTemplateExpr(a, expr, expectedType)
 	case *ast.BLangXMLAttribute:
 		// XML attributes are metadata on elements and should not be analyzed as standalone expressions
 		// Their values are already analyzed as part of XMLElement processing
@@ -1021,7 +1027,7 @@ func analyzeCheckedExpr[A analyzer](a A, expr *ast.BLangCheckedExpr, expectedTyp
 	return validateResolvedType(a, expr, expectedType)
 }
 
-var templateInsertionAllowedTypes = semtypes.BOOLEAN | semtypes.INT | semtypes.FLOAT | semtypes.DECIMAL | semtypes.STRING
+const templateInsertionAllowedTypes = semtypes.BOOLEAN | semtypes.INT | semtypes.FLOAT | semtypes.DECIMAL | semtypes.STRING
 
 func analyzeTemplateExpr[A analyzer](a A, expr *ast.BLangTemplateExpr, expectedType semtypes.SemType) bool {
 	for _, ins := range expr.Insertions {
@@ -1030,6 +1036,27 @@ func analyzeTemplateExpr[A analyzer](a A, expr *ast.BLangTemplateExpr, expectedT
 		}
 	}
 	return validateResolvedType(a, expr, expectedType)
+}
+
+func analyzeXMLTemplateExpr[A analyzer](a A, expr *ast.BLangXMLTemplateExpr, expectedType semtypes.SemType) bool {
+	if len(expr.InsertionKinds) != len(expr.Insertions) {
+		a.internalError(fmt.Sprintf("xml template insertion kind count mismatch: got %d kinds for %d insertions", len(expr.InsertionKinds), len(expr.Insertions)), expr.GetPosition())
+		return false
+	}
+	for i, ins := range expr.Insertions {
+		allowed := xmlTemplateInsertionAllowedTypes(expr.InsertionKinds[i])
+		if !analyzeActionOrExpression(a, ins, allowed) {
+			return false
+		}
+	}
+	return validateResolvedType(a, expr, expectedType)
+}
+
+func xmlTemplateInsertionAllowedTypes(kind ast.XMLTemplateInsertionKind) semtypes.SemType {
+	if kind == ast.XMLTemplateInsertionKindContent {
+		return semtypes.Union(templateInsertionAllowedTypes, semtypes.XML)
+	}
+	return templateInsertionAllowedTypes
 }
 
 func analyzeTrapExpr[A analyzer](a A, expr *ast.BLangTrapExpr, expectedType semtypes.SemType) bool {

--- a/semantics/symbol_resolver.go
+++ b/semantics/symbol_resolver.go
@@ -862,6 +862,12 @@ func visitInnerSymbolResolver[T symbolResolver](resolver T, node ast.BLangNode) 
 		resolveXMLElementLiteralNamespaces(resolver, resolver.GetScope(), n, rootNeeds)
 		mergeNamespaces(n, rootNeeds)
 		return nil
+	case *ast.BLangXMLTemplateExpr:
+		resolveXMLTemplateNamespaces(resolver, resolver.GetScope(), n)
+		for _, ins := range n.Insertions {
+			ast.Walk(resolver, ins)
+		}
+		return nil
 	case *ast.BLangXMLSequenceLiteral:
 		for _, child := range n.Children {
 			ast.Walk(resolver, child)

--- a/semantics/type_resolver.go
+++ b/semantics/type_resolver.go
@@ -2396,6 +2396,8 @@ func resolveExpressionInner(t typeResolver, chain *binding, expr ast.BLangAction
 		return resolveXMLSequenceLiteral(t, chain, e, expectedType)
 	case *ast.BLangTemplateExpr:
 		return resolveTemplateExpr(t, chain, e)
+	case *ast.BLangXMLTemplateExpr:
+		return resolveXMLTemplateExpr(t, chain, e)
 	case *ast.BLangXMLElementLiteral:
 		return resolveXMLElementLiteral(t, chain, e)
 	case *ast.BLangXMLPILiteral:
@@ -2501,6 +2503,21 @@ func resolveStringTemplateType(t typeResolver, chain *binding, e *ast.BLangTempl
 		return semtypes.StringConst(sb.String()), true
 	}
 	return semtypes.STRING, true
+}
+
+func resolveXMLTemplateExpr(t typeResolver, chain *binding, e *ast.BLangXMLTemplateExpr) (semtypes.SemType, expressionEffect, bool) {
+	if len(e.InsertionKinds) != len(e.Insertions) {
+		t.internalError(fmt.Sprintf("xml template insertion kind count mismatch: got %d kinds for %d insertions", len(e.InsertionKinds), len(e.Insertions)), e.GetPosition())
+		return nil, expressionEffect{}, false
+	}
+	for i, ins := range e.Insertions {
+		allowed := xmlTemplateInsertionAllowedTypes(e.InsertionKinds[i])
+		if _, _, ok := resolveActionOrExpression(t, chain, ins, allowed); !ok {
+			return nil, expressionEffect{}, false
+		}
+	}
+	setExpectedType(e, semtypes.XML)
+	return semtypes.XML, defaultExpressionEffect(chain), true
 }
 
 func resolveXMLSequenceLiteral(t typeResolver, chain *binding, e *ast.BLangXMLSequenceLiteral, _ semtypes.SemType) (semtypes.SemType, expressionEffect, bool) {

--- a/semantics/xmlns_resolver.go
+++ b/semantics/xmlns_resolver.go
@@ -288,3 +288,30 @@ func mergeNamespaces(root *ast.BLangXMLElementLiteral, extras map[string]string)
 		root.Namespaces[k] = v
 	}
 }
+
+func resolveXMLTemplateNamespaces[T symbolResolver](resolver T, scope model.Scope, e *ast.BLangXMLTemplateExpr) {
+	for stringIndex := range e.NamespaceInsertions {
+		for i := range e.NamespaceInsertions[stringIndex] {
+			insn := &e.NamespaceInsertions[stringIndex][i]
+			if insn.Namespaces == nil {
+				insn.Namespaces = map[string]string{}
+			}
+			if insn.NeedsDefaultNS {
+				if uri, _, ok := scope.LookupXMLNS(""); ok {
+					insn.Namespaces["xmlns"] = uri
+				}
+			}
+			for prefix := range insn.UsedPrefixes {
+				uri, _, ok := scope.LookupXMLNS(prefix)
+				if !ok {
+					semanticError(resolver, "undefined XML namespace prefix '"+prefix+"'", e.GetPosition())
+					continue
+				}
+				if prefix == "" || prefix == model.XMLNSReservedPrefix {
+					continue
+				}
+				insn.Namespaces["xmlns:"+prefix] = uri
+			}
+		}
+	}
+}

--- a/values/values.go
+++ b/values/values.go
@@ -75,9 +75,11 @@ func fillerFactoryFromDesc(cx semtypes.Context, f semtypes.Filler) FillerFactory
 		return func() BalValue { return NewMap(ty, atomic, readonly, nil) }
 	case semtypes.ListFiller:
 		return listFillerFactory(cx, f)
-	case semtypes.ObjectFiller, semtypes.StreamFiller, semtypes.TableFiller, semtypes.XMLFiller:
+	case semtypes.XMLFiller:
+		return func() BalValue { return &XMLText{} }
+	case semtypes.ObjectFiller, semtypes.StreamFiller, semtypes.TableFiller:
 		return func() BalValue {
-			panic("internal error: filler factory not implemented for object/stream/table/xml types")
+			panic("internal error: filler factory not implemented for object/stream/table types")
 		}
 	default:
 		panic("unknown filler kind")

--- a/values/xml.go
+++ b/values/xml.go
@@ -97,29 +97,31 @@ func writeXMLStringMap(b *strings.Builder, m *Map, kind string) {
 		b.WriteByte(' ')
 		b.WriteString(k)
 		b.WriteString(`="`)
-		b.WriteString(escapeAttr(sv))
+		b.WriteString(EscapeXMLAttribute(sv))
 		b.WriteByte('"')
 	}
 }
 
-// escapeText escapes characters in XML text node bodies.
-func escapeText(s string) string {
-	replacer := strings.NewReplacer(
-		"&", "&amp;",
-		"<", "&lt;",
-		">", "&gt;",
-	)
-	return replacer.Replace(s)
+var xmlContentEscaper = strings.NewReplacer(
+	"&", "&amp;",
+	"<", "&lt;",
+	">", "&gt;",
+)
+
+var xmlAttributeEscaper = strings.NewReplacer(
+	"&", "&amp;",
+	"<", "&lt;",
+	"\"", "&quot;",
+)
+
+// EscapeXMLContent escapes characters in XML text node bodies.
+func EscapeXMLContent(s string) string {
+	return xmlContentEscaper.Replace(s)
 }
 
-// escapeAttr escapes characters in XML attribute values quoted with `"`.
-func escapeAttr(s string) string {
-	replacer := strings.NewReplacer(
-		"&", "&amp;",
-		"<", "&lt;",
-		"\"", "&quot;",
-	)
-	return replacer.Replace(s)
+// EscapeXMLAttribute escapes characters in XML attribute values quoted with `"`.
+func EscapeXMLAttribute(s string) string {
+	return xmlAttributeEscaper.Replace(s)
 }
 
 func (s *XMLSequence) XMLString() string {
@@ -138,7 +140,7 @@ func (p *XMLProcessingInstruction) XMLString() string {
 }
 
 func (t *XMLText) XMLString() string {
-	return escapeText(t.Body)
+	return EscapeXMLContent(t.Body)
 }
 
 func (c *XMLComment) XMLString() string {

--- a/values/xml_parse.go
+++ b/values/xml_parse.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package values
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"strings"
+
+	"ballerina-lang-go/semtypes"
+)
+
+const xmlNamespaceURI = "http://www.w3.org/XML/1998/namespace"
+
+type xmlParseElement struct {
+	e  *XMLElement
+	ns map[string]string
+}
+
+func ParseAsXMLValue(content string) (XMLValue, error) {
+	decoder := xml.NewDecoder(strings.NewReader(content))
+	decoder.Strict = true
+	var stack []xmlParseElement
+	var top []XMLValue
+	currentNS := map[string]string{}
+	for {
+		tok, err := decoder.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("xml template re-parse failed: %v (source: %q)", err, content)
+		}
+		var item XMLValue
+		switch t := tok.(type) {
+		case xml.StartElement:
+			ns := cloneStringMap(currentNS)
+			attrs, namespaces := xmlAttrsAndNamespaces(t.Attr, ns)
+			name := xmlQualifiedName(t.Name, ns, true)
+			stack = append(stack, xmlParseElement{e: &XMLElement{Name: name, Attributes: attrs, Namespaces: namespaces}, ns: currentNS})
+			currentNS = ns
+			continue
+		case xml.EndElement:
+			if len(stack) == 0 {
+				return nil, fmt.Errorf("xml template re-parse failed: unexpected end element </%s> (source: %q)", t.Name.Local, content)
+			}
+			last := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			currentNS = last.ns
+			item = last.e
+		case xml.CharData:
+			if len(t) == 0 {
+				continue
+			}
+			item = &XMLText{Body: string(t)}
+		case xml.Comment:
+			item = &XMLComment{Body: string(t)}
+		case xml.ProcInst:
+			if strings.EqualFold(t.Target, "xml") {
+				return nil, fmt.Errorf("xml processing instruction target %q is reserved", t.Target)
+			}
+			item = &XMLProcessingInstruction{Target: t.Target, Data: string(t.Inst)}
+		case xml.Directive:
+			return nil, fmt.Errorf("xml directive not allowed in template content: <!%s>", string(t))
+		default:
+			continue
+		}
+		if len(stack) > 0 {
+			parent := stack[len(stack)-1].e
+			parent.Children = appendXMLChild(parent.Children, item)
+		} else {
+			top = append(top, item)
+		}
+	}
+	if len(stack) != 0 {
+		return nil, fmt.Errorf("xml template re-parse failed: unexpected EOF (source: %q)", content)
+	}
+	return collapseXMLItems(top), nil
+}
+
+func appendXMLChild(children XMLValue, item XMLValue) XMLValue {
+	if children == nil {
+		return item
+	}
+	return NewXMLSequence([]XMLValue{children, item})
+}
+
+func collapseXMLItems(items []XMLValue) XMLValue {
+	if len(items) == 0 {
+		return &XMLText{}
+	}
+	if len(items) == 1 {
+		return items[0]
+	}
+	return NewXMLSequence(items)
+}
+
+func xmlAttrsAndNamespaces(attrs []xml.Attr, ns map[string]string) (*Map, *Map) {
+	var nsEntries []MapEntry
+	for _, attr := range attrs {
+		if !isXMLNSParseAttr(attr) {
+			continue
+		}
+		key := "xmlns"
+		prefix := ""
+		if attr.Name.Space == "xmlns" {
+			key = "xmlns:" + attr.Name.Local
+			prefix = attr.Name.Local
+		}
+		ns[prefix] = attr.Value
+		nsEntries = append(nsEntries, MapEntry{Key: key, Value: attr.Value})
+	}
+	var attrEntries []MapEntry
+	for _, attr := range attrs {
+		if isXMLNSParseAttr(attr) {
+			continue
+		}
+		attrEntries = append(attrEntries, MapEntry{Key: xmlQualifiedName(attr.Name, ns, false), Value: attr.Value})
+	}
+	return newXMLStringMap(attrEntries), newXMLStringMap(nsEntries)
+}
+
+func isXMLNSParseAttr(attr xml.Attr) bool {
+	return attr.Name.Space == "xmlns" || attr.Name.Space == "" && attr.Name.Local == "xmlns"
+}
+
+func newXMLStringMap(entries []MapEntry) *Map {
+	if len(entries) == 0 {
+		return nil
+	}
+	return NewMap(semtypes.MAPPING, &semtypes.MAPPING_ATOMIC_INNER, false, entries)
+}
+
+func xmlQualifiedName(name xml.Name, ns map[string]string, element bool) string {
+	if name.Space == "" {
+		return name.Local
+	}
+	bestPrefix := ""
+	for prefix, uri := range ns {
+		if uri != name.Space {
+			continue
+		}
+		if prefix == "" && element && bestPrefix == "" {
+			continue
+		}
+		if prefix > bestPrefix {
+			bestPrefix = prefix
+		}
+	}
+	if bestPrefix != "" {
+		return bestPrefix + ":" + name.Local
+	}
+	if name.Space == xmlNamespaceURI {
+		return "xml:" + name.Local
+	}
+	return name.Local
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}


### PR DESCRIPTION
## Purpose
$subject
Resolves #413 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added XML template expression support, enabling dynamic XML construction with interpolated values using `${...}` syntax
  * Supports content and attribute interpolation with automatic XML escaping
  * Includes namespace resolution and declaration for templated XML elements
  * Enforces validation to prevent invalid interpolations in comments, processing instructions, CDATA sections, and xmlns attributes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->