### PR TITLE
fix(semantics): avoid mutating semtype interner during lookup

### DIFF
--- a/semantics/type_resolver.go
+++ b/semantics/type_resolver.go
@@ -260,7 +260,11 @@ func (t *packageTypeResolver) nextMonoFnName(origName string) string {
 }
 
 func (t *packageTypeResolver) lookupClassMethodSymbol(receiverTy semtypes.SemType, methodName string) (model.SymbolRef, bool) {
-	classRef, ok := t.classSymbolByType[t.semtypeInterner.Intern(receiverTy)]
+	handle, ok := t.semtypeInterner.Lookup(receiverTy)
+	if !ok {
+		return model.SymbolRef{}, false
+	}
+	classRef, ok := t.classSymbolByType[handle]
 	if !ok {
 		return model.SymbolRef{}, false
 	}

--- a/semtypes/semtype_interner.go
+++ b/semtypes/semtype_interner.go
@@ -16,6 +16,9 @@
 
 package semtypes
 
+// SemtypeInterner is meant to be used to intern copies of the same semtype. IMPORTANT: this does not
+// actually check if two given types are equal under IsEqual. SemtypeInterner is thread compatible,
+// leaving users to apply suitable synchronization logic where needed.
 type SemtypeInterner struct {
 	basicTypeHandles      map[basicTypeBitSet]InternHandle
 	complexSemtypeHandles map[complexSemtypeInternKey]complexSemtypeInternValues
@@ -46,7 +49,7 @@ func (i *SemtypeInterner) Intern(ty SemType) InternHandle {
 		if handle, ok := i.basicTypeHandles[bits]; ok {
 			return handle
 		}
-		handle := InternHandle(-int(bits) - 1)
+		handle := basicInternHandle(bits)
 		i.basicTypeHandles[bits] = handle
 		return handle
 	}
@@ -65,6 +68,28 @@ func (i *SemtypeInterner) Intern(ty SemType) InternHandle {
 	values.dataLists = append(values.dataLists, dataList)
 	i.complexSemtypeHandles[key] = values
 	return complexInternHandle(values.base, idx)
+}
+
+func (i *SemtypeInterner) Lookup(ty SemType) (InternHandle, bool) {
+	if ty.some() == 0 {
+		return basicInternHandle(ty.all()), true
+	}
+	key := complexSemtypeInternKey{all: ty.all(), some: ty.some()}
+	values, ok := i.complexSemtypeHandles[key]
+	if !ok {
+		return 0, false
+	}
+	dataList := ty.subtypeDataList()
+	for idx, existing := range values.dataLists {
+		if sameSubtypeDataList(existing, dataList) {
+			return complexInternHandle(values.base, idx), true
+		}
+	}
+	return 0, false
+}
+
+func basicInternHandle(bits basicTypeBitSet) InternHandle {
+	return InternHandle(-int(bits) - 1)
 }
 
 func complexInternHandle(base int32, index int) InternHandle {


### PR DESCRIPTION
Fixes #542

## Summary
- add non-mutating SemtypeInterner.Lookup
- use Lookup for class method symbol lookup during local node resolution
- keep Intern usage limited to class-symbol prepopulation before parallel function resolution

## Tests
- go test -race -count=1 -run 'Test(TypeResolver|SemanticAnalysis)/subset9/09-object/service1-v\\.bal' ./semantics\n- go test -race -count=1 ./semtypes ./semantics