### PR TITLE
Use memory pools for frames

### DIFF
--- a/.github/workflows/wasm-ci.yml
+++ b/.github/workflows/wasm-ci.yml
@@ -25,4 +25,4 @@ jobs:
           export GOARCH=wasm
           export GOEXPERIMENT=greenteagc
           export GOGC=1000
-          go test -skip 'TestParseCorpusFiles|TestJBalUnitTests|TestJBalUnitBIRTests' -timeout 30m ./... -exec="$(go env GOROOT)/lib/wasm/go_js_wasm_exec"
+          go test -p=1 -skip 'TestParseCorpusFiles|TestJBalUnitTests|TestJBalUnitBIRTests' -timeout 30m ./... -exec="$(go env GOROOT)/lib/wasm/go_js_wasm_exec"

--- a/corpus/ast/subset9/09-bug/trap-scope-v.txt
+++ b/corpus/ast/subset9/09-bug/trap-scope-v.txt
@@ -1,0 +1,19 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (block-stmt
+        (var-def
+          (variable res (type
+            (union-type
+              (error-type)
+              (value-type int))) (expr
+            (trap-expr
+              (binary-expr /
+                (literal 1)
+                (literal 0))))))
+        (expression-stmt
+          (invocation io println (
+            (simple-var-ref res))))))))

--- a/corpus/bal/subset9/09-bug/trap-scope-v.bal
+++ b/corpus/bal/subset9/09-bug/trap-scope-v.bal
@@ -1,0 +1,24 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    {
+        error|int res = trap 1 / 0;
+        io:println(res); // @output error("divide by zero")
+    }
+}

--- a/corpus/bir/subset9/09-bug/trap-scope-v.txt
+++ b/corpus/bir/subset9/09-bug/trap-scope-v.txt
@@ -1,0 +1,29 @@
+module $anon.. v 0.0.0;
+import ballerina.io v 0.0.0;
+main() -> nil{
+  bb0 {
+    PushScopeFrame 8
+    GOTO bb1;
+  }
+  bb1 {
+    %2 = ConstantLoad 1
+    %3 = %2;
+    %4 = ConstantLoad 0
+    %5 = %4;
+    %1 = / %3 %5;
+    %0 = %1;
+    GOTO bb2;
+  }
+  bb2 {
+    res = %0;
+    %7 = println(res) -> bb3;
+  }
+  bb3 {
+    PopScopeFrame
+    return;
+  }
+  
+  error-table {
+    [bb1, bb1] -> bb2, %0
+  }
+}

--- a/corpus/cfg/subset9/09-bug/trap-scope-v.txt
+++ b/corpus/cfg/subset9/09-bug/trap-scope-v.txt
@@ -1,0 +1,16 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable res (type
+        (union-type
+          (error-type)
+          (value-type int))) (expr
+        (trap-expr
+          (binary-expr /
+            (literal 1)
+            (literal 0))))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref res))))
+  )
+)

--- a/corpus/desugared/subset9/09-bug/trap-scope-v.txt
+++ b/corpus/desugared/subset9/09-bug/trap-scope-v.txt
@@ -1,0 +1,18 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (block-stmt
+        (var-def
+          (variable res (type
+            (union-type
+              (error-type)
+              (value-type int))) (expr
+            (trap-expr
+              (binary-expr /
+                (literal 1)
+                (literal 0))))))
+        (expression-stmt
+          (invocation io println (
+            (simple-var-ref res))))))))

--- a/corpus/integration/subset2/02-misc/stackoverflow-p.txtar
+++ b/corpus/integration/subset2/02-misc/stackoverflow-p.txtar
@@ -1,7 +1,7 @@
 -- stdout --
 -- stderr --
 error: stack overflow
-        at $anon/stackoverflow-p:f(unknown)
+        at f(unknown)
            f(stackoverflow-p.bal:24)
            f(stackoverflow-p.bal:24)
            f(stackoverflow-p.bal:24)

--- a/corpus/integration/subset9/09-bug/trap-scope-v.txtar
+++ b/corpus/integration/subset9/09-bug/trap-scope-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+error("divide by zero")
+-- stderr --

--- a/runtime/internal/exec/callstack.go
+++ b/runtime/internal/exec/callstack.go
@@ -16,21 +16,35 @@
 
 package exec
 
+import "ballerina-lang-go/bir"
+
+type callStackEntry struct {
+	frame    *Frame
+	location bir.Location
+}
+
 type callStack struct {
-	elements []*Frame
+	elements []callStackEntry
 }
 
 func (cs *callStack) Push(frame *Frame) {
-	cs.elements = append(cs.elements, frame)
+	cs.elements = append(cs.elements, callStackEntry{frame: frame})
 }
 
 func (cs *callStack) Pop() {
 	cs.elements = cs.elements[:len(cs.elements)-1]
 }
 
-// Frames returns the current frames in the call stack from bottom to top.
-func (cs *callStack) Frames() []*Frame {
-	frames := make([]*Frame, len(cs.elements))
-	copy(frames, cs.elements)
-	return frames
+func (cs *callStack) SetCurrentLocation(location bir.Location) {
+	if len(cs.elements) == 0 {
+		return
+	}
+	cs.elements[len(cs.elements)-1].location = location
+}
+
+// Entries returns the current entries in the call stack from bottom to top.
+func (cs *callStack) Entries() []callStackEntry {
+	entries := make([]callStackEntry, len(cs.elements))
+	copy(entries, cs.elements)
+	return entries
 }

--- a/runtime/internal/exec/callstack.go
+++ b/runtime/internal/exec/callstack.go
@@ -35,6 +35,14 @@ func (cs *callStack) Pop() {
 	cs.elements = cs.elements[:len(cs.elements)-1]
 }
 
+func (cs *callStack) top() *Frame {
+	return cs.elements[len(cs.elements)-1].frame
+}
+
+func (cs *callStack) len() int {
+	return len(cs.elements)
+}
+
 func (cs *callStack) SetCurrentLocation(location bir.Location) {
 	if len(cs.elements) == 0 {
 		return

--- a/runtime/internal/exec/errors.go
+++ b/runtime/internal/exec/errors.go
@@ -54,7 +54,7 @@ func formatCallStack(cs *callStack) []string {
 		entry := entries[i]
 		loc := entry.location
 		if bir.IsLocationEmpty(loc) {
-			out = append(out, fmt.Sprintf("%s(unknown)", entry.frame.FunctionKey()))
+			out = append(out, fmt.Sprintf("%s(unknown)", prettyFunctionName(entry.frame.FunctionKey())))
 			continue
 		}
 		file := filepath.Base(loc.FilePath())

--- a/runtime/internal/exec/errors.go
+++ b/runtime/internal/exec/errors.go
@@ -43,23 +43,23 @@ func panicMessage(r any) string {
 }
 
 func formatCallStack(cs *callStack) []string {
-	frames := cs.Frames()
+	entries := cs.Entries()
 	const maxFrames = 32
-	out := make([]string, 0, len(frames))
-	for i := len(frames) - 1; i >= 0; i-- {
+	out := make([]string, 0, len(entries))
+	for i := len(entries) - 1; i >= 0; i-- {
 		if len(out) >= maxFrames {
 			out = append(out, "...")
 			break
 		}
-		f := frames[i]
-		loc := f.Location()
+		entry := entries[i]
+		loc := entry.location
 		if bir.IsLocationEmpty(loc) {
-			out = append(out, fmt.Sprintf("%s(unknown)", f.FunctionKey()))
+			out = append(out, fmt.Sprintf("%s(unknown)", entry.frame.FunctionKey()))
 			continue
 		}
 		file := filepath.Base(loc.FilePath())
 		line := loc.StartLine() + 1
-		out = append(out, fmt.Sprintf("%s(%s:%d)", prettyFunctionName(f.FunctionKey()), file, line))
+		out = append(out, fmt.Sprintf("%s(%s:%d)", prettyFunctionName(entry.frame.FunctionKey()), file, line))
 	}
 	return out
 }

--- a/runtime/internal/exec/errors.go
+++ b/runtime/internal/exec/errors.go
@@ -52,14 +52,14 @@ func formatCallStack(cs *callStack) []string {
 			break
 		}
 		f := frames[i]
-		loc := f.location
+		loc := f.Location()
 		if bir.IsLocationEmpty(loc) {
-			out = append(out, fmt.Sprintf("%s(unknown)", f.functionKey))
+			out = append(out, fmt.Sprintf("%s(unknown)", f.FunctionKey()))
 			continue
 		}
 		file := filepath.Base(loc.FilePath())
 		line := loc.StartLine() + 1
-		out = append(out, fmt.Sprintf("%s(%s:%d)", prettyFunctionName(f.functionKey), file, line))
+		out = append(out, fmt.Sprintf("%s(%s:%d)", prettyFunctionName(f.FunctionKey()), file, line))
 	}
 	return out
 }

--- a/runtime/internal/exec/executor.go
+++ b/runtime/internal/exec/executor.go
@@ -73,6 +73,7 @@ func createFunctionFrame(ctx *extern.Context, birFunc *bir.BIRFunction, args []v
 }
 
 func initLocalsForFunction(ctx *extern.Context, birFunc *bir.BIRFunction, args []values.BalValue, frame *Frame) {
+	frame.SetLocal(0, nil)
 	localVars := &birFunc.LocalVars
 	argOffset := 0
 	if birFunc.Flags.Has(model.FlagAttached) {

--- a/runtime/internal/exec/executor.go
+++ b/runtime/internal/exec/executor.go
@@ -22,6 +22,7 @@ import (
 	"ballerina-lang-go/bir"
 	"ballerina-lang-go/model"
 	"ballerina-lang-go/runtime/extern"
+	runtimeframe "ballerina-lang-go/runtime/internal/frame"
 	"ballerina-lang-go/semtypes"
 	"ballerina-lang-go/values"
 )
@@ -36,12 +37,16 @@ func executeFunction(ctx *extern.Context, birFunc bir.BIRFunction, args []values
 	} else {
 		executeFunctionNoTrap(ctx, bb, frame)
 	}
+	result := frame.Local(0)
 	popFrame(ctx)
-	return frame.locals[0]
+	return result
 }
 
 func popFrame(ctx *extern.Context) {
-	getCallStack(ctx).Pop()
+	cs := getCallStack(ctx)
+	frame := cs.elements[len(cs.elements)-1]
+	cs.Pop()
+	frame.Free()
 }
 
 func pushFrame(ctx *extern.Context, frame *Frame) {
@@ -57,8 +62,9 @@ func getCallStack(ctx *extern.Context) *callStack {
 }
 
 func createFunctionFrame(ctx *extern.Context, birFunc *bir.BIRFunction, args []values.BalValue, parentFrame *Frame) *Frame {
-	locals := initLocalsForFunction(ctx, birFunc, args)
-	frame := &Frame{locals: locals, functionKey: birFunc.FunctionLookupKey, parent: parentFrame}
+	frame := runtimeframe.New(len(birFunc.LocalVars), parentFrame)
+	frame.SetFunctionKey(birFunc.FunctionLookupKey)
+	initLocalsForFunction(ctx, birFunc, args, frame)
 	pushFrame(ctx, frame)
 	if callStackDepth(ctx) > maxRecursionDepth {
 		panic(values.NewErrorWithMessage("stack overflow"))
@@ -66,17 +72,16 @@ func createFunctionFrame(ctx *extern.Context, birFunc *bir.BIRFunction, args []v
 	return frame
 }
 
-func initLocalsForFunction(ctx *extern.Context, birFunc *bir.BIRFunction, args []values.BalValue) []values.BalValue {
+func initLocalsForFunction(ctx *extern.Context, birFunc *bir.BIRFunction, args []values.BalValue, frame *Frame) {
 	localVars := &birFunc.LocalVars
-	locals := make([]values.BalValue, len(*localVars))
 	argOffset := 0
 	if birFunc.Flags.Has(model.FlagAttached) {
-		locals[1] = args[0]
+		frame.SetLocal(1, args[0])
 		argOffset = 1
 	}
 	requiredCount := len(birFunc.RequiredParams)
 	for i := range requiredCount {
-		locals[i+1+argOffset] = args[i+argOffset]
+		frame.SetLocal(i+1+argOffset, args[i+argOffset])
 	}
 
 	if birFunc.RestParams != nil {
@@ -90,14 +95,12 @@ func initLocalsForFunction(ctx *extern.Context, birFunc *bir.BIRFunction, args [
 		initial := make([]values.BalValue, len(restArgs))
 		copy(initial, restArgs)
 		list := values.NewList(restParamType, atomic, true, nil, len(restArgs), initial)
-		locals[restParamIdx] = list
+		frame.SetLocal(restParamIdx, list)
 	} else {
 		if len(args) > requiredCount+argOffset {
 			panic(values.NewErrorWithMessage("too many arguments"))
 		}
 	}
-
-	return locals
 }
 
 func executeFunctionWithTrap(ctx *extern.Context, birFunc *bir.BIRFunction, bb *bir.BIRBasicBlock, frame *Frame) {
@@ -114,6 +117,7 @@ func executeFunctionWithTrap(ctx *extern.Context, birFunc *bir.BIRFunction, bb *
 				panic(recovered)
 			}
 			unwindCallStackToFrame(ctx, frame)
+			unwindScopeFramesToFrame(nextFrame, frame)
 			errVal := panicValueToErrorValue(recovered)
 			// After unwinding, the active frame is the function frame.
 			currentFrame = frame
@@ -145,30 +149,39 @@ func executeFunctionNoTrap(ctx *extern.Context, bb *bir.BIRBasicBlock, frame *Fr
 func executeBasicBlockWithTrap(ctx *extern.Context, bb *bir.BIRBasicBlock, frame *Frame, currentFrame *Frame) (nextBB *bir.BIRBasicBlock, nextFrame *Frame, recovered any) {
 	defer func() {
 		if r := recover(); r != nil {
+			nextFrame = currentFrame
 			recovered = r
 		}
 	}()
-	nextBB, nextFrame = executeBasicBlock(ctx, bb, frame, currentFrame)
-	return nextBB, nextFrame, nil
+	for _, inst := range bb.Instructions {
+		posProvider := inst.(interface{ GetPos() bir.Location })
+		frame.SetLocation(posProvider.GetPos())
+		currentFrame = execInstruction(ctx, inst, currentFrame)
+	}
+	posProvider := bb.Terminator.(interface{ GetPos() bir.Location })
+	frame.SetLocation(posProvider.GetPos())
+	return execTerminator(ctx, bb.Terminator, currentFrame), currentFrame, nil
 }
 
 func executeBasicBlock(ctx *extern.Context, bb *bir.BIRBasicBlock, frame *Frame, currentFrame *Frame) (*bir.BIRBasicBlock, *Frame) {
 	for _, inst := range bb.Instructions {
 		posProvider := inst.(interface{ GetPos() bir.Location })
-		frame.location = posProvider.GetPos()
+		frame.SetLocation(posProvider.GetPos())
 		currentFrame = execInstruction(ctx, inst, currentFrame)
 	}
 	posProvider := bb.Terminator.(interface{ GetPos() bir.Location })
-	frame.location = posProvider.GetPos()
+	frame.SetLocation(posProvider.GetPos())
 	return execTerminator(ctx, bb.Terminator, currentFrame), currentFrame
 }
 
 func execInstruction(ctx *extern.Context, inst bir.BIRNonTerminator, frame *Frame) *Frame {
 	switch v := inst.(type) {
 	case *bir.PushScopeFrame:
-		return &Frame{locals: make([]values.BalValue, v.NumLocals), parent: frame}
+		return runtimeframe.New(v.NumLocals, frame)
 	case *bir.PopScopeFrame:
-		return frame.parent
+		parent := frame.Parent()
+		frame.Free()
+		return parent
 	case *bir.ConstantLoad:
 		execConstantLoad(ctx, v, frame)
 	case *bir.Move:
@@ -387,5 +400,13 @@ func findTrapErrorEntry(birFunc *bir.BIRFunction, bbNumber int) *bir.BIRErrorEnt
 func unwindCallStackToFrame(ctx *extern.Context, frame *Frame) {
 	for callStackDepth(ctx) > 0 && getCallStack(ctx).elements[callStackDepth(ctx)-1] != frame {
 		popFrame(ctx)
+	}
+}
+
+func unwindScopeFramesToFrame(currentFrame *Frame, targetFrame *Frame) {
+	for currentFrame != nil && currentFrame != targetFrame {
+		parent := currentFrame.Parent()
+		currentFrame.Free()
+		currentFrame = parent
 	}
 }

--- a/runtime/internal/exec/executor.go
+++ b/runtime/internal/exec/executor.go
@@ -44,7 +44,7 @@ func executeFunction(ctx *extern.Context, birFunc bir.BIRFunction, args []values
 
 func popFrame(ctx *extern.Context) {
 	cs := getCallStack(ctx)
-	frame := cs.elements[len(cs.elements)-1]
+	frame := cs.elements[len(cs.elements)-1].frame
 	cs.Pop()
 	frame.Free()
 }
@@ -154,23 +154,19 @@ func executeBasicBlockWithTrap(ctx *extern.Context, bb *bir.BIRBasicBlock, frame
 		}
 	}()
 	for _, inst := range bb.Instructions {
-		posProvider := inst.(interface{ GetPos() bir.Location })
-		frame.SetLocation(posProvider.GetPos())
+		getCallStack(ctx).SetCurrentLocation(inst.GetPos())
 		currentFrame = execInstruction(ctx, inst, currentFrame)
 	}
-	posProvider := bb.Terminator.(interface{ GetPos() bir.Location })
-	frame.SetLocation(posProvider.GetPos())
+	getCallStack(ctx).SetCurrentLocation(bb.Terminator.GetPos())
 	return execTerminator(ctx, bb.Terminator, currentFrame), currentFrame, nil
 }
 
 func executeBasicBlock(ctx *extern.Context, bb *bir.BIRBasicBlock, frame *Frame, currentFrame *Frame) (*bir.BIRBasicBlock, *Frame) {
 	for _, inst := range bb.Instructions {
-		posProvider := inst.(interface{ GetPos() bir.Location })
-		frame.SetLocation(posProvider.GetPos())
+		getCallStack(ctx).SetCurrentLocation(inst.GetPos())
 		currentFrame = execInstruction(ctx, inst, currentFrame)
 	}
-	posProvider := bb.Terminator.(interface{ GetPos() bir.Location })
-	frame.SetLocation(posProvider.GetPos())
+	getCallStack(ctx).SetCurrentLocation(bb.Terminator.GetPos())
 	return execTerminator(ctx, bb.Terminator, currentFrame), currentFrame
 }
 
@@ -398,7 +394,7 @@ func findTrapErrorEntry(birFunc *bir.BIRFunction, bbNumber int) *bir.BIRErrorEnt
 }
 
 func unwindCallStackToFrame(ctx *extern.Context, frame *Frame) {
-	for callStackDepth(ctx) > 0 && getCallStack(ctx).elements[callStackDepth(ctx)-1] != frame {
+	for callStackDepth(ctx) > 0 && getCallStack(ctx).elements[callStackDepth(ctx)-1].frame != frame {
 		popFrame(ctx)
 	}
 }

--- a/runtime/internal/exec/executor.go
+++ b/runtime/internal/exec/executor.go
@@ -44,7 +44,7 @@ func executeFunction(ctx *extern.Context, birFunc bir.BIRFunction, args []values
 
 func popFrame(ctx *extern.Context) {
 	cs := getCallStack(ctx)
-	frame := cs.elements[len(cs.elements)-1].frame
+	frame := cs.top()
 	cs.Pop()
 	frame.Free()
 }
@@ -54,7 +54,7 @@ func pushFrame(ctx *extern.Context, frame *Frame) {
 }
 
 func callStackDepth(ctx *extern.Context) int {
-	return len(getCallStack(ctx).elements)
+	return getCallStack(ctx).len()
 }
 
 func getCallStack(ctx *extern.Context) *callStack {
@@ -118,11 +118,8 @@ func executeFunctionWithTrap(ctx *extern.Context, birFunc *bir.BIRFunction, bb *
 				panic(recovered)
 			}
 			unwindCallStackToFrame(ctx, frame)
-			unwindScopeFramesToFrame(nextFrame, frame)
 			errVal := panicValueToErrorValue(recovered)
-			// After unwinding, the active frame is the function frame.
-			currentFrame = frame
-			setOperandValue(ctx, handler.ErrorOp, currentFrame, errVal)
+			currentFrame = setRecoveredError(ctx, handler.ErrorOp, nextFrame, errVal)
 			bb = &birFunc.BasicBlocks[handler.Target]
 			continue
 		}
@@ -372,6 +369,18 @@ func panicValueToErrorValue(r any) values.BalValue {
 	panic(r)
 }
 
+func setRecoveredError(ctx *extern.Context, op *bir.BIROperand, currentFrame *Frame, errVal values.BalValue) *Frame {
+	if gv, ok := op.VariableDcl.(*bir.BIRGlobalVariableDcl); ok {
+		module := getModule(ctx, gv.PkgId)
+		module.Globals[gv.GlobalVarLookupKey] = errVal
+		return currentFrame
+	}
+	targetFrame := resolveFrame(currentFrame, op.Address)
+	unwindScopeFramesToFrame(currentFrame, targetFrame)
+	targetFrame.SetLocal(op.Address.FrameIndex, errVal)
+	return targetFrame
+}
+
 func findTrapErrorEntry(birFunc *bir.BIRFunction, bbNumber int) *bir.BIRErrorEntry {
 	var best *bir.BIRErrorEntry
 	var bestSpan int
@@ -395,7 +404,7 @@ func findTrapErrorEntry(birFunc *bir.BIRFunction, bbNumber int) *bir.BIRErrorEnt
 }
 
 func unwindCallStackToFrame(ctx *extern.Context, frame *Frame) {
-	for callStackDepth(ctx) > 0 && getCallStack(ctx).elements[callStackDepth(ctx)-1].frame != frame {
+	for callStackDepth(ctx) > 0 && getCallStack(ctx).top() != frame {
 		popFrame(ctx)
 	}
 }

--- a/runtime/internal/exec/frame.go
+++ b/runtime/internal/exec/frame.go
@@ -20,22 +20,18 @@ import (
 	"ballerina-lang-go/bir"
 	"ballerina-lang-go/model"
 	"ballerina-lang-go/runtime/extern"
+	runtimeframe "ballerina-lang-go/runtime/internal/frame"
 	"ballerina-lang-go/runtime/internal/modules"
 	"ballerina-lang-go/values"
 )
 
-type Frame struct {
-	locals      []values.BalValue // variable index → value (indexed by BIROperand.Address.FrameIndex)
-	functionKey string            // function key (package name + function name)
-	location    bir.Location      // source location of the currently executing instruction/terminator
-	parent      *Frame
-}
+type Frame = runtimeframe.Frame
 
 func resolveFrame(frame *Frame, address bir.Address) *Frame {
 	if address.Mode == bir.AddressingModeAbsolute {
 		f := frame
 		for i := 0; i < address.BaseIndex; i++ {
-			f = f.parent
+			f = f.Parent()
 		}
 		return f
 	}
@@ -44,12 +40,12 @@ func resolveFrame(frame *Frame, address bir.Address) *Frame {
 
 // Load retrieves the value at the given address in the frame.
 func Load(frame *Frame, address bir.Address) values.BalValue {
-	return resolveFrame(frame, address).locals[address.FrameIndex]
+	return resolveFrame(frame, address).Local(address.FrameIndex)
 }
 
 // Store sets the value at the given address in the frame.
 func Store(frame *Frame, address bir.Address, value values.BalValue) {
-	resolveFrame(frame, address).locals[address.FrameIndex] = value
+	resolveFrame(frame, address).SetLocal(address.FrameIndex, value)
 }
 
 func getOperandValue(ctx *extern.Context, op *bir.BIROperand, currentFrame *Frame) values.BalValue {

--- a/runtime/internal/exec/interpreter.go
+++ b/runtime/internal/exec/interpreter.go
@@ -25,7 +25,7 @@ import (
 
 func Interpret(pkg bir.BIRPackage, env *extern.Env) (err error) {
 	ctx := extern.CreateContext(env)
-	cs := &callStack{elements: make([]*Frame, 0, 32)}
+	cs := &callStack{elements: make([]callStackEntry, 0, 32)}
 	ctx.CallStack = cs
 	env.Registry.(*modules.Registry).RegisterModule(pkg.PackageID, modules.NewBIRModule(ctx, &pkg))
 	defer func() {

--- a/runtime/internal/exec/non_terminators.go
+++ b/runtime/internal/exec/non_terminators.go
@@ -210,6 +210,7 @@ func execFPLoad(ctx *extern.Context, fpLoad *bir.FPLoad, frame *Frame) {
 		LookupKey: fpLoad.FunctionLookupKey,
 	}
 	if fpLoad.IsClosure {
+		frame.MarkEscaped()
 		fn.ParentFrame = frame
 	}
 	setOperandValue(ctx, fpLoad.LhsOp, frame, fn)

--- a/runtime/internal/frame/frame.go
+++ b/runtime/internal/frame/frame.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package frame
+
+import (
+	"ballerina-lang-go/bir"
+	"ballerina-lang-go/values"
+)
+
+type Frame struct {
+	locals      []values.BalValue
+	functionKey string
+	location    bir.Location
+	parent      *Frame
+}
+
+func New(numLocals int, parent *Frame) *Frame {
+	return &Frame{locals: make([]values.BalValue, numLocals), parent: parent}
+}
+
+func (f *Frame) Free() {
+}
+
+func (f *Frame) Parent() *Frame {
+	return f.parent
+}
+
+func (f *Frame) FunctionKey() string {
+	return f.functionKey
+}
+
+func (f *Frame) SetFunctionKey(functionKey string) {
+	f.functionKey = functionKey
+}
+
+func (f *Frame) Location() bir.Location {
+	return f.location
+}
+
+func (f *Frame) SetLocation(location bir.Location) {
+	f.location = location
+}
+
+func (f *Frame) Local(idx int) values.BalValue {
+	return f.locals[idx]
+}
+
+func (f *Frame) SetLocal(idx int, value values.BalValue) {
+	f.locals[idx] = value
+}

--- a/runtime/internal/frame/frame.go
+++ b/runtime/internal/frame/frame.go
@@ -16,19 +16,80 @@
 
 package frame
 
-import "ballerina-lang-go/values"
+import (
+	"sync"
+
+	"ballerina-lang-go/values"
+)
+
+var (
+	localsPool8   = sync.Pool{New: func() any { return new([8]values.BalValue) }}
+	localsPool16  = sync.Pool{New: func() any { return new([16]values.BalValue) }}
+	localsPool32  = sync.Pool{New: func() any { return new([32]values.BalValue) }}
+	localsPool64  = sync.Pool{New: func() any { return new([64]values.BalValue) }}
+	localsPool128 = sync.Pool{New: func() any { return new([128]values.BalValue) }}
+)
 
 type Frame struct {
 	locals      []values.BalValue
 	functionKey string
 	parent      *Frame
+	escaped     bool
 }
 
+// New create a frame for holding numLocals. The backing memory may be reused from already
+// freed frames there for locals may have garbage. Caller must either clean the memory or more
+// likely overwrite it.
 func New(numLocals int, parent *Frame) *Frame {
-	return &Frame{locals: make([]values.BalValue, numLocals), parent: parent}
+	return &Frame{locals: newLocals(numLocals), parent: parent}
+}
+
+func newLocals(numLocals int) []values.BalValue {
+	switch {
+	case numLocals <= 0:
+		return make([]values.BalValue, numLocals)
+	case numLocals <= 8:
+		return localsPool8.Get().(*[8]values.BalValue)[:numLocals]
+	case numLocals <= 16:
+		return localsPool16.Get().(*[16]values.BalValue)[:numLocals]
+	case numLocals <= 32:
+		return localsPool32.Get().(*[32]values.BalValue)[:numLocals]
+	case numLocals <= 64:
+		return localsPool64.Get().(*[64]values.BalValue)[:numLocals]
+	case numLocals <= 128:
+		return localsPool128.Get().(*[128]values.BalValue)[:numLocals]
+	default:
+		return make([]values.BalValue, numLocals)
+	}
 }
 
 func (f *Frame) Free() {
+	if f.escaped {
+		// Calling free here is deseptive given that this frame has been captured
+		// and can't be freed.
+		return
+	}
+
+	locals := f.locals
+	switch cap(locals) {
+	case 8:
+		localsPool8.Put((*[8]values.BalValue)(locals[:8]))
+	case 16:
+		localsPool16.Put((*[16]values.BalValue)(locals[:16]))
+	case 32:
+		localsPool32.Put((*[32]values.BalValue)(locals[:32]))
+	case 64:
+		localsPool64.Put((*[64]values.BalValue)(locals[:64]))
+	case 128:
+		localsPool128.Put((*[128]values.BalValue)(locals[:128]))
+	}
+}
+
+func (f *Frame) MarkEscaped() {
+	for f != nil {
+		f.escaped = true
+		f = f.parent
+	}
 }
 
 func (f *Frame) Parent() *Frame {

--- a/runtime/internal/frame/frame.go
+++ b/runtime/internal/frame/frame.go
@@ -16,15 +16,11 @@
 
 package frame
 
-import (
-	"ballerina-lang-go/bir"
-	"ballerina-lang-go/values"
-)
+import "ballerina-lang-go/values"
 
 type Frame struct {
 	locals      []values.BalValue
 	functionKey string
-	location    bir.Location
 	parent      *Frame
 }
 
@@ -45,14 +41,6 @@ func (f *Frame) FunctionKey() string {
 
 func (f *Frame) SetFunctionKey(functionKey string) {
 	f.functionKey = functionKey
-}
-
-func (f *Frame) Location() bir.Location {
-	return f.location
-}
-
-func (f *Frame) SetLocation(location bir.Location) {
-	f.location = location
 }
 
 func (f *Frame) Local(idx int) values.BalValue {

--- a/runtime/internal/frame/frame.go
+++ b/runtime/internal/frame/frame.go
@@ -65,7 +65,7 @@ func newLocals(numLocals int) []values.BalValue {
 
 func (f *Frame) Free() {
 	if f.escaped {
-		// Calling free here is deseptive given that this frame has been captured
+		// Calling free here is deceptive given that this frame has been captured
 		// and can't be freed.
 		return
 	}


### PR DESCRIPTION
## Purpose
Reduce the allocation pressure by using memory pools for frame locals



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved runtime frame management with pooled locals to reduce allocations and improve performance.
  * Call stack now preserves per-entry location metadata, enhancing diagnostics and error stack accuracy.

* **Bug Fixes / Stability**
  * More robust trap/unwind handling and scope-frame management for clearer error recovery.
  * CI test runner adjusted to improve WASM test stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->